### PR TITLE
feat(deps): bump supported Go versions to 1.22 and 1.21

### DIFF
--- a/.github/variables/go-versions.env
+++ b/.github/variables/go-versions.env
@@ -1,2 +1,2 @@
-latest=1.18
-penultimate=1.19
+latest=1.22
+penultimate=1.21

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,6 @@ run:
 linters:
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dupl
     - errcheck
@@ -36,7 +35,6 @@ linters:
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
   fast: false
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,6 @@ run:
 linters:
   enable:
     - bodyclose
-    - depguard
     - dupl
     - errcheck
     - exportloopref
@@ -52,4 +51,3 @@ linters-settings:
 issues:
   exclude-use-default: false
   max-same-issues: 1000
-  max-per-linter: 1000

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-GOLANGCI_LINT_VERSION=v1.48.0
+GOLANGCI_LINT_VERSION=v1.57.1
 
 LINTER=./bin/golangci-lint
 LINTER_VERSION_FILE=./bin/.golangci-lint-version-$(GOLANGCI_LINT_VERSION)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@
 
 ## Supported Go versions
 
-This version of the LaunchDarkly SDK requires a Go version of 1.18 or higher.
+This version of the LaunchDarkly SDK supports Go version 1.21 or higher. 
+
+The policy for this SDK follows that of the official Go [Release Policy](https://go.dev/doc/devel/release): each major Go release is supported until there
+are two newer major releases.
 
 ## Getting started
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/launchdarkly/go-server-sdk/v7
 
-go 1.18
+go 1.21
 
 require (
 	github.com/fsnotify/fsnotify v1.4.7

--- a/go.sum
+++ b/go.sum
@@ -12,7 +12,9 @@ github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFF
 github.com/karlseguin/expect v1.0.2-0.20190806010014-778a5f0c6003 h1:vJ0Snvo+SLMY72r5J4sEfkuE7AFbixEP2qRbEcum/wA=
 github.com/karlseguin/expect v1.0.2-0.20190806010014-778a5f0c6003/go.mod h1:zNBxMY8P21owkeogJELCLeHIt+voOSduHYTFUbwRAV8=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/launchdarkly/ccache v1.1.0 h1:voD1M+ZJXR3MREOKtBwgTF9hYHl1jg+vFKS/+VAkR2k=
 github.com/launchdarkly/ccache v1.1.0/go.mod h1:TlxzrlnzvYeXiLHmesMuvoZetu4Z97cV1SsdqqBJi1Q=
 github.com/launchdarkly/eventsource v1.6.2 h1:5SbcIqzUomn+/zmJDrkb4LYw7ryoKFzH/0TbR0/3Bdg=
@@ -67,6 +69,7 @@ golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/ghodss/yaml.v1 v1.0.0 h1:JlY4R6oVz+ZSvcDhVfNQ/k/8Xo6yb2s1PBhslPZPX4c=
 gopkg.in/ghodss/yaml.v1 v1.0.0/go.mod h1:HDvRMPQLqycKPs9nWLuzZWxsxRzISLCRORiDpBUOMqg=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/endpoints/configure_endpoints.go
+++ b/internal/endpoints/configure_endpoints.go
@@ -11,9 +11,9 @@ import (
 type ServiceType int
 
 const (
-	StreamingService ServiceType = iota //nolint:revive // don't really need doc comments here
-	PollingService   ServiceType = iota
-	EventsService    ServiceType = iota
+	StreamingService ServiceType = iota //nolint:revive // internal constant
+	PollingService   ServiceType = iota //nolint:revive // internal constant
+	EventsService    ServiceType = iota //nolint:revive // internal constant
 )
 
 func (s ServiceType) String() string {

--- a/internal/sharedtest/mocks/mock_components.go
+++ b/internal/sharedtest/mocks/mock_components.go
@@ -8,6 +8,7 @@ type SingleComponentConfigurer[T any] struct {
 	Instance T
 }
 
+// Build builds the component.
 func (c SingleComponentConfigurer[T]) Build(clientContext subsystems.ClientContext) (T, error) {
 	return c.Instance, nil
 }
@@ -18,6 +19,7 @@ type ComponentConfigurerThatReturnsError[T any] struct {
 	Err error
 }
 
+// Build builds the component.
 func (c ComponentConfigurerThatReturnsError[T]) Build(clientContext subsystems.ClientContext) (T, error) {
 	var empty T
 	return empty, c.Err
@@ -30,6 +32,7 @@ type ComponentConfigurerThatCapturesClientContext[T any] struct {
 	ReceivedClientContext subsystems.ClientContext
 }
 
+// Build builds the component.
 func (c *ComponentConfigurerThatCapturesClientContext[T]) Build(clientContext subsystems.ClientContext) (T, error) {
 	c.ReceivedClientContext = clientContext
 	return c.Configurer.Build(clientContext)

--- a/testservice/go.mod
+++ b/testservice/go.mod
@@ -1,6 +1,6 @@
 module github.com/launchdarkly/go-server-sdk/v7/testservice
 
-go 1.18
+go 1.21
 
 require (
 	github.com/gorilla/mux v1.8.0


### PR DESCRIPTION
Bumps our supported Go versions from 1.18 and 1.19 to 1.21 and 1.22.

This caused some issues with golanglintci which I've fixed.