### PR TITLE
refactor: remove unused baseURI variables related to ServiceEndpoints

### DIFF
--- a/internal/endpoints/configure_endpoints.go
+++ b/internal/endpoints/configure_endpoints.go
@@ -48,11 +48,8 @@ func getCustom(serviceEndpoints interfaces.ServiceEndpoints, serviceType Service
 }
 
 // IsCustom returns true if the service endpoint has been overridden with a non-default value.
-func IsCustom(serviceEndpoints interfaces.ServiceEndpoints, serviceType ServiceType, overrideValue string) bool {
-	uri := overrideValue
-	if uri == "" {
-		uri = getCustom(serviceEndpoints, serviceType)
-	}
+func IsCustom(serviceEndpoints interfaces.ServiceEndpoints, serviceType ServiceType) bool {
+	uri := getCustom(serviceEndpoints, serviceType)
 	return uri != "" && strings.TrimSuffix(uri, "/") != strings.TrimSuffix(DefaultBaseURI(serviceType), "/")
 }
 
@@ -74,23 +71,20 @@ func DefaultBaseURI(serviceType ServiceType) string {
 func SelectBaseURI(
 	serviceEndpoints interfaces.ServiceEndpoints,
 	serviceType ServiceType,
-	overrideValue string,
 	loggers ldlog.Loggers,
 ) string {
-	configuredBaseURI := overrideValue
-	if configuredBaseURI == "" {
-		if anyCustom(serviceEndpoints) {
-			configuredBaseURI = getCustom(serviceEndpoints, serviceType)
-			if configuredBaseURI == "" {
-				loggers.Errorf(
-					"You have set custom ServiceEndpoints without specifying the %s base URI; connections may not work properly",
-					serviceType,
-				)
-				configuredBaseURI = DefaultBaseURI(serviceType)
-			}
-		} else {
+	var configuredBaseURI string
+	if anyCustom(serviceEndpoints) {
+		configuredBaseURI = getCustom(serviceEndpoints, serviceType)
+		if configuredBaseURI == "" {
+			loggers.Errorf(
+				"You have set custom ServiceEndpoints without specifying the %s base URI; connections may not work properly",
+				serviceType,
+			)
 			configuredBaseURI = DefaultBaseURI(serviceType)
 		}
+	} else {
+		configuredBaseURI = DefaultBaseURI(serviceType)
 	}
 	return strings.TrimRight(configuredBaseURI, "/")
 }

--- a/internal/endpoints/configure_endpoints_test.go
+++ b/internal/endpoints/configure_endpoints_test.go
@@ -1,0 +1,73 @@
+package endpoints
+
+import (
+	"fmt"
+	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
+	"github.com/launchdarkly/go-sdk-common/v3/ldlogtest"
+	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func TestDefaultURISelectedIfNoCustomURISpecified(t *testing.T) {
+	logger := ldlogtest.NewMockLog()
+	endpoints := interfaces.ServiceEndpoints{}
+	services := []ServiceType{StreamingService, PollingService, EventsService}
+	for _, service := range services {
+		assert.Equal(t, strings.TrimSuffix(DefaultBaseURI(service), "/"), SelectBaseURI(endpoints, service, logger.Loggers))
+	}
+}
+
+func TestSelectCustomURIs(t *testing.T) {
+	logger := ldlogtest.NewMockLog()
+	const customURI = "http://custom_uri"
+
+	cases := []struct {
+		endpoints interfaces.ServiceEndpoints
+		service   ServiceType
+	}{
+		{interfaces.ServiceEndpoints{Polling: customURI}, PollingService},
+		{interfaces.ServiceEndpoints{Streaming: customURI}, StreamingService},
+		{interfaces.ServiceEndpoints{Events: customURI}, EventsService},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, customURI, SelectBaseURI(c.endpoints, c.service, logger.Loggers))
+	}
+
+	assert.Empty(t, logger.GetOutput(ldlog.Error))
+}
+
+func TestLogErrorIfAtLeastOneButNotAllCustomURISpecified(t *testing.T) {
+	logger := ldlogtest.NewMockLog()
+	const customURI = "http://custom_uri"
+
+	cases := []struct {
+		endpoints interfaces.ServiceEndpoints
+		service   ServiceType
+	}{
+		{interfaces.ServiceEndpoints{Streaming: customURI}, PollingService},
+		{interfaces.ServiceEndpoints{Events: customURI}, PollingService},
+		{interfaces.ServiceEndpoints{Streaming: customURI, Events: customURI}, PollingService},
+
+		{interfaces.ServiceEndpoints{Polling: customURI}, StreamingService},
+		{interfaces.ServiceEndpoints{Events: customURI}, StreamingService},
+		{interfaces.ServiceEndpoints{Polling: customURI, Events: customURI}, StreamingService},
+
+		{interfaces.ServiceEndpoints{Streaming: customURI}, EventsService},
+		{interfaces.ServiceEndpoints{Polling: customURI}, EventsService},
+		{interfaces.ServiceEndpoints{Streaming: customURI, Polling: customURI}, EventsService},
+	}
+
+	// Even if the configuration is considered to be likely malformed, we should still return the proper default URI for
+	// the service that wasn't configured.
+	for _, c := range cases {
+		assert.Equal(t, strings.TrimSuffix(DefaultBaseURI(c.service), "/"), SelectBaseURI(c.endpoints, c.service, logger.Loggers))
+	}
+
+	// For each service that wasn't configured, we should see a log message indicating that.
+	for _, c := range cases {
+		logger.AssertMessageMatch(t, true, ldlog.Error, fmt.Sprintf("You have set custom ServiceEndpoints without specifying the %s base URI", c.service))
+	}
+}

--- a/ldcomponents/polling_data_source_builder.go
+++ b/ldcomponents/polling_data_source_builder.go
@@ -20,7 +20,6 @@ const DefaultPollInterval = 30 * time.Second
 //
 // See [PollingDataSource] for usage.
 type PollingDataSourceBuilder struct {
-	baseURI      string
 	pollInterval time.Duration
 	filterKey    ldvalue.OptionalString
 }
@@ -90,7 +89,6 @@ func (b *PollingDataSourceBuilder) Build(context subsystems.ClientContext) (subs
 	configuredBaseURI := endpoints.SelectBaseURI(
 		context.GetServiceEndpoints(),
 		endpoints.PollingService,
-		b.baseURI,
 		context.GetLogging().Loggers,
 	)
 	cfg := datasource.PollingConfig{
@@ -107,7 +105,7 @@ func (b *PollingDataSourceBuilder) DescribeConfiguration(context subsystems.Clie
 	return ldvalue.ObjectBuild().
 		SetBool("streamingDisabled", true).
 		SetBool("customBaseURI",
-			endpoints.IsCustom(context.GetServiceEndpoints(), endpoints.PollingService, b.baseURI)).
+			endpoints.IsCustom(context.GetServiceEndpoints(), endpoints.PollingService)).
 		Set("pollingIntervalMillis", durationToMillisValue(b.pollInterval)).
 		SetBool("usingRelayDaemon", false).
 		Build()

--- a/ldcomponents/send_events.go
+++ b/ldcomponents/send_events.go
@@ -34,7 +34,6 @@ const (
 // See [SendEvents] for usage.
 type EventProcessorBuilder struct {
 	allAttributesPrivate        bool
-	baseURI                     string
 	capacity                    int
 	diagnosticRecordingInterval time.Duration
 	flushInterval               time.Duration
@@ -74,7 +73,6 @@ func (b *EventProcessorBuilder) Build(
 	configuredBaseURI := endpoints.SelectBaseURI(
 		context.GetServiceEndpoints(),
 		endpoints.EventsService,
-		b.baseURI,
 		loggers,
 	)
 
@@ -206,7 +204,7 @@ func (b *EventProcessorBuilder) DescribeConfiguration(context subsystems.ClientC
 	return ldvalue.ObjectBuild().
 		Set("allAttributesPrivate", ldvalue.Bool(b.allAttributesPrivate)).
 		Set("customEventsURI", ldvalue.Bool(
-			endpoints.IsCustom(context.GetServiceEndpoints(), endpoints.EventsService, b.baseURI))).
+			endpoints.IsCustom(context.GetServiceEndpoints(), endpoints.EventsService))).
 		Set("diagnosticRecordingIntervalMillis", durationToMillisValue(b.diagnosticRecordingInterval)).
 		Set("eventsCapacity", ldvalue.Int(b.capacity)).
 		Set("eventsFlushIntervalMillis", durationToMillisValue(b.flushInterval)).

--- a/ldcomponents/streaming_data_source_builder.go
+++ b/ldcomponents/streaming_data_source_builder.go
@@ -20,7 +20,6 @@ const DefaultInitialReconnectDelay = time.Second
 //
 // See StreamingDataSource for usage.
 type StreamingDataSourceBuilder struct {
-	baseURI               string
 	initialReconnectDelay time.Duration
 	filterKey             ldvalue.OptionalString
 }
@@ -81,7 +80,6 @@ func (b *StreamingDataSourceBuilder) Build(context subsystems.ClientContext) (su
 	configuredBaseURI := endpoints.SelectBaseURI(
 		context.GetServiceEndpoints(),
 		endpoints.StreamingService,
-		b.baseURI,
 		context.GetLogging().Loggers,
 	)
 	cfg := datasource.StreamConfig{
@@ -101,7 +99,7 @@ func (b *StreamingDataSourceBuilder) DescribeConfiguration(context subsystems.Cl
 	return ldvalue.ObjectBuild().
 		SetBool("streamingDisabled", false).
 		SetBool("customStreamURI",
-			endpoints.IsCustom(context.GetServiceEndpoints(), endpoints.StreamingService, b.baseURI)).
+			endpoints.IsCustom(context.GetServiceEndpoints(), endpoints.StreamingService)).
 		Set("reconnectTimeMillis", durationToMillisValue(b.initialReconnectDelay)).
 		SetBool("usingRelayDaemon", false).
 		Build()


### PR DESCRIPTION
While working on https://github.com/launchdarkly/go-server-sdk/issues/103, I noticed that some of the code related to `ServiceEndpoints` seems to be using a `baseURI` variable that isn't actually set anywhere. 

I've removed those internal `baseURI` variables in the streaming/polling/event builders, which allowed me to remove an unused `overrideValue` parameter from some of the ServiceEndpoint utility functions.
