### PR TITLE
ci: don't update Go.mod versions when new Go versions are releases

### DIFF
--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -58,27 +58,14 @@ jobs:
           sed -i -e "s#latest=[^ ]*#latest=${{ env.officialLatestVersion }}#g" \
                  -e "s#penultimate=[^ ]*#penultimate=${{ env.officialPenultimateVersion }}#g" \
                   ./.github/variables/go-versions.env
-          sed -i "s/Go version ${{ steps.go-versions.outputs.penultimate }}/Go version ${{ env.officialPenultimateVersion }}/g" \
-                  README.md
-
-      - name: Update go.mod and testservice/go.mod
-        if: steps.update-go-versions.outcome == 'success'
-        id: update-go-mod
-        run: |
-          go mod edit -go=${{ env.officialPenultimateVersion }}
-          cd testservice
-          go mod edit -go=${{ env.officialPenultimateVersion }}
 
       - name: Create pull request
-        if: steps.update-go-mod.outcome == 'success'
+        if: steps.update-go-versions.outcome == 'success'
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           add-paths: |
             .github/variables/go-versions.env
-            README.md
-            go.mod
-            testservice/go.mod
           branch: "launchdarklyreleasebot/update-to-go${{ env.officialLatestVersion }}-${{ matrix.branch }}"
           author: "LaunchDarklyReleaseBot <LaunchDarklyReleaseBot@launchdarkly.com>"
           committer: "LaunchDarklyReleaseBot <LaunchDarklyReleaseBot@launchdarkly.com>"


### PR DESCRIPTION
I recently merged [this PR](https://github.com/launchdarkly/go-server-sdk/pull/165), which allows us to test a minimum Go version in CI. 

This updates the automated Go version checker scripts to _no longer_ update the Go.mod whenever a new version is released: instead, the SDK authors can bump it manually only when necessary. 

With this change, we can be sure that the SDK is usable by the largest amount of consumers while still utilizing new features when necessary. 