### PR TITLE
chore: Create FDv2 compatible datasource implementation

### DIFF
--- a/internal/datasource/streaming_data_source_events.go
+++ b/internal/datasource/streaming_data_source_events.go
@@ -16,7 +16,7 @@ var (
 	deleteDataRequiredProperties = []string{"path", "version"} //nolint:gochecknoglobals
 )
 
-// This is the logical representation of the data in the "put" event. In the JSON representation,
+// PutData is the logical representation of the data in the "put" event. In the JSON representation,
 // the "data" property is actually a map of maps, but the schema we use internally is a list of
 // lists instead.
 //
@@ -37,12 +37,12 @@ var (
 //	    }
 //	  }
 //	}
-type putData struct {
+type PutData struct {
 	Path string // we don't currently do anything with this
 	Data []ldstoretypes.Collection
 }
 
-// This is the logical representation of the data in the "patch" event. In the JSON representation,
+// PatchData is the logical representation of the data in the "patch" event. In the JSON representation,
 // there is a "path" property in the format "/flags/key" or "/segments/key", which we convert into
 // Kind and Key when we parse it. The "data" property is the JSON representation of the flag or
 // segment, which we deserialize into an ItemDescriptor.
@@ -56,13 +56,13 @@ type putData struct {
 //	    "version": 2, ...etc.
 //	  }
 //	}
-type patchData struct {
+type PatchData struct {
 	Kind ldstoretypes.DataKind
 	Key  string
 	Data ldstoretypes.ItemDescriptor
 }
 
-// This is the logical representation of the data in the "delete" event. In the JSON representation,
+// DeleteData is the logical representation of the data in the "delete" event. In the JSON representation,
 // there is a "path" property in the format "/flags/key" or "/segments/key", which we convert into
 // Kind and Key when we parse it.
 //
@@ -72,14 +72,14 @@ type patchData struct {
 //	  "path": "/flags/flagkey",
 //	  "version": 3
 //	}
-type deleteData struct {
+type DeleteData struct {
 	Kind    ldstoretypes.DataKind
 	Key     string
 	Version int
 }
 
-func parsePutData(data []byte) (putData, error) {
-	var ret putData
+func parsePutData(data []byte) (PutData, error) {
+	var ret PutData
 	r := jreader.NewReader(data)
 	for obj := r.Object().WithRequiredProperties(putDataRequiredProperties); obj.Next(); {
 		switch string(obj.Name()) {
@@ -92,15 +92,15 @@ func parsePutData(data []byte) (putData, error) {
 	return ret, r.Error()
 }
 
-func parsePatchData(data []byte) (patchData, error) {
-	var ret patchData
+func parsePatchData(data []byte) (PatchData, error) {
+	var ret PatchData
 	r := jreader.NewReader(data)
 	var kind datakinds.DataKindInternal
 	var key string
-	parseItem := func() (patchData, error) {
+	parseItem := func() (PatchData, error) {
 		item, err := kind.DeserializeFromJSONReader(&r)
 		if err != nil {
-			return patchData{}, err
+			return PatchData{}, err
 		}
 		ret.Data = item
 		return ret, nil
@@ -126,7 +126,7 @@ func parsePatchData(data []byte) (patchData, error) {
 		}
 	}
 	if err := r.Error(); err != nil {
-		return patchData{}, err
+		return PatchData{}, err
 	}
 	// If we got here, it means we couldn't parse the data model object yet because we saw the
 	// "data" property first. But we definitely saw both properties (otherwise we would've got
@@ -138,13 +138,13 @@ func parsePatchData(data []byte) (patchData, error) {
 		}
 	}
 	if r.Error() != nil {
-		return patchData{}, r.Error()
+		return PatchData{}, r.Error()
 	}
-	return patchData{}, errors.New("patch event had no data property")
+	return PatchData{}, errors.New("patch event had no data property")
 }
 
-func parseDeleteData(data []byte) (deleteData, error) {
-	var ret deleteData
+func parseDeleteData(data []byte) (DeleteData, error) {
+	var ret DeleteData
 	r := jreader.NewReader(data)
 	for obj := r.Object().WithRequiredProperties(deleteDataRequiredProperties); obj.Next(); {
 		switch string(obj.Name()) {
@@ -161,7 +161,7 @@ func parseDeleteData(data []byte) (deleteData, error) {
 		}
 	}
 	if r.Error() != nil {
-		return deleteData{}, r.Error()
+		return DeleteData{}, r.Error()
 	}
 	return ret, nil
 }

--- a/internal/datasourcev2/helpers.go
+++ b/internal/datasourcev2/helpers.go
@@ -1,0 +1,54 @@
+package datasourcev2
+
+//nolint: godox
+// TODO: This was copied from datasource/helpers.go. We should extract these
+// out into a common module, or if we decide we don't need these later in the
+// v2 implementation, we should clean this up.
+
+import (
+	"fmt"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
+)
+
+// Tests whether an HTTP error status represents a condition that might resolve on its own if we retry,
+// or at least should not make us permanently stop sending requests.
+func isHTTPErrorRecoverable(statusCode int) bool {
+	if statusCode >= 400 && statusCode < 500 {
+		switch statusCode {
+		case 400: // bad request
+			return true
+		case 408: // request timeout
+			return true
+		case 429: // too many requests
+			return true
+		default:
+			return false // all other 4xx errors are unrecoverable
+		}
+	}
+	return true
+}
+
+func httpErrorDescription(statusCode int) string {
+	message := ""
+	if statusCode == 401 || statusCode == 403 {
+		message = " (invalid SDK key)"
+	}
+	return fmt.Sprintf("HTTP error %d%s", statusCode, message)
+}
+
+// Logs an HTTP error or network error at the appropriate level and determines whether it is recoverable
+// (as defined by isHTTPErrorRecoverable).
+func checkIfErrorIsRecoverableAndLog(
+	loggers ldlog.Loggers,
+	errorDesc, errorContext string,
+	statusCode int,
+	recoverableMessage string,
+) bool {
+	if statusCode > 0 && !isHTTPErrorRecoverable(statusCode) {
+		loggers.Errorf("Error %s (giving up permanently): %s", errorContext, errorDesc)
+		return false
+	}
+	loggers.Warnf("Error %s (%s): %s", errorContext, recoverableMessage, errorDesc)
+	return true
+}

--- a/internal/datasourcev2/package_info.go
+++ b/internal/datasourcev2/package_info.go
@@ -1,0 +1,9 @@
+// Package datasourcev2 is an internal package containing implementation types for the SDK's data source
+// implementations (streaming, polling, etc.) and related functionality. These types are not visible
+// from outside of the SDK.
+//
+// WARNING: This particular implementation supports the upcoming flag delivery v2 format which is not
+// publicly available.
+//
+// This does not include the file data source, which is in the ldfiledata package.
+package datasourcev2

--- a/internal/datasourcev2/streaming_data_source.go
+++ b/internal/datasourcev2/streaming_data_source.go
@@ -1,0 +1,681 @@
+package datasourcev2
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/launchdarkly/go-jsonstream/v3/jreader"
+	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
+	"github.com/launchdarkly/go-sdk-common/v3/ldtime"
+	ldevents "github.com/launchdarkly/go-sdk-events/v3"
+	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
+	"github.com/launchdarkly/go-server-sdk/v7/internal"
+	"github.com/launchdarkly/go-server-sdk/v7/internal/datakinds"
+	"github.com/launchdarkly/go-server-sdk/v7/internal/datasource"
+	"github.com/launchdarkly/go-server-sdk/v7/internal/endpoints"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
+
+	es "github.com/launchdarkly/eventsource"
+
+	"golang.org/x/exp/maps"
+)
+
+const (
+	keyField     = "key"
+	kindField    = "kind"
+	versionField = "version"
+
+	putEventName    = "put-object"
+	deleteEventName = "delete-object"
+
+	streamReadTimeout        = 5 * time.Minute // the LaunchDarkly stream should send a heartbeat comment every 3 minutes
+	streamMaxRetryDelay      = 30 * time.Second
+	streamRetryResetInterval = 60 * time.Second
+	streamJitterRatio        = 0.5
+	defaultStreamRetryDelay  = 1 * time.Second
+
+	streamingErrorContext     = "in stream connection"
+	streamingWillRetryMessage = "will retry"
+)
+
+// Implementation of the streaming data source, not including the lower-level SSE implementation which is in
+// the eventsource package.
+//
+// Error handling works as follows:
+// 1. If any event is malformed, we must assume the stream is broken and we may have missed updates. Set the
+// data source state to INTERRUPTED, with an error kind of INVALID_DATA, and restart the stream.
+// 2. If we try to put updates into the data store and we get an error, we must assume something's wrong with the
+// data store. We don't have to log this error because it is logged by DataSourceUpdateSinkImpl, which will also set
+// our state to INTERRUPTED for us.
+// 2a. If the data store supports status notifications (which all persistent stores normally do), then we can
+// assume it has entered a failed state and will notify us once it is working again. If and when it recovers, then
+// it will tell us whether we need to restart the stream (to ensure that we haven't missed any updates), or
+// whether it has already persisted all of the stream updates we received during the outage.
+// 2b. If the data store doesn't support status notifications (which is normally only true of the in-memory store)
+// then we don't know the significance of the error, but we must assume that updates have been lost, so we'll
+// restart the stream.
+// 3. If we receive an unrecoverable error like HTTP 401, we close the stream and don't retry, and set the state
+// to OFF. Any other HTTP error or network error causes a retry with backoff, with a state of INTERRUPTED.
+// 4. We set the Future returned by start() to tell the client initialization logic that initialization has either
+// succeeded (we got an initial payload and successfully stored it) or permanently failed (we got a 401, etc.).
+// Otherwise, the client initialization method may time out but we will still be retrying in the background, and
+// if we succeed then the client can detect that we're initialized now by calling our Initialized method.
+
+type changeSet struct {
+	intent *serverIntent
+	events []es.Event
+}
+
+type serverIntent struct {
+	Payloads []payload `json:"payloads"`
+}
+
+type payload struct {
+	// The id here doesn't seem to match the state that is included in the
+	// payload transferred object.
+
+	// It would be nice if we had the same value available in both so we could
+	// use that as the key consistently throughout the the process.
+	ID     string `json:"id"`
+	Target int    `json:"target"`
+	Code   string `json:"code"`
+	Reason string `json:"reason"`
+}
+
+// This is the general shape of a put-object event. The delete-object is the same, with the object field being nil.
+// type baseObject struct {
+// 	Version int             `json:"version"`
+// 	Kind    string          `json:"kind"`
+// 	Key     string          `json:"key"`
+// 	Object  json.RawMessage `json:"object"`
+// }
+
+// type payloadTransferred struct {
+// 	State   string `json:"state"`
+// 	Version int    `json:"version"`
+// }
+
+// TODO: Todd doesn't have this in his spec. What are we going to do here?
+//
+//nolint:godox
+type errorEvent struct {
+	PayloadID string `json:"payloadId"`
+	Reason    string `json:"reason"`
+}
+
+// type heartBeat struct{}
+
+type goodbye struct {
+	Reason      string `json:"reason"`
+	Silent      bool   `json:"silent"`
+	Catastrophe bool   `json:"catastrophe"`
+	//nolint:godox
+	// TODO: Might later include some advice or backoff information
+}
+
+// StreamProcessor is the internal implementation of the streaming data source.
+//
+// This type is exported from internal so that the StreamingDataSourceBuilder tests can verify its
+// configuration. All other code outside of this package should interact with it only via the
+// DataSource interface.
+type StreamProcessor struct {
+	cfg                        datasource.StreamConfig
+	dataSourceUpdates          subsystems.DataSourceUpdateSink
+	client                     *http.Client
+	headers                    http.Header
+	diagnosticsManager         *ldevents.DiagnosticsManager
+	loggers                    ldlog.Loggers
+	isInitialized              internal.AtomicBoolean
+	halt                       chan struct{}
+	storeStatusCh              <-chan interfaces.DataStoreStatus
+	connectionAttemptStartTime ldtime.UnixMillisecondTime
+	connectionAttemptLock      sync.Mutex
+	readyOnce                  sync.Once
+	closeOnce                  sync.Once
+}
+
+// NewStreamProcessor creates the internal implementation of the streaming data source.
+func NewStreamProcessor(
+	context subsystems.ClientContext,
+	dataSourceUpdates subsystems.DataSourceUpdateSink,
+	cfg datasource.StreamConfig,
+) *StreamProcessor {
+	sp := &StreamProcessor{
+		dataSourceUpdates: dataSourceUpdates,
+		headers:           context.GetHTTP().DefaultHeaders,
+		loggers:           context.GetLogging().Loggers,
+		halt:              make(chan struct{}),
+		cfg:               cfg,
+	}
+	if cci, ok := context.(*internal.ClientContextImpl); ok {
+		sp.diagnosticsManager = cci.DiagnosticsManager
+	}
+
+	sp.client = context.GetHTTP().CreateHTTPClient()
+	// Client.Timeout isn't just a connect timeout, it will break the connection if a full response
+	// isn't received within that time (which, with the stream, it never will be), so we must make
+	// sure it's zero and not the usual configured default. What we do want is a *connection* timeout,
+	// which is set by Config.newHTTPClient as a property of the Dialer.
+	sp.client.Timeout = 0
+
+	return sp
+}
+
+//nolint:revive // no doc comment for standard method
+func (sp *StreamProcessor) IsInitialized() bool {
+	return sp.isInitialized.Get()
+}
+
+//nolint:revive // no doc comment for standard method
+func (sp *StreamProcessor) Start(closeWhenReady chan<- struct{}) {
+	sp.loggers.Info("Starting LaunchDarkly streaming connection")
+	if sp.dataSourceUpdates.GetDataStoreStatusProvider().IsStatusMonitoringEnabled() {
+		sp.storeStatusCh = sp.dataSourceUpdates.GetDataStoreStatusProvider().AddStatusListener()
+	}
+	go sp.subscribe(closeWhenReady)
+}
+
+// TODO: Remove this nolint once we have a better implementation.
+//
+//nolint:gocyclo,godox // this function is a stepping stone. It will get better over time.
+func (sp *StreamProcessor) consumeStream(stream *es.Stream, closeWhenReady chan<- struct{}) {
+	// Consume remaining Events and Errors so we can garbage collect
+	defer func() {
+		for range stream.Events {
+		} // COVERAGE: no way to cause this condition in unit tests
+		if stream.Errors != nil {
+			for range stream.Errors { // COVERAGE: no way to cause this condition in unit tests
+			}
+		}
+	}()
+
+	currentChangeSet := changeSet{
+		events: make([]es.Event, 0),
+	}
+
+	for {
+		select {
+		case event, ok := <-stream.Events:
+			if !ok {
+				// COVERAGE: stream.Events is only closed if the EventSource has been closed. However, that
+				// only happens when we have received from sp.halt, in which case we return immediately
+				// after calling stream.Close(), terminating the for loop-- so we should not actually reach
+				// this point. Still, in case the channel is somehow closed unexpectedly, we do want to
+				// terminate the loop.
+				return
+			}
+
+			sp.logConnectionResult(true)
+
+			processedEvent := true
+			shouldRestart := false
+
+			gotMalformedEvent := func(event es.Event, err error) {
+				if event == nil {
+					sp.loggers.Errorf(
+						"Received streaming events with malformed JSON data (%s); will restart stream",
+						err,
+					)
+				} else {
+					sp.loggers.Errorf(
+						"Received streaming \"%s\" event with malformed JSON data (%s); will restart stream",
+						event.Event(),
+						err,
+					)
+				}
+
+				errorInfo := interfaces.DataSourceErrorInfo{
+					Kind:    interfaces.DataSourceErrorKindInvalidData,
+					Message: err.Error(),
+					Time:    time.Now(),
+				}
+				sp.dataSourceUpdates.UpdateStatus(interfaces.DataSourceStateInterrupted, errorInfo)
+
+				shouldRestart = true // scenario 1 in error handling comments at top of file
+				processedEvent = false
+			}
+
+			storeUpdateFailed := func(updateDesc string) {
+				if sp.storeStatusCh != nil {
+					sp.loggers.Errorf("Failed to store %s in data store; will try again once data store is working", updateDesc)
+					// scenario 2a in error handling comments at top of file
+				} else {
+					sp.loggers.Errorf("Failed to store %s in data store; will restart stream until successful", updateDesc)
+					shouldRestart = true // scenario 2b
+					processedEvent = false
+				}
+			}
+
+			switch event.Event() {
+			case "heart-beat":
+				// Swallow the event and move on.
+			case "server-intent":
+				//nolint: godox
+				// TODO: Replace all this json unmarshalling with a nicer jreader implementation.
+				var serverIntent serverIntent
+				err := json.Unmarshal([]byte(event.Data()), &serverIntent)
+				if err != nil {
+					gotMalformedEvent(event, err)
+					break
+				} else if len(serverIntent.Payloads) == 0 {
+					gotMalformedEvent(event, errors.New("server-intent event has no payloads"))
+					break
+				}
+
+				if serverIntent.Payloads[0].Code == "none" {
+					sp.loggers.Info("Server intent is none, skipping")
+					continue
+				}
+
+				currentChangeSet = changeSet{events: make([]es.Event, 0), intent: &serverIntent}
+
+			case putEventName:
+				currentChangeSet.events = append(currentChangeSet.events, event)
+			case deleteEventName:
+				currentChangeSet.events = append(currentChangeSet.events, event)
+			case "goodbye":
+				var goodbye goodbye
+				err := json.Unmarshal([]byte(event.Data()), &goodbye)
+				if err != nil {
+					gotMalformedEvent(event, err)
+					break
+				}
+
+				if !goodbye.Silent {
+					sp.loggers.Errorf("SSE server received error: %s (%s)", goodbye.Reason, goodbye.Catastrophe)
+				}
+			case "error":
+				var errorData errorEvent
+				err := json.Unmarshal([]byte(event.Data()), &errorData)
+				if err != nil {
+					//nolint: godox
+					// TODO: Confirm that an error means we have to discard
+					// everything that has come before.
+					currentChangeSet = changeSet{events: make([]es.Event, 0)}
+					gotMalformedEvent(event, err)
+					break
+				}
+
+				sp.loggers.Errorf("Error on %s: %s", errorData.PayloadID, errorData.Reason)
+
+				currentChangeSet = changeSet{events: make([]es.Event, 0)}
+				//nolint: godox
+				// TODO: Do we need to restart here?
+			case "payload-transferred":
+				currentChangeSet.events = append(currentChangeSet.events, event)
+				updates, err := processChangeset(currentChangeSet)
+				if err != nil {
+					sp.loggers.Errorf("Error processing changeset: %s", err)
+					gotMalformedEvent(nil, err)
+					break
+				}
+				for _, update := range updates {
+					switch u := update.(type) {
+					case datasource.PatchData:
+						if !sp.dataSourceUpdates.Upsert(u.Kind, u.Key, u.Data) {
+							storeUpdateFailed("streaming update of " + u.Key)
+						}
+					case datasource.PutData:
+						if sp.dataSourceUpdates.Init(u.Data) {
+							sp.setInitializedAndNotifyClient(true, closeWhenReady)
+						} else {
+							storeUpdateFailed("initial streaming data")
+						}
+					case datasource.DeleteData:
+						deletedItem := ldstoretypes.ItemDescriptor{Version: u.Version, Item: nil}
+						if !sp.dataSourceUpdates.Upsert(u.Kind, u.Key, deletedItem) {
+							storeUpdateFailed("streaming deletion of " + u.Key)
+						}
+
+					default:
+						sp.loggers.Infof("Unexpected update found in changeset: %s", update)
+					}
+				}
+				currentChangeSet = changeSet{events: make([]es.Event, 0)}
+			default:
+				sp.loggers.Infof("Unexpected event found in stream: %s", event.Event())
+			}
+
+			if processedEvent {
+				sp.dataSourceUpdates.UpdateStatus(interfaces.DataSourceStateValid, interfaces.DataSourceErrorInfo{})
+			}
+			if shouldRestart {
+				stream.Restart()
+			}
+
+		case newStoreStatus := <-sp.storeStatusCh:
+			if sp.loggers.IsDebugEnabled() {
+				sp.loggers.Debugf("StreamProcessorV2 received store status update: %+v", newStoreStatus)
+			}
+			if newStoreStatus.Available {
+				// The store has just transitioned from unavailable to available (scenario 2a above)
+				if newStoreStatus.NeedsRefresh {
+					// The store is telling us that it can't guarantee that all of the latest data was cached.
+					// So we'll restart the stream to ensure a full refresh.
+					sp.loggers.Warn("Restarting stream to refresh data after data store outage")
+					stream.Restart()
+				}
+				// All of the updates were cached and have been written to the store, so we don't need to
+				// restart the stream. We just need to make sure the client knows we're initialized now
+				// (in case the initial "put" was not stored).
+				sp.setInitializedAndNotifyClient(true, closeWhenReady)
+			}
+
+		case <-sp.halt:
+			stream.Close()
+			return
+		}
+	}
+}
+
+func (sp *StreamProcessor) subscribe(closeWhenReady chan<- struct{}) {
+	req, reqErr := http.NewRequest("GET", endpoints.AddPath(sp.cfg.URI, endpoints.StreamingRequestPath), nil)
+	if reqErr != nil {
+		sp.loggers.Errorf(
+			"Unable to create a stream request; this is not a network problem, most likely a bad base URI: %s",
+			reqErr,
+		)
+		sp.dataSourceUpdates.UpdateStatus(interfaces.DataSourceStateOff, interfaces.DataSourceErrorInfo{
+			Kind:    interfaces.DataSourceErrorKindUnknown,
+			Message: reqErr.Error(),
+			Time:    time.Now(),
+		})
+		sp.logConnectionResult(false)
+		close(closeWhenReady)
+		return
+	}
+	if sp.cfg.FilterKey != "" {
+		req.URL.RawQuery = url.Values{
+			"filter": {sp.cfg.FilterKey},
+		}.Encode()
+	}
+	if sp.headers != nil {
+		req.Header = maps.Clone(sp.headers)
+	}
+	sp.loggers.Info("Connecting to LaunchDarkly stream")
+
+	sp.logConnectionStarted()
+
+	initialRetryDelay := sp.cfg.InitialReconnectDelay
+	if initialRetryDelay <= 0 { // COVERAGE: can't cause this condition in unit tests
+		initialRetryDelay = defaultStreamRetryDelay
+	}
+
+	errorHandler := func(err error) es.StreamErrorHandlerResult {
+		sp.logConnectionResult(false)
+
+		if se, ok := err.(es.SubscriptionError); ok {
+			errorInfo := interfaces.DataSourceErrorInfo{
+				Kind:       interfaces.DataSourceErrorKindErrorResponse,
+				StatusCode: se.Code,
+				Time:       time.Now(),
+			}
+			recoverable := checkIfErrorIsRecoverableAndLog(
+				sp.loggers,
+				httpErrorDescription(se.Code),
+				streamingErrorContext,
+				se.Code,
+				streamingWillRetryMessage,
+			)
+			if recoverable {
+				sp.logConnectionStarted()
+				sp.dataSourceUpdates.UpdateStatus(interfaces.DataSourceStateInterrupted, errorInfo)
+				return es.StreamErrorHandlerResult{CloseNow: false}
+			}
+			sp.dataSourceUpdates.UpdateStatus(interfaces.DataSourceStateOff, errorInfo)
+			return es.StreamErrorHandlerResult{CloseNow: true}
+		}
+
+		checkIfErrorIsRecoverableAndLog(
+			sp.loggers,
+			err.Error(),
+			streamingErrorContext,
+			0,
+			streamingWillRetryMessage,
+		)
+		errorInfo := interfaces.DataSourceErrorInfo{
+			Kind:    interfaces.DataSourceErrorKindNetworkError,
+			Message: err.Error(),
+			Time:    time.Now(),
+		}
+		sp.dataSourceUpdates.UpdateStatus(interfaces.DataSourceStateInterrupted, errorInfo)
+		sp.logConnectionStarted()
+		return es.StreamErrorHandlerResult{CloseNow: false}
+	}
+
+	stream, err := es.SubscribeWithRequestAndOptions(req,
+		es.StreamOptionHTTPClient(sp.client),
+		es.StreamOptionReadTimeout(streamReadTimeout),
+		es.StreamOptionInitialRetry(initialRetryDelay),
+		es.StreamOptionUseBackoff(streamMaxRetryDelay),
+		es.StreamOptionUseJitter(streamJitterRatio),
+		es.StreamOptionRetryResetInterval(streamRetryResetInterval),
+		es.StreamOptionErrorHandler(errorHandler),
+		es.StreamOptionCanRetryFirstConnection(-1),
+		es.StreamOptionLogger(sp.loggers.ForLevel(ldlog.Info)),
+	)
+
+	if err != nil {
+		sp.logConnectionResult(false)
+
+		close(closeWhenReady)
+		return
+	}
+
+	sp.consumeStream(stream, closeWhenReady)
+}
+
+func (sp *StreamProcessor) setInitializedAndNotifyClient(success bool, closeWhenReady chan<- struct{}) {
+	if success {
+		wasAlreadyInitialized := sp.isInitialized.GetAndSet(true)
+		if !wasAlreadyInitialized {
+			sp.loggers.Info("LaunchDarkly streaming is active")
+		}
+	}
+	sp.readyOnce.Do(func() {
+		close(closeWhenReady)
+	})
+}
+
+func (sp *StreamProcessor) logConnectionStarted() {
+	sp.connectionAttemptLock.Lock()
+	defer sp.connectionAttemptLock.Unlock()
+	sp.connectionAttemptStartTime = ldtime.UnixMillisNow()
+}
+
+func (sp *StreamProcessor) logConnectionResult(success bool) {
+	sp.connectionAttemptLock.Lock()
+	startTimeWas := sp.connectionAttemptStartTime
+	sp.connectionAttemptStartTime = 0
+	sp.connectionAttemptLock.Unlock()
+
+	if startTimeWas > 0 && sp.diagnosticsManager != nil {
+		timestamp := ldtime.UnixMillisNow()
+		sp.diagnosticsManager.RecordStreamInit(timestamp, !success, uint64(timestamp-startTimeWas))
+	}
+}
+
+//nolint:revive // no doc comment for standard method
+func (sp *StreamProcessor) Close() error {
+	sp.closeOnce.Do(func() {
+		close(sp.halt)
+		if sp.storeStatusCh != nil {
+			sp.dataSourceUpdates.GetDataStoreStatusProvider().RemoveStatusListener(sp.storeStatusCh)
+		}
+		sp.dataSourceUpdates.UpdateStatus(interfaces.DataSourceStateOff, interfaces.DataSourceErrorInfo{})
+	})
+	return nil
+}
+
+// GetBaseURI returns the configured streaming base URI, for testing.
+func (sp *StreamProcessor) GetBaseURI() string {
+	return sp.cfg.URI
+}
+
+// GetInitialReconnectDelay returns the configured reconnect delay, for testing.
+func (sp *StreamProcessor) GetInitialReconnectDelay() time.Duration {
+	return sp.cfg.InitialReconnectDelay
+}
+
+// GetFilterKey returns the configured key, for testing.
+func (sp *StreamProcessor) GetFilterKey() string {
+	return sp.cfg.FilterKey
+}
+
+func processChangeset(changeSet changeSet) ([]any, error) {
+	if changeSet.intent == nil || changeSet.intent.Payloads[0].Code != "xfer-full" {
+		return convertChangesetEventsToPatchData(changeSet.events)
+	}
+
+	return convertChangesetEventsToPutData(changeSet.events)
+}
+
+func convertChangesetEventsToPatchData(events []es.Event) ([]any, error) {
+	updates := make([]interface{}, 0, len(events))
+
+	parseItem := func(r jreader.Reader, kind datakinds.DataKindInternal) (ldstoretypes.ItemDescriptor, error) {
+		item, err := kind.DeserializeFromJSONReader(&r)
+		return item, err
+	}
+
+	for _, event := range events {
+		switch event.Event() {
+		case putEventName:
+			r := jreader.NewReader([]byte(event.Data()))
+			// var version int
+			var dataKind datakinds.DataKindInternal
+			var key string
+			var item ldstoretypes.ItemDescriptor
+			var err error
+
+			for obj := r.Object().WithRequiredProperties([]string{versionField, kindField, keyField, "object"}); obj.Next(); {
+				switch string(obj.Name()) {
+				case versionField:
+					// version = r.Int()
+				case kindField:
+					kind := r.String()
+					dataKind = dataKindFromKind(kind)
+					if dataKind == nil {
+						//nolint: godox
+						// TODO: We are skipping here without showing a warning. Need to address that later.
+						continue
+					}
+				case keyField:
+					key = r.String()
+				case "object":
+					item, err = parseItem(r, dataKind)
+					if err != nil {
+						return updates, err
+					}
+				}
+			}
+
+			patchData := datasource.PatchData{Kind: dataKind, Key: key, Data: item}
+			updates = append(updates, patchData)
+		case deleteEventName:
+			r := jreader.NewReader([]byte(event.Data()))
+			var version int
+			var dataKind datakinds.DataKindInternal
+			var kind, key string
+
+			for obj := r.Object().WithRequiredProperties([]string{versionField, kindField, keyField}); obj.Next(); {
+				switch string(obj.Name()) {
+				case versionField:
+					version = r.Int()
+				case kindField:
+					kind = strings.TrimRight(r.String(), "s")
+					dataKind = dataKindFromKind(kind)
+					if dataKind == nil {
+						//nolint: godox
+						// TODO: We are skipping here without showing a warning. Need to address that later.
+						continue
+					}
+				case keyField:
+					key = r.String()
+				}
+			}
+			patchData := datasource.DeleteData{Kind: dataKind, Key: key, Version: version}
+			updates = append(updates, patchData)
+		}
+	}
+
+	return updates, nil
+}
+
+func convertChangesetEventsToPutData(events []es.Event) ([]any, error) {
+	segmentCollection := ldstoretypes.Collection{
+		Kind:  datakinds.Segments,
+		Items: make([]ldstoretypes.KeyedItemDescriptor, 0)}
+	flagCollection := ldstoretypes.Collection{
+		Kind:  datakinds.Features,
+		Items: make([]ldstoretypes.KeyedItemDescriptor, 0)}
+
+	parseItem := func(r jreader.Reader, kind datakinds.DataKindInternal) (ldstoretypes.ItemDescriptor, error) {
+		item, err := kind.DeserializeFromJSONReader(&r)
+		return item, err
+	}
+
+	for _, event := range events {
+		switch event.Event() {
+		case putEventName:
+			r := jreader.NewReader([]byte(event.Data()))
+			// var version int
+			var kind, key string
+			var item ldstoretypes.ItemDescriptor
+			var err error
+			var dataKind datakinds.DataKindInternal
+
+			for obj := r.Object().WithRequiredProperties([]string{versionField, kindField, "key", "object"}); obj.Next(); {
+				switch string(obj.Name()) {
+				case versionField:
+					// version = r.Int()
+				case kindField:
+					kind = strings.TrimRight(r.String(), "s")
+					dataKind = dataKindFromKind(kind)
+				case "key":
+					key = r.String()
+				case "object":
+					item, err = parseItem(r, dataKind)
+					if err != nil {
+						return []any{}, err
+					}
+				}
+			}
+
+			//nolint: godox
+			// TODO: What is the actual name we should use here?
+			if kind == "flag" {
+				flagCollection.Items = append(flagCollection.Items, ldstoretypes.KeyedItemDescriptor{Key: key, Item: item})
+			} else if kind == "segment" {
+				segmentCollection.Items = append(segmentCollection.Items, ldstoretypes.KeyedItemDescriptor{Key: key, Item: item})
+			}
+		case deleteEventName:
+			// NOTE: We can skip this. We are replacing everything in the
+			// store so who cares if something was deleted. This shouldn't
+			// even occur really.
+		}
+	}
+
+	putData := datasource.PutData{Path: "/", Data: []ldstoretypes.Collection{flagCollection, segmentCollection}}
+
+	return []any{putData}, nil
+}
+
+func dataKindFromKind(kind string) datakinds.DataKindInternal {
+	switch kind {
+	case "flag":
+		return datakinds.Features
+	case "segment":
+		return datakinds.Segments
+	default:
+		return nil
+	}
+}
+
+// vim: foldmethod=marker foldlevel=0


### PR DESCRIPTION
Introduces the new `datasourcev2` package to hold all FDv2 related
functionality.

This package contains a streaming datasource implementation that is
compatible with our current SDK, but pulls data updates from a
FDv2-compatible source.

It does not support any of the other FDv2-specific features like picking
up from a known state. That will be introduced in later work as we
re-shape the datasource integration on a larger scale.
