### PR TITLE
chore: Add a warning message if the waitFor duration is too long

### DIFF
--- a/ldclient.go
+++ b/ldclient.go
@@ -34,8 +34,8 @@ import (
 // Version is the SDK version.
 const Version = internal.SDKVersion
 
-// HighWaitForSeconds is the initialization wait time threshold that we will log a warning message
-const HighWaitForSeconds = 60
+// highWaitForSeconds is the initialization wait time threshold that we will log a warning message
+const highWaitForSeconds = 60
 
 const (
 	boolVarFuncName   = "LDClient.BoolVariation"
@@ -333,8 +333,8 @@ func MakeCustomClient(sdkKey string, config Config, waitFor time.Duration) (*LDC
 
 		// If you use a long duration and wait for the timeout, then any network delays will cause
 		// your application to wait a long time before continuing execution.
-		if waitFor.Seconds() > HighWaitForSeconds {
-			loggers.Warnf("Make Client was called with a timeout greater than %d. "+
+		if waitFor.Seconds() > highWaitForSeconds {
+			loggers.Warnf("Client was created was with a timeout greater than %d. "+
 				"We recommend a timeout of less than %d seconds", HighWaitForSeconds)
 		}
 

--- a/ldclient.go
+++ b/ldclient.go
@@ -335,7 +335,7 @@ func MakeCustomClient(sdkKey string, config Config, waitFor time.Duration) (*LDC
 		// your application to wait a long time before continuing execution.
 		if waitFor.Seconds() > highWaitForSeconds {
 			loggers.Warnf("Client was created was with a timeout greater than %d. "+
-				"We recommend a timeout of less than %d seconds", HighWaitForSeconds)
+				"We recommend a timeout of less than %d seconds", highWaitForSeconds, highWaitForSeconds)
 		}
 
 		timeout := time.After(waitFor)

--- a/ldclient.go
+++ b/ldclient.go
@@ -34,6 +34,9 @@ import (
 // Version is the SDK version.
 const Version = internal.SDKVersion
 
+// HighWaitForSeconds is the initialization wait time threshold that we will log a warning message
+const HighWaitForSeconds = 60
+
 const (
 	boolVarFuncName   = "LDClient.BoolVariation"
 	intVarFuncName    = "LDClient.IntVariation"
@@ -327,6 +330,14 @@ func MakeCustomClient(sdkKey string, config Config, waitFor time.Duration) (*LDC
 	if waitFor > 0 && client.dataSource != datasource.NewNullDataSource() {
 		loggers.Infof("Waiting up to %d milliseconds for LaunchDarkly client to start...",
 			waitFor/time.Millisecond)
+
+		// If you use a long duration and wait for the timeout, then any network delays will cause
+		// your application to wait a long time before continuing execution.
+		if waitFor.Seconds() > HighWaitForSeconds {
+			loggers.Warnf("Make Client was called with a timeout greater than %d. "+
+				"We recommend a timeout of less than %d seconds", HighWaitForSeconds)
+		}
+
 		timeout := time.After(waitFor)
 		for {
 			select {


### PR DESCRIPTION
This adds a warning-level message and we make sure the test still runs


BEGIN_COMMIT_OVERRIDE
fix: add warning log message if client init duration is longer than recommended (60s)
END_COMMIT_OVERRIDE