### PR TITLE
Use env vars to configure proxy

### DIFF
--- a/config.go
+++ b/config.go
@@ -103,6 +103,7 @@ func (c Config) newHTTPClient() *http.Client {
 	client := http.Client{
 		Timeout: c.Timeout,
 		Transport: &http.Transport{
+			Proxy:       http.ProxyFromEnvironment,
 			DialContext: dialer.DialContext,
 		},
 	}


### PR DESCRIPTION
The custom transport the sdk uses isn't respecting the `HTTPS_PROXY` and `HTTP_PROXY` env vars. I'm pretty sure that since ld-relay depends on this, it means the relay doesn't support proxying either, even though it's documented that it does.