### PR TITLE
Reduce allocs in NewAnonymousUser

### DIFF
--- a/user.go
+++ b/user.go
@@ -50,9 +50,12 @@ func NewUser(key string) User {
 	return User{Key: &key}
 }
 
+var (
+	anonymous = true
+)
+
 // NewAnonymousUser creates a new anonymous user identified by the given key.
 func NewAnonymousUser(key string) User {
-	anonymous := true
 	return User{Key: &key, Anonymous: &anonymous}
 }
 

--- a/user_test.go
+++ b/user_test.go
@@ -21,3 +21,13 @@ func TestNewAnonymousUser(t *testing.T) {
 	anonymous, _ := user.valueOf("anonymous")
 	assert.Equal(t, true, anonymous)
 }
+
+var benchUser User
+
+func BenchmarkNewAnonymousUser(b *testing.B) {
+	var user User
+	for i := 0; i < b.N; i++ {
+		user = NewAnonymousUser("some-key")
+	}
+	benchUser = user
+}


### PR DESCRIPTION
Hi maintainers,

I've made a change to reduce allocations in `NewAnonymousUser`, which creates a bool on the heap for `User.Anonymous`. 

This change creates a global bool for reuse resulting in 1 fewer allocation and an improvement of approximately 34ns -> 26ns on my laptop.

A downside is that because User.Anonymous is public the value of the global anonymous flag can be changed.
```
user := NewAnonymousUser("some-key")
*user.Anonymous = false  // global `anonymous` is now false
```

Ordinarily I'd open an issue first to discuss whether this side effect is ok but given the small amount of work here it was easy to just put in a PR.

Before
```
$ go test -count=1 -v -benchmem -run=^$ -bench '^BenchmarkNewAnonymousUser$' .
goos: darwin
goarch: amd64
pkg: github.com/launchdarkly/go-server-sdk
BenchmarkNewAnonymousUser-8       32967243            34.2 ns/op          17 B/op           2 allocs/op
PASS
ok      github.com/launchdarkly/go-server-sdk    1.220s
```
After
```
$ go test -count=1 -v -benchmem -run=^$ -bench '^BenchmarkNewAnonymousUser$' .
goos: darwin
goarch: amd64
pkg: github.com/launchdarkly/go-server-sdk
BenchmarkNewAnonymousUser-8       42159354            25.8 ns/op          16 B/op           1 allocs/op
PASS
ok      github.com/launchdarkly/go-server-sdk    1.428s
```

