### PR TITLE
ci: swap latest and penultimate go versions

### DIFF
--- a/.github/variables/go-versions.env
+++ b/.github/variables/go-versions.env
@@ -1,2 +1,2 @@
-latest=1.18
-penultimate=1.19
+latest=1.19
+penultimate=1.18


### PR DESCRIPTION
Accidentally swapped the penultimate/latest versions in `go-versions.env`. 
