### PR TITLE
Added ldclient evaluation benchmarks

### DIFF
--- a/ldclient_evaluation_benchmark_test.go
+++ b/ldclient_evaluation_benchmark_test.go
@@ -1,0 +1,440 @@
+package ldclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"gopkg.in/launchdarkly/go-sdk-common.v1/ldvalue"
+)
+
+/*
+ * Test env
+ */
+
+type benchmarkEnv struct {
+	client           *LDClient
+	targetFeatureKey string
+}
+
+func newBenchmarkEnv() *benchmarkEnv {
+	return &benchmarkEnv{}
+}
+
+func (env *benchmarkEnv) setUp(bc benchmarkCase, variations []interface{}) {
+	// Set up the client.
+	env.client = makeTestClient()
+
+	// Set up the feature flag store.
+	testFlags := makeBenchmarkFlags(bc, variations)
+	for _, ff := range testFlags {
+		env.client.store.Upsert(Features, ff)
+	}
+
+	// Target a feature key in the middle of the list in case a linear search is being used.
+	targetFeatureKeyIndex := 0
+	if bc.numFlags > 0 {
+		targetFeatureKeyIndex = bc.numFlags / 2
+	}
+	env.targetFeatureKey = fmt.Sprintf("flag-%d", targetFeatureKeyIndex)
+}
+
+func (env *benchmarkEnv) tearDown() {
+	// Prepare for the next benchmark case.
+	env.client.Close()
+	env.client = nil
+	env.targetFeatureKey = ""
+}
+
+/*
+ * Benchmark cases
+ */
+
+var (
+	evalBenchmarkUser = NewUserBuilder("user-nomatch").
+		Name("name-nomatch").
+		Custom("stringAttr", ldvalue.String("stringAttr-nomatch")).
+		Custom("numAttr", ldvalue.Int(0)).Build()
+)
+
+type benchmarkCase struct {
+	numUsers      int
+	numFlags      int
+	numVariations int
+	numTargets    int
+	numRules      int
+	numClauses    int
+	prereqsWidth  int
+	prereqsDepth  int
+	operator      Operator
+}
+
+var benchmarkCases = []benchmarkCase{
+	// simple
+	{
+		numUsers:      1000,
+		numFlags:      1000,
+		numVariations: 2,
+		numTargets:    1,
+	},
+
+	// realistic
+	{
+		numUsers:      10000,
+		numFlags:      10000,
+		numVariations: 2,
+		numTargets:    1,
+	},
+	{
+		numUsers:      10000,
+		numFlags:      10000,
+		numVariations: 2,
+		numTargets:    10,
+	},
+	{
+		numUsers:      10000,
+		numFlags:      1000,
+		numVariations: 2,
+		numRules:      1,
+		numClauses:    1,
+	},
+	{
+		numUsers:      10000,
+		numFlags:      1000,
+		numVariations: 2,
+		numRules:      1,
+		numClauses:    3,
+	},
+	{
+		numUsers:      10000,
+		numFlags:      1000,
+		numVariations: 2,
+		numRules:      5,
+		numClauses:    3,
+	},
+
+	// prereqs
+	{
+		numUsers:      10000,
+		numFlags:      1000,
+		numVariations: 2,
+		numRules:      1,
+		numClauses:    1,
+		prereqsWidth:  5,
+		prereqsDepth:  1,
+	},
+	{
+		numUsers:      10000,
+		numFlags:      1000,
+		numVariations: 2,
+		numRules:      1,
+		numClauses:    1,
+		prereqsWidth:  1,
+		prereqsDepth:  5,
+	},
+	{
+		numUsers:      10000,
+		numFlags:      1000,
+		numVariations: 2,
+		numTargets:    1,
+		prereqsWidth:  2,
+		prereqsDepth:  2,
+	},
+	{
+		numUsers:      10000,
+		numFlags:      1000,
+		numVariations: 2,
+		numRules:      1,
+		numClauses:    1,
+		prereqsWidth:  5,
+		prereqsDepth:  5,
+	},
+
+	// operations
+	{
+		numUsers:      10000,
+		numFlags:      1000,
+		numVariations: 2,
+		numRules:      1,
+		numClauses:    1,
+		operator:      OperatorGreaterThan,
+	},
+	{
+		numUsers:      10000,
+		numFlags:      1000,
+		numVariations: 2,
+		numRules:      1,
+		numClauses:    1,
+		operator:      OperatorContains,
+	},
+	{
+		numUsers:      10000,
+		numFlags:      1000,
+		numVariations: 2,
+		numRules:      1,
+		numClauses:    1,
+		operator:      OperatorIn,
+	},
+
+	// // slow case
+	// {
+	// 	numUsers:       100000,
+	// 	numFlags:      10000,
+	// 	numVariations: 3,
+	// 	numRules:      3,
+	// 	numClauses:    3,
+	// 	prereqsWidth:  5,
+	// 	prereqsDepth:  5,
+	// 	operator:      OperatorIn,
+	// },
+}
+
+var (
+	/*
+	 * Always record the result of an operation to prevent the
+	 * compiler eliminating the function call.
+	 *
+	 * Always store the result to a package level variable so
+	 * the compiler cannot eliminate the benchmark itself.
+	 */
+	boolResult   bool
+	intResult    int
+	stringResult string
+	jsonResult   ldvalue.Value
+)
+
+func BenchmarkBoolVariation(b *testing.B) {
+	env := newBenchmarkEnv()
+	for _, bc := range benchmarkCases {
+		variations := makeBoolVariations(bc.numVariations)
+		env.setUp(bc, variations)
+
+		b.Run(fmt.Sprintf("%+v", bc), func(b *testing.B) {
+			var r bool
+			for i := 0; i < b.N; i++ {
+				r, _ = env.client.BoolVariation(env.targetFeatureKey, evalBenchmarkUser, false)
+			}
+			boolResult = r
+		})
+		env.tearDown()
+	}
+}
+
+func BenchmarkIntVariation(b *testing.B) {
+	env := newBenchmarkEnv()
+	for _, bc := range benchmarkCases {
+		variations := makeIntVariations(bc.numVariations)
+		env.setUp(bc, variations)
+
+		b.Run(fmt.Sprintf("%+v", bc), func(b *testing.B) {
+			var r int
+			for i := 0; i < b.N; i++ {
+				r, _ = env.client.IntVariation(env.targetFeatureKey, evalBenchmarkUser, 0)
+			}
+			intResult = r
+		})
+		env.tearDown()
+	}
+}
+
+func BenchmarkStringVariation(b *testing.B) {
+	env := newBenchmarkEnv()
+	for _, bc := range benchmarkCases {
+		variations := makeStringVariations(bc.numVariations)
+		env.setUp(bc, variations)
+
+		b.Run(fmt.Sprintf("%+v", bc), func(b *testing.B) {
+			var r string
+			for i := 0; i < b.N; i++ {
+				r, _ = env.client.StringVariation(env.targetFeatureKey, evalBenchmarkUser, "variation-0")
+			}
+			stringResult = r
+		})
+		env.tearDown()
+	}
+}
+
+func BenchmarkJSONVariation(b *testing.B) {
+	env := newBenchmarkEnv()
+	for _, bc := range benchmarkCases {
+		variations := makeJSONVariations(bc.numVariations)
+		env.setUp(bc, variations)
+
+		b.Run(fmt.Sprintf("%+v", bc), func(b *testing.B) {
+			var r ldvalue.Value
+			defaultValAsRawJSON := ldvalue.Raw(json.RawMessage(`{"result":{"value":[0]}}`))
+			for i := 0; i < b.N; i++ {
+				r, _ = env.client.JSONVariation(env.targetFeatureKey, evalBenchmarkUser, defaultValAsRawJSON)
+			}
+			jsonResult = r
+		})
+		env.tearDown()
+	}
+}
+
+/*
+ * Helpers
+ */
+
+func newBenchmarkFlag(key string, fallThroughVariation int, targets []Target, rules []Rule, prereqs []Prerequisite, variations ...interface{}) *FeatureFlag {
+	return &FeatureFlag{
+		Key:           key,
+		Version:       1,
+		On:            true,
+		Fallthrough:   VariationOrRollout{Variation: &fallThroughVariation},
+		Variations:    variations,
+		Rules:         rules,
+		Targets:       targets,
+		Prerequisites: prereqs,
+	}
+}
+
+func makeBoolVariations(numVariations int) []interface{} {
+	variations := make([]interface{}, 0, numVariations)
+	for i := 0; i < numVariations; i++ {
+		variation := false
+		if i%2 == 0 {
+			variation = true
+		}
+		variations = append(variations, variation)
+	}
+	return variations
+}
+
+func makeIntVariations(numVariations int) []interface{} {
+	variations := make([]interface{}, 0, numVariations)
+	for i := 0; i < numVariations; i++ {
+		variations = append(variations, i)
+	}
+	return variations
+}
+
+func makeStringVariations(numVariations int) []interface{} {
+	variations := make([]interface{}, 0, numVariations)
+	for i := 0; i < numVariations; i++ {
+		variations = append(variations, fmt.Sprintf("variation-%d", i))
+	}
+	return variations
+}
+
+func makeJSONVariations(numVariations int) []interface{} {
+	variations := make([]interface{}, 0, numVariations)
+	for i := 0; i < numVariations; i++ {
+		valAsRawJSON := ldvalue.Raw(json.RawMessage(fmt.Sprintf(`{"result":{"value":[%d]}}`, i)))
+		variations = append(variations, valAsRawJSON)
+	}
+	return variations
+}
+
+func makeClauses(numClauses int, op Operator) []Clause {
+	clauses := make([]Clause, 0, numClauses)
+	for i := 0; i < numClauses; i++ {
+		clause := Clause{Op: op}
+		switch op {
+		case OperatorGreaterThan:
+			clause.Attribute = "numAttr"
+			clause.Values = []interface{}{i}
+		case OperatorContains:
+			clause.Attribute = "name"
+			clause.Values = []interface{}{
+				fmt.Sprintf("name-%d", i),
+				fmt.Sprintf("name-%d", i+1),
+				fmt.Sprintf("name-%d", i+2),
+			}
+		case OperatorIn:
+			clause.Attribute = "stringAttr"
+			clause.Values = []interface{}{
+				fmt.Sprintf("stringAttr-%d", i),
+				fmt.Sprintf("stringAttr-%d", i+1),
+				fmt.Sprintf("stringAttr-%d", i+2),
+			}
+		default:
+			clause.Op = OperatorMatches
+			clause.Attribute = "stringAttr"
+			clause.Values = []interface{}{
+				fmt.Sprintf("stringAttr-%d", i),
+				fmt.Sprintf("stringAttr-%d", i+1),
+				fmt.Sprintf("stringAttr-%d", i+2),
+			}
+		}
+		clauses = append(clauses, clause)
+	}
+	return clauses
+}
+
+func makeBenchmarkFlags(bc benchmarkCase, variations []interface{}) []*FeatureFlag {
+	testFlags := make([]*FeatureFlag, 0, bc.numFlags)
+	for i := 0; i < bc.numFlags; i++ {
+		targets := make([]Target, 0, bc.numVariations)
+		for j := 0; j < bc.numVariations; j++ {
+			values := make([]string, 0, bc.numTargets)
+			for k := 0; k < bc.numTargets; k++ {
+				values = append(values, fmt.Sprintf("user-%d", k))
+			}
+			targets = append(targets, Target{
+				Values:    values,
+				Variation: j,
+			})
+		}
+		rules := make([]Rule, 0, bc.numRules)
+		variation := 0
+		for j := 0; j < bc.numRules; j++ {
+			rules = append(rules, Rule{
+				ID:      fmt.Sprintf("%d-%d", i, j),
+				Clauses: makeClauses(bc.numClauses, bc.operator),
+				VariationOrRollout: VariationOrRollout{
+					Variation: &variation,
+				},
+			})
+		}
+
+		testFlag := newBenchmarkFlag(fmt.Sprintf("flag-%d", i), 1, targets, rules, nil, variations...)
+		testFlags = append(testFlags, testFlag)
+	}
+
+	if bc.prereqsWidth > 0 && bc.prereqsDepth > 0 {
+		assignPrereqTree(testFlags, bc.prereqsWidth, bc.prereqsDepth)
+	}
+
+	return testFlags
+}
+
+// assignPrereqTree assigns prerequisites to each of the given feature flags such that each flag
+// has at most `width` children and `depth` ancestors. If the depth of the prerequisite "tree"
+// exceeds `depth`, a new tree is assigned starting with the next feature flag the root node.
+func assignPrereqTree(flags []*FeatureFlag, width, depth int) {
+	var parentLevel []*FeatureFlag
+	levelIndex := 0
+
+	i := 0
+	for i < len(flags) {
+		if levelIndex > depth {
+			levelIndex = 0
+			parentLevel = []*FeatureFlag{flags[i]}
+			// log.Println("\n\n*** new tree!")
+			// log.Print("\nlevel 0 - " + flags[i].Key)
+		}
+		if levelIndex == 0 {
+			levelIndex++
+			i++
+			continue
+		}
+
+		// log.Printf("\nlevel %d - ", levelIndex)
+
+		var childLevel []*FeatureFlag
+		for _, parent := range parentLevel {
+			// log.Print(parent.Key + ": ")
+			for w := 0; w < width && i+w < len(flags); w++ {
+				child := flags[i+w]
+				child.Prerequisites = []Prerequisite{{Key: parent.Key, Variation: 0}}
+				childLevel = append(childLevel, child)
+				// log.Print(child.Key + ", ")
+			}
+			i += width
+		}
+		parentLevel = childLevel
+		levelIndex++
+	}
+	// log.Println()
+}


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

N/A

**Describe the solution you've provided**

I've added benchmarks to measure the throughput and memory allocations of several evaluation functions.

**Describe alternatives you've considered**

N/A

**Additional context**

Results:

```
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ gopkg.in/launchdarkly/go-server-sdk.v4 -bench ^(BenchmarkBoolVariation|BenchmarkIntVariation|BenchmarkStringVariation|BenchmarkJSONVariation)$

goos: linux
goarch: amd64
pkg: gopkg.in/launchdarkly/go-server-sdk.v4
BenchmarkBoolVariation/{numUsers:1000_numFlags:1000_numVariations:2_numTargets:1_numRules:0_numClauses:0_prereqsWidth:0_prereqsDepth:0_operator:}-16         	 1212894	      1050 ns/op	     593 B/op	       4 allocs/op
BenchmarkBoolVariation/{numUsers:10000_numFlags:10000_numVariations:2_numTargets:1_numRules:0_numClauses:0_prereqsWidth:0_prereqsDepth:0_operator:}-16       	 1407657	       858 ns/op	     579 B/op	       4 allocs/op
BenchmarkBoolVariation/{numUsers:10000_numFlags:10000_numVariations:2_numTargets:10_numRules:0_numClauses:0_prereqsWidth:0_prereqsDepth:0_operator:}-16      	 1367804	       895 ns/op	     581 B/op	       4 allocs/op
BenchmarkBoolVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:0_prereqsDepth:0_operator:}-16        	  120196	      9596 ns/op	    6863 B/op	      65 allocs/op
BenchmarkBoolVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:3_prereqsWidth:0_prereqsDepth:0_operator:}-16        	  117769	      9706 ns/op	    6868 B/op	      65 allocs/op
BenchmarkBoolVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:5_numClauses:3_prereqsWidth:0_prereqsDepth:0_operator:}-16        	   26331	     44985 ns/op	   32055 B/op	     309 allocs/op
BenchmarkBoolVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:5_prereqsDepth:1_operator:}-16        	  110031	     10680 ns/op	    7705 B/op	      69 allocs/op
BenchmarkBoolVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:1_prereqsDepth:5_operator:}-16        	  108960	     10678 ns/op	    7704 B/op	      69 allocs/op
BenchmarkBoolVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:1_numRules:0_numClauses:0_prereqsWidth:2_prereqsDepth:2_operator:}-16        	  658082	      1913 ns/op	    1405 B/op	       8 allocs/op
BenchmarkBoolVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:5_prereqsDepth:5_operator:}-16        	   76873	     15517 ns/op	   14525 B/op	      86 allocs/op
BenchmarkBoolVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:0_prereqsDepth:0_operator:greaterThan}-16         	 1000000	      1092 ns/op	     599 B/op	       7 allocs/op
BenchmarkBoolVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:0_prereqsDepth:0_operator:contains}-16            	 1000000	      1044 ns/op	     591 B/op	       5 allocs/op
BenchmarkBoolVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:0_prereqsDepth:0_operator:in}-16                  	  995553	      1146 ns/op	     592 B/op	       5 allocs/op
BenchmarkIntVariation/{numUsers:1000_numFlags:1000_numVariations:2_numTargets:1_numRules:0_numClauses:0_prereqsWidth:0_prereqsDepth:0_operator:}-16                      	 1351836	       915 ns/op	     590 B/op	       5 allocs/op
BenchmarkIntVariation/{numUsers:10000_numFlags:10000_numVariations:2_numTargets:1_numRules:0_numClauses:0_prereqsWidth:0_prereqsDepth:0_operator:}-16                    	 1338130	       922 ns/op	     591 B/op	       5 allocs/op
BenchmarkIntVariation/{numUsers:10000_numFlags:10000_numVariations:2_numTargets:10_numRules:0_numClauses:0_prereqsWidth:0_prereqsDepth:0_operator:}-16                   	 1349911	       934 ns/op	     590 B/op	       5 allocs/op
BenchmarkIntVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:0_prereqsDepth:0_operator:}-16                     	  117642	      9812 ns/op	    6871 B/op	      66 allocs/op
BenchmarkIntVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:3_prereqsWidth:0_prereqsDepth:0_operator:}-16                     	  117109	      9951 ns/op	    6874 B/op	      66 allocs/op
BenchmarkIntVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:5_numClauses:3_prereqsWidth:0_prereqsDepth:0_operator:}-16                     	   26042	     44585 ns/op	   32022 B/op	     310 allocs/op
BenchmarkIntVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:5_prereqsDepth:1_operator:}-16                     	  109071	     10850 ns/op	    7712 B/op	      70 allocs/op
BenchmarkIntVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:1_prereqsDepth:5_operator:}-16                     	  108716	     10636 ns/op	    7713 B/op	      70 allocs/op
BenchmarkIntVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:1_numRules:0_numClauses:0_prereqsWidth:2_prereqsDepth:2_operator:}-16                     	  683667	      1875 ns/op	    1407 B/op	       9 allocs/op
BenchmarkIntVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:5_prereqsDepth:5_operator:}-16                     	   76902	     15611 ns/op	   14530 B/op	      87 allocs/op
BenchmarkIntVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:0_prereqsDepth:0_operator:greaterThan}-16          	 1000000	      1139 ns/op	     607 B/op	       8 allocs/op
BenchmarkIntVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:0_prereqsDepth:0_operator:contains}-16             	 1000000	      1052 ns/op	     599 B/op	       6 allocs/op
BenchmarkIntVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:0_prereqsDepth:0_operator:in}-16                   	  980880	      1166 ns/op	     601 B/op	       6 allocs/op
BenchmarkStringVariation/{numUsers:1000_numFlags:1000_numVariations:2_numTargets:1_numRules:0_numClauses:0_prereqsWidth:0_prereqsDepth:0_operator:}-16                   	 1000000	      1001 ns/op	     607 B/op	       6 allocs/op
BenchmarkStringVariation/{numUsers:10000_numFlags:10000_numVariations:2_numTargets:1_numRules:0_numClauses:0_prereqsWidth:0_prereqsDepth:0_operator:}-16                 	 1277961	      1000 ns/op	     620 B/op	       6 allocs/op
BenchmarkStringVariation/{numUsers:10000_numFlags:10000_numVariations:2_numTargets:10_numRules:0_numClauses:0_prereqsWidth:0_prereqsDepth:0_operator:}-16                	 1236304	       952 ns/op	     623 B/op	       6 allocs/op
BenchmarkStringVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:0_prereqsDepth:0_operator:}-16                  	  115327	     10022 ns/op	    6893 B/op	      67 allocs/op
BenchmarkStringVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:3_prereqsWidth:0_prereqsDepth:0_operator:}-16                  	  113648	     10062 ns/op	    6893 B/op	      67 allocs/op
BenchmarkStringVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:5_numClauses:3_prereqsWidth:0_prereqsDepth:0_operator:}-16                  	   26416	     45946 ns/op	   32024 B/op	     311 allocs/op
BenchmarkStringVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:5_prereqsDepth:1_operator:}-16                  	  105981	     11005 ns/op	    7728 B/op	      73 allocs/op
BenchmarkStringVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:1_prereqsDepth:5_operator:}-16                  	  107774	     10939 ns/op	    7770 B/op	      73 allocs/op
BenchmarkStringVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:1_numRules:0_numClauses:0_prereqsWidth:2_prereqsDepth:2_operator:}-16                  	  624622	      2037 ns/op	    1478 B/op	      12 allocs/op
BenchmarkStringVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:5_prereqsDepth:5_operator:}-16                  	   76010	     15926 ns/op	   14594 B/op	      90 allocs/op
BenchmarkStringVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:0_prereqsDepth:0_operator:greaterThan}-16       	  985740	      1199 ns/op	     632 B/op	       9 allocs/op
BenchmarkStringVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:0_prereqsDepth:0_operator:contains}-16          	 1000000	      1159 ns/op	     623 B/op	       7 allocs/op
BenchmarkStringVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:0_prereqsDepth:0_operator:in}-16                	  935442	      1268 ns/op	     629 B/op	       7 allocs/op
BenchmarkJSONVariation/{numUsers:1000_numFlags:1000_numVariations:2_numTargets:1_numRules:0_numClauses:0_prereqsWidth:0_prereqsDepth:0_operator:}-16                     	 1000000	      1056 ns/op	     703 B/op	       8 allocs/op
BenchmarkJSONVariation/{numUsers:10000_numFlags:10000_numVariations:2_numTargets:1_numRules:0_numClauses:0_prereqsWidth:0_prereqsDepth:0_operator:}-16                   	 1000000	      1064 ns/op	     703 B/op	       8 allocs/op
BenchmarkJSONVariation/{numUsers:10000_numFlags:10000_numVariations:2_numTargets:10_numRules:0_numClauses:0_prereqsWidth:0_prereqsDepth:0_operator:}-16                  	 1000000	      1094 ns/op	     703 B/op	       8 allocs/op
BenchmarkJSONVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:0_prereqsDepth:0_operator:}-16                    	  116539	      9967 ns/op	    6980 B/op	      69 allocs/op
BenchmarkJSONVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:3_prereqsWidth:0_prereqsDepth:0_operator:}-16                    	  115340	     10069 ns/op	    6984 B/op	      69 allocs/op
BenchmarkJSONVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:5_numClauses:3_prereqsWidth:0_prereqsDepth:0_operator:}-16                    	   25959	     45521 ns/op	   32118 B/op	     313 allocs/op
BenchmarkJSONVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:5_prereqsDepth:1_operator:}-16                    	  105205	     11329 ns/op	    7918 B/op	      77 allocs/op
BenchmarkJSONVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:1_prereqsDepth:5_operator:}-16                    	  103836	     11189 ns/op	    7920 B/op	      77 allocs/op
BenchmarkJSONVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:1_numRules:0_numClauses:0_prereqsWidth:2_prereqsDepth:2_operator:}-16                    	  550192	      2267 ns/op	    1694 B/op	      16 allocs/op
BenchmarkJSONVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:5_prereqsDepth:5_operator:}-16                    	   73746	     16134 ns/op	   14800 B/op	      94 allocs/op
BenchmarkJSONVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:0_prereqsDepth:0_operator:greaterThan}-16         	  908146	      1301 ns/op	     736 B/op	      11 allocs/op
BenchmarkJSONVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:0_prereqsDepth:0_operator:contains}-16            	  936613	      1935 ns/op	     725 B/op	       9 allocs/op
BenchmarkJSONVariation/{numUsers:10000_numFlags:1000_numVariations:2_numTargets:0_numRules:1_numClauses:1_prereqsWidth:0_prereqsDepth:0_operator:in}-16                  	  854199	      1363 ns/op	     713 B/op	       9 allocs/op
PASS
ok  	gopkg.in/launchdarkly/go-server-sdk.v4	76.605s
```