### PR TITLE
refactor: hide data source configuration behind dataSystem interface

### DIFF
--- a/internal/datastore/data_store_eval_impl.go
+++ b/internal/datastore/data_store_eval_impl.go
@@ -9,13 +9,13 @@ import (
 )
 
 type dataStoreEvaluatorDataProviderImpl struct {
-	store   subsystems.DataStore
+	store   subsystems.ReadOnlyStore
 	loggers ldlog.Loggers
 }
 
 // NewDataStoreEvaluatorDataProviderImpl creates the internal implementation of the adapter that connects
 // the Evaluator (from go-server-sdk-evaluation) with the data store.
-func NewDataStoreEvaluatorDataProviderImpl(store subsystems.DataStore, loggers ldlog.Loggers) ldeval.DataProvider {
+func NewDataStoreEvaluatorDataProviderImpl(store subsystems.ReadOnlyStore, loggers ldlog.Loggers) ldeval.DataProvider {
 	return dataStoreEvaluatorDataProviderImpl{store, loggers}
 }
 

--- a/internal/datasystem/data_availability.go
+++ b/internal/datasystem/data_availability.go
@@ -1,5 +1,6 @@
 package datasystem
 
+// DataAvailability represents the availability of data in the SDK.
 type DataAvailability string
 
 const (

--- a/internal/datasystem/data_availability.go
+++ b/internal/datasystem/data_availability.go
@@ -1,0 +1,12 @@
+package datasystem
+
+type DataAvailability string
+
+const (
+	// Defaults means the SDK has no data and will evaluate flags using the application-provided default values.
+	Defaults = DataAvailability("defaults")
+	// Cached means the SDK has data, not necessarily the latest, which will be used to evaluate flags.
+	Cached = DataAvailability("cached")
+	// Refreshed means the SDK has obtained, at least once, the latest known data from LaunchDarkly.
+	Refreshed = DataAvailability("refreshed")
+)

--- a/internal/datasystem/fdv1_datasystem.go
+++ b/internal/datasystem/fdv1_datasystem.go
@@ -1,0 +1,147 @@
+package datasystem
+
+import (
+	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
+	"github.com/launchdarkly/go-server-sdk/v7/internal"
+	"github.com/launchdarkly/go-server-sdk/v7/internal/datasource"
+	"github.com/launchdarkly/go-server-sdk/v7/internal/datastore"
+	"github.com/launchdarkly/go-server-sdk/v7/ldcomponents"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+)
+
+type FDv1 struct {
+	dataSourceStatusBroadcaster *internal.Broadcaster[interfaces.DataSourceStatus]
+	dataSourceStatusProvider    interfaces.DataSourceStatusProvider
+	dataStoreStatusBroadcaster  *internal.Broadcaster[interfaces.DataStoreStatus]
+	dataStoreStatusProvider     interfaces.DataStoreStatusProvider
+	flagChangeEventBroadcaster  *internal.Broadcaster[interfaces.FlagChangeEvent]
+	dataStore                   subsystems.DataStore
+	dataSource                  subsystems.DataSource
+	offline                     bool
+}
+
+func NewFDv1(offline bool, dataStoreFactory subsystems.ComponentConfigurer[subsystems.DataStore], dataSourceFactory subsystems.ComponentConfigurer[subsystems.DataSource], clientContext *internal.ClientContextImpl) (*FDv1, error) {
+	system := &FDv1{
+		dataSourceStatusBroadcaster: internal.NewBroadcaster[interfaces.DataSourceStatus](),
+		dataStoreStatusBroadcaster:  internal.NewBroadcaster[interfaces.DataStoreStatus](),
+		flagChangeEventBroadcaster:  internal.NewBroadcaster[interfaces.FlagChangeEvent](),
+		offline:                     offline,
+	}
+
+	dataStoreUpdateSink := datastore.NewDataStoreUpdateSinkImpl(system.dataStoreStatusBroadcaster)
+	storeFactory := dataStoreFactory
+	if storeFactory == nil {
+		storeFactory = ldcomponents.InMemoryDataStore()
+	}
+	clientContextWithDataStoreUpdateSink := clientContext
+	clientContextWithDataStoreUpdateSink.DataStoreUpdateSink = dataStoreUpdateSink
+	store, err := storeFactory.Build(clientContextWithDataStoreUpdateSink)
+	if err != nil {
+		return nil, err
+	}
+	system.dataStore = store
+
+	system.dataStoreStatusProvider = datastore.NewDataStoreStatusProviderImpl(store, dataStoreUpdateSink)
+
+	dataSourceUpdateSink := datasource.NewDataSourceUpdateSinkImpl(
+		store,
+		system.dataStoreStatusProvider,
+		system.dataSourceStatusBroadcaster,
+		system.flagChangeEventBroadcaster,
+		clientContext.GetLogging().LogDataSourceOutageAsErrorAfter,
+		clientContext.GetLogging().Loggers,
+	)
+
+	dataSource, err := createDataSource(clientContext, dataSourceFactory, dataSourceUpdateSink)
+	if err != nil {
+		return nil, err
+	}
+	system.dataSource = dataSource
+	system.dataSourceStatusProvider = datasource.NewDataSourceStatusProviderImpl(
+		system.dataSourceStatusBroadcaster,
+		dataSourceUpdateSink,
+	)
+
+	return system, nil
+
+}
+
+func createDataSource(
+	context *internal.ClientContextImpl,
+	dataSourceBuilder subsystems.ComponentConfigurer[subsystems.DataSource],
+	dataSourceUpdateSink subsystems.DataSourceUpdateSink,
+) (subsystems.DataSource, error) {
+	if context.Offline {
+		context.GetLogging().Loggers.Info("Starting LaunchDarkly client in offline mode")
+		dataSourceUpdateSink.UpdateStatus(interfaces.DataSourceStateValid, interfaces.DataSourceErrorInfo{})
+		return datasource.NewNullDataSource(), nil
+	}
+	factory := dataSourceBuilder
+	if factory == nil {
+		// COVERAGE: can't cause this condition in unit tests because it would try to connect to production LD
+		factory = ldcomponents.StreamingDataSource()
+	}
+	contextCopy := *context
+	contextCopy.BasicClientContext.DataSourceUpdateSink = dataSourceUpdateSink
+	return factory.Build(&contextCopy)
+}
+
+func (f *FDv1) DataSourceStatusBroadcaster() *internal.Broadcaster[interfaces.DataSourceStatus] {
+	return f.dataSourceStatusBroadcaster
+}
+
+func (f *FDv1) DataSourceStatusProvider() interfaces.DataSourceStatusProvider {
+	return f.dataSourceStatusProvider
+}
+
+func (f *FDv1) DataStoreStatusBroadcaster() *internal.Broadcaster[interfaces.DataStoreStatus] {
+	return f.dataStoreStatusBroadcaster
+}
+
+func (f *FDv1) DataStoreStatusProvider() interfaces.DataStoreStatusProvider {
+	return f.dataStoreStatusProvider
+}
+
+func (f *FDv1) FlagChangeEventBroadcaster() *internal.Broadcaster[interfaces.FlagChangeEvent] {
+	return f.flagChangeEventBroadcaster
+}
+
+func (f *FDv1) Start(closeWhenReady chan struct{}) {
+	f.dataSource.Start(closeWhenReady)
+}
+
+func (f *FDv1) Stop() error {
+	if f.dataSource != nil {
+		_ = f.dataSource.Close()
+	}
+	if f.dataStore != nil {
+		_ = f.dataStore.Close()
+	}
+	if f.dataSourceStatusBroadcaster != nil {
+		f.dataSourceStatusBroadcaster.Close()
+	}
+	if f.dataStoreStatusBroadcaster != nil {
+		f.dataStoreStatusBroadcaster.Close()
+	}
+	if f.flagChangeEventBroadcaster != nil {
+		f.flagChangeEventBroadcaster.Close()
+	}
+	return nil
+}
+
+func (f *FDv1) DataAvailability() DataAvailability {
+	if f.offline {
+		return Defaults
+	}
+	if f.dataSource.IsInitialized() {
+		return Refreshed
+	}
+	if f.dataStore.IsInitialized() {
+		return Cached
+	}
+	return Defaults
+}
+
+func (f *FDv1) Store() subsystems.ReadOnlyStore {
+	return f.dataStore
+}

--- a/internal/datasystem/fdv1_datasystem.go
+++ b/internal/datasystem/fdv1_datasystem.go
@@ -9,6 +9,8 @@ import (
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
 )
 
+// FDv1 implements the configuration and interactions between the SDK's data store, data source, and
+// other related components.
 type FDv1 struct {
 	dataSourceStatusBroadcaster *internal.Broadcaster[interfaces.DataSourceStatus]
 	dataSourceStatusProvider    interfaces.DataSourceStatusProvider
@@ -20,7 +22,11 @@ type FDv1 struct {
 	offline                     bool
 }
 
-func NewFDv1(offline bool, dataStoreFactory subsystems.ComponentConfigurer[subsystems.DataStore], dataSourceFactory subsystems.ComponentConfigurer[subsystems.DataSource], clientContext *internal.ClientContextImpl) (*FDv1, error) {
+// NewFDv1 creates a new FDv1 instance from data store and data source configurers. Offline determines if the
+// client is in offline mode. If configuration is invalid, an error will be returned.
+func NewFDv1(offline bool, dataStoreFactory subsystems.ComponentConfigurer[subsystems.DataStore],
+	dataSourceFactory subsystems.ComponentConfigurer[subsystems.DataSource],
+	clientContext *internal.ClientContextImpl) (*FDv1, error) {
 	system := &FDv1{
 		dataSourceStatusBroadcaster: internal.NewBroadcaster[interfaces.DataSourceStatus](),
 		dataStoreStatusBroadcaster:  internal.NewBroadcaster[interfaces.DataStoreStatus](),
@@ -63,7 +69,6 @@ func NewFDv1(offline bool, dataStoreFactory subsystems.ComponentConfigurer[subsy
 	)
 
 	return system, nil
-
 }
 
 func createDataSource(
@@ -86,30 +91,37 @@ func createDataSource(
 	return factory.Build(&contextCopy)
 }
 
+//nolint:revive // Data system implementation.
 func (f *FDv1) DataSourceStatusBroadcaster() *internal.Broadcaster[interfaces.DataSourceStatus] {
 	return f.dataSourceStatusBroadcaster
 }
 
+//nolint:revive // Data system implementation.
 func (f *FDv1) DataSourceStatusProvider() interfaces.DataSourceStatusProvider {
 	return f.dataSourceStatusProvider
 }
 
+//nolint:revive // Data system implementation.
 func (f *FDv1) DataStoreStatusBroadcaster() *internal.Broadcaster[interfaces.DataStoreStatus] {
 	return f.dataStoreStatusBroadcaster
 }
 
+//nolint:revive // Data system implementation.
 func (f *FDv1) DataStoreStatusProvider() interfaces.DataStoreStatusProvider {
 	return f.dataStoreStatusProvider
 }
 
+//nolint:revive // Data system implementation.
 func (f *FDv1) FlagChangeEventBroadcaster() *internal.Broadcaster[interfaces.FlagChangeEvent] {
 	return f.flagChangeEventBroadcaster
 }
 
+//nolint:revive // Data system implementation.
 func (f *FDv1) Start(closeWhenReady chan struct{}) {
 	f.dataSource.Start(closeWhenReady)
 }
 
+//nolint:revive // Data system implementation.
 func (f *FDv1) Stop() error {
 	if f.dataSource != nil {
 		_ = f.dataSource.Close()
@@ -129,6 +141,7 @@ func (f *FDv1) Stop() error {
 	return nil
 }
 
+//nolint:revive // Data system implementation.
 func (f *FDv1) DataAvailability() DataAvailability {
 	if f.offline {
 		return Defaults
@@ -142,6 +155,7 @@ func (f *FDv1) DataAvailability() DataAvailability {
 	return Defaults
 }
 
+//nolint:revive // Data system implementation.
 func (f *FDv1) Store() subsystems.ReadOnlyStore {
 	return f.dataStore
 }

--- a/internal/datasystem/package.go
+++ b/internal/datasystem/package.go
@@ -1,0 +1,5 @@
+// Package datasystem encapsulates the interactions between the SDK's data store, data source, and other related
+// components.
+// Currently, there is only one data system implementation, FDv1, which represents the functionality of the SDK
+// before the FDv2 protocol was introduced.
+package datasystem

--- a/ldclient.go
+++ b/ldclient.go
@@ -67,8 +67,8 @@ const (
 	migrationVarExFuncName = "LDClient.MigrationVariationCtx"
 )
 
-// The dataSystem interface represents the requirements for the client to retrieve data necessary
-// for evaluations, as well as the related status updates related to the data.
+// dataSystem represents the requirements the client has for storing/retrieving/detecting changes related
+// to the SDK's data model.
 type dataSystem interface {
 	DataSourceStatusBroadcaster() *internal.Broadcaster[interfaces.DataSourceStatus]
 	DataSourceStatusProvider() interfaces.DataSourceStatusProvider
@@ -79,11 +79,14 @@ type dataSystem interface {
 	// Start starts the data system; the given channel will be closed when the system has reached an initial state
 	// (either permanently failed, e.g. due to bad auth, or succeeded, where Initialized() == true).
 	Start(closeWhenReady chan struct{})
-	// Stop halts the data system. Should be called when the client is closed to stop any long running operations.
+
+	// Stop halts the data system. Should be called when the client is closed to stop any long-running operations.
 	Stop() error
 
+	// Store returns a read-only accessor for the data model.
 	Store() subsystems.ReadOnlyStore
 
+	// DataAvailability indicates what form of data is available.
 	DataAvailability() datasystem.DataAvailability
 }
 
@@ -279,7 +282,6 @@ func MakeCustomClient(sdkKey string, config Config, waitFor time.Duration) (*LDC
 		)
 	}
 
-	// TODO: We can't actually pass STore() here because it wont' swap between the active ones.
 	dataProvider := ldstoreimpl.NewDataStoreEvaluatorDataProvider(client.dataSystem.Store(), loggers)
 	evalOptions := []ldeval.EvaluatorOption{
 		ldeval.EvaluatorOptionErrorLogger(client.loggers.ForLevel(ldlog.Error)),

--- a/ldclient_test.go
+++ b/ldclient_test.go
@@ -100,8 +100,8 @@ func makeTestClientWithConfigAndStore(modConfig func(*Config), populate func(sto
 	return client
 }
 
-// populateStore (which is a function) is defined here a type so that we can implement the ComponentConfigurer interface
-// on it. That way, when the SDK configures the data store, we can hook in additional logic to populate the store
+// The populateStore type exist so that we can implement the ComponentConfigurer interface
+// on it. When the SDK configures the data store, we can hook in additional logic to populate the store
 // via the callback provided in makeTestClientWithConfigAndStore.
 type populateStore func(store subsystems.DataStore)
 

--- a/ldclient_test.go
+++ b/ldclient_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/launchdarkly/go-server-sdk/v7/internal/datastore"
+
 	"github.com/launchdarkly/go-server-sdk/v7/internal/sharedtest/mocks"
 
 	"github.com/launchdarkly/go-sdk-common/v3/lduser"
@@ -77,9 +79,16 @@ func makeTestClient() *LDClient {
 }
 
 func makeTestClientWithConfig(modConfig func(*Config)) *LDClient {
+	return makeTestClientWithConfigAndStore(modConfig, func(store subsystems.DataStore) {})
+}
+
+// makeTestClientWithConfigAndStore is a variant of makeTestClientWithConfig, which allows you to also pre-populate the
+// client's in-memory data store with some test data. The second argument is a callback that provides you access to the
+// store; then you can call Upsert/Init to inject data.
+func makeTestClientWithConfigAndStore(modConfig func(*Config), populate func(store subsystems.DataStore)) *LDClient {
 	config := Config{
 		Offline:    false,
-		DataStore:  ldcomponents.InMemoryDataStore(),
+		DataStore:  populateStore(populate),
 		DataSource: mocks.DataSourceThatIsAlwaysInitialized(),
 		Events:     mocks.SingleComponentConfigurer[ldevents.EventProcessor]{Instance: &mocks.CapturingEventProcessor{}},
 		Logging:    ldcomponents.Logging().Loggers(sharedtest.NewTestLoggers()),
@@ -89,4 +98,15 @@ func makeTestClientWithConfig(modConfig func(*Config)) *LDClient {
 	}
 	client, _ := MakeCustomClient(testSdkKey, config, time.Duration(0))
 	return client
+}
+
+// populateStore (which is a function) is defined here a type so that we can implement the ComponentConfigurer interface
+// on it. That way, when the SDK configures the data store, we can hook in additional logic to populate the store
+// via the callback provided in makeTestClientWithConfigAndStore.
+type populateStore func(store subsystems.DataStore)
+
+func (populate populateStore) Build(context subsystems.ClientContext) (subsystems.DataStore, error) {
+	inMemory := datastore.NewInMemoryDataStore(context.GetLogging().Loggers)
+	populate(inMemory)
+	return inMemory, nil
 }

--- a/subsystems/data_store.go
+++ b/subsystems/data_store.go
@@ -15,6 +15,8 @@ import (
 type DataStore interface {
 	io.Closer
 
+	ReadOnlyStore
+
 	// Init overwrites the store's contents with a set of items for each collection.
 	//
 	// All previous data should be discarded, regardless of versioning.
@@ -23,21 +25,6 @@ type DataStore interface {
 	// must first add or update each item in the same order that they are given in the input
 	// data, and then delete any previously stored items that were not in the input data.
 	Init(allData []ldstoretypes.Collection) error
-
-	// Get retrieves an item from the specified collection, if available.
-	//
-	// If the specified key does not exist in the collection, it should return an ItemDescriptor
-	// whose Version is -1.
-	//
-	// If the item has been deleted and the store contains a placeholder, it should return an
-	// ItemDescriptor whose Version is the version of the placeholder, and whose Item is nil.
-	Get(kind ldstoretypes.DataKind, key string) (ldstoretypes.ItemDescriptor, error)
-
-	// GetAll retrieves all items from the specified collection.
-	//
-	// If the store contains placeholders for deleted items, it should include them in the results,
-	// not filter them out.
-	GetAll(kind ldstoretypes.DataKind) ([]ldstoretypes.KeyedItemDescriptor, error)
 
 	// Upsert updates or inserts an item in the specified collection. For updates, the object will only be
 	// updated if the existing version is less than the new version.
@@ -49,16 +36,6 @@ type DataStore interface {
 	// The method returns true if the item was updated, or false if it was not updated because the store
 	// contains an equal or greater version.
 	Upsert(kind ldstoretypes.DataKind, key string, item ldstoretypes.ItemDescriptor) (bool, error)
-
-	// IsInitialized returns true if the data store contains a data set, meaning that Init has been
-	// called at least once.
-	//
-	// In a shared data store, it should be able to detect this even if Init was called in a
-	// different process: that is, the test should be based on looking at what is in the data store.
-	// Once this has been determined to be true, it can continue to return true without having to
-	// check the store again; this method should be as fast as possible since it may be called during
-	// feature flag evaluations.
-	IsInitialized() bool
 
 	// IsStatusMonitoringEnabled returns true if this data store implementation supports status
 	// monitoring.

--- a/subsystems/ldstoreimpl/data_store_eval.go
+++ b/subsystems/ldstoreimpl/data_store_eval.go
@@ -16,6 +16,6 @@ import (
 //
 // Normal use of the SDK does not require this type. It is provided for use by other LaunchDarkly
 // components that use DataStore and Evaluator separately from the SDK.
-func NewDataStoreEvaluatorDataProvider(store subsystems.DataStore, loggers ldlog.Loggers) ldeval.DataProvider {
+func NewDataStoreEvaluatorDataProvider(store subsystems.ReadOnlyStore, loggers ldlog.Loggers) ldeval.DataProvider {
 	return datastore.NewDataStoreEvaluatorDataProviderImpl(store, loggers)
 }

--- a/subsystems/read_only_store.go
+++ b/subsystems/read_only_store.go
@@ -1,0 +1,30 @@
+package subsystems
+
+import "github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
+
+type ReadOnlyStore interface {
+	// Get retrieves an item from the specified collection, if available.
+	//
+	// If the specified key does not exist in the collection, it should return an ItemDescriptor
+	// whose Version is -1.
+	//
+	// If the item has been deleted and the store contains a placeholder, it should return an
+	// ItemDescriptor whose Version is the version of the placeholder, and whose Item is nil.
+	Get(kind ldstoretypes.DataKind, key string) (ldstoretypes.ItemDescriptor, error)
+
+	// GetAll retrieves all items from the specified collection.
+	//
+	// If the store contains placeholders for deleted items, it should include them in the results,
+	// not filter them out.
+	GetAll(kind ldstoretypes.DataKind) ([]ldstoretypes.KeyedItemDescriptor, error)
+
+	// IsInitialized returns true if the data store contains a data set, meaning that Init has been
+	// called at least once.
+	//
+	// In a shared data store, it should be able to detect this even if Init was called in a
+	// different process: that is, the test should be based on looking at what is in the data store.
+	// Once this has been determined to be true, it can continue to return true without having to
+	// check the store again; this method should be as fast as possible since it may be called during
+	// feature flag evaluations.
+	IsInitialized() bool
+}

--- a/subsystems/read_only_store.go
+++ b/subsystems/read_only_store.go
@@ -2,6 +2,8 @@ package subsystems
 
 import "github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
 
+// ReadOnlyStore represents a read-only data store that can be used to retrieve
+// any of the SDK's supported DataKinds.
 type ReadOnlyStore interface {
 	// Get retrieves an item from the specified collection, if available.
 	//


### PR DESCRIPTION
This change defines a new `dataSystem` interface, used internally by `LDClient` to implement all functionality related to data store and data source interactions.

The purpose is to be able to swap out the implementation with one suited for FDv2 in a future PR. 