### PR TITLE
Get started hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## LaunchDarkly overview
 
-[LaunchDarkly](https://www.launchdarkly.com) is a feature management platform that serves over 100 billion feature flags daily to help teams build better software, faster. [Get started](https://docs.launchdarkly.com/docs/getting-started) using LaunchDarkly today!
+[LaunchDarkly](https://www.launchdarkly.com) is a feature management platform that serves over 100 billion feature flags daily to help teams build better software, faster. [Get started](https://docs.launchdarkly.com/home/getting-started) using LaunchDarkly today!
 
 ## Supported Go versions
 


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/v5/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

The issue was not recorded.

**Describe the solution you've provided**

The "Getting Started" hyperlink in the README seems to be wrong, and following it lands you in a 404 error page. This PR changes it so that it points to the "Getting Started" section of the Launch Darkly docs site.

**Describe alternatives you've considered**

No alternatives were considered.

**Additional context**

Stumbled upon the issue while going through the README.
