### PR TITLE
docs: update 'supported Go versions' section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@
 
 ## Supported Go versions
 
-This version of the LaunchDarkly SDK requires a Go version of 1.18 or higher.
+This version of the LaunchDarkly SDK supports Go version 1.18 or higher.
+
+The policy for this SDK follows that of the official Go [Release Policy](https://go.dev/doc/devel/release): each major Go release is supported until there
+are two newer major releases.
 
 ## Getting started
 


### PR DESCRIPTION
Updating this section to match v7 branch. This is necessary for automated updating via check-go-versions workflow.