### PR TITLE
Additional test for Broadcaster data race

### DIFF
--- a/internal/broadcasters_test.go
+++ b/internal/broadcasters_test.go
@@ -97,7 +97,7 @@ func TestBroadcasterDataRace(t *testing.T) {
 		func() { b.HasListeners() },
 		func() { b.RemoveListener(nil) },
 	} {
-		const concurrentRoutinesWithSelf = 2
+		const concurrentRoutinesWithSelf = 10
 		// run a method concurrently with itself to detect data races
 		for i := 0; i < concurrentRoutinesWithSelf; i++ {
 			waitGroup.Add(1)


### PR DESCRIPTION
This is a small cleanup to the existing Broadcasters implementation to use `slices.DeleteFunc`.

Additionally, I've upped the number of parallel goroutines used in the new race detection test to 10, to have a slightly higher chance of catching issues, and added a new test that randomly runs the functions against each-other.