### PR TITLE
refactor: streaming/polling processors take DataDestination/StatusReporter interfaces

### DIFF
--- a/internal/sharedtest/mocks/mock_data_destination.go
+++ b/internal/sharedtest/mocks/mock_data_destination.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// MockDataDestination is a mock implementation of a data destination used tests involving FDv2 data sources.
+// MockDataDestination is a mock implementation of a data destination used by tests involving FDv2 data sources.
 type MockDataDestination struct {
 	DataStore               *CapturingDataStore
 	Statuses                chan interfaces.DataSourceStatus

--- a/internal/sharedtest/mocks/mock_data_destination.go
+++ b/internal/sharedtest/mocks/mock_data_destination.go
@@ -1,0 +1,104 @@
+package mocks
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
+
+	th "github.com/launchdarkly/go-test-helpers/v3"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// MockDataDestination is a mock implementation of a data destination used tests involving FDv2 data sources.
+type MockDataDestination struct {
+	DataStore               *CapturingDataStore
+	Statuses                chan interfaces.DataSourceStatus
+	dataStoreStatusProvider *mockDataStoreStatusProvider
+	lastStatus              interfaces.DataSourceStatus
+	lock                    sync.Mutex
+}
+
+// NewMockDataDestination creates an instance of MockDataDestination.
+//
+// The DataStoreStatusProvider can be nil if we are not doing a test that requires manipulation of that
+// component.
+func NewMockDataDestination(realStore subsystems.DataStore) *MockDataDestination {
+	dataStore := NewCapturingDataStore(realStore)
+	dataStoreStatusProvider := &mockDataStoreStatusProvider{
+		dataStore: dataStore,
+		status:    interfaces.DataStoreStatus{Available: true},
+		statusCh:  make(chan interfaces.DataStoreStatus, 10),
+	}
+	return &MockDataDestination{
+		DataStore:               dataStore,
+		Statuses:                make(chan interfaces.DataSourceStatus, 10),
+		dataStoreStatusProvider: dataStoreStatusProvider,
+	}
+}
+
+// Init in this test implementation, delegates to d.DataStore.CapturedUpdates.
+func (d *MockDataDestination) Init(allData []ldstoretypes.Collection, _ *int) bool {
+	// For now, the payloadVersion is ignored. When the data sources start making use of it, it should be
+	// stored so that assertions can be made.
+	for _, coll := range allData {
+		AssertNotNil(coll.Kind)
+	}
+	err := d.DataStore.Init(allData)
+	return err == nil
+}
+
+// Upsert in this test implementation, delegates to d.DataStore.CapturedUpdates.
+func (d *MockDataDestination) Upsert(
+	kind ldstoretypes.DataKind,
+	key string,
+	newItem ldstoretypes.ItemDescriptor,
+) bool {
+	AssertNotNil(kind)
+	_, err := d.DataStore.Upsert(kind, key, newItem)
+	return err == nil
+}
+
+// UpdateStatus in this test implementation, pushes a value onto the Statuses channel.
+func (d *MockDataDestination) UpdateStatus(
+	newState interfaces.DataSourceState,
+	newError interfaces.DataSourceErrorInfo,
+) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	if newState != d.lastStatus.State || newError.Kind != "" {
+		d.lastStatus = interfaces.DataSourceStatus{State: newState, LastError: newError}
+		d.Statuses <- d.lastStatus
+	}
+}
+
+// GetDataStoreStatusProvider returns a stub implementation that does not have full functionality
+// but enough to test a data source with.
+func (d *MockDataDestination) GetDataStoreStatusProvider() interfaces.DataStoreStatusProvider {
+	return d.dataStoreStatusProvider
+}
+
+// UpdateStoreStatus simulates a change in the data store status.
+func (d *MockDataDestination) UpdateStoreStatus(newStatus interfaces.DataStoreStatus) {
+	d.dataStoreStatusProvider.statusCh <- newStatus
+}
+
+// RequireStatusOf blocks until a new data source status is available, and verifies its state.
+func (d *MockDataDestination) RequireStatusOf(
+	t *testing.T,
+	newState interfaces.DataSourceState,
+) interfaces.DataSourceStatus {
+	status := d.RequireStatus(t)
+	assert.Equal(t, string(newState), string(status.State))
+	// string conversion is due to a bug in assert with type aliases
+	return status
+}
+
+// RequireStatus blocks until a new data source status is available.
+func (d *MockDataDestination) RequireStatus(t *testing.T) interfaces.DataSourceStatus {
+	return th.RequireValue(t, d.Statuses, time.Second, "timed out waiting for new data source status")
+}

--- a/internal/sharedtest/mocks/mock_status_reporter.go
+++ b/internal/sharedtest/mocks/mock_status_reporter.go
@@ -1,0 +1,58 @@
+package mocks
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
+	th "github.com/launchdarkly/go-test-helpers/v3"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// MockStatusReporter is a mock implementation of DataSourceUpdates for testing data sources.
+type MockStatusReporter struct {
+	Statuses   chan interfaces.DataSourceStatus
+	lastStatus interfaces.DataSourceStatus
+	lock       sync.Mutex
+}
+
+// NewMockStatusReporter creates an instance of MockStatusReporter.
+//
+// The DataStoreStatusProvider can be nil if we are not doing a test that requires manipulation of that
+// component.
+func NewMockStatusReporter() *MockStatusReporter {
+	return &MockStatusReporter{
+		Statuses: make(chan interfaces.DataSourceStatus, 10),
+	}
+}
+
+// UpdateStatus in this test implementation, pushes a value onto the Statuses channel.
+func (d *MockStatusReporter) UpdateStatus(
+	newState interfaces.DataSourceState,
+	newError interfaces.DataSourceErrorInfo,
+) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	if newState != d.lastStatus.State || newError.Kind != "" {
+		d.lastStatus = interfaces.DataSourceStatus{State: newState, LastError: newError}
+		d.Statuses <- d.lastStatus
+	}
+}
+
+// RequireStatusOf blocks until a new data source status is available, and verifies its state.
+func (d *MockStatusReporter) RequireStatusOf(
+	t *testing.T,
+	newState interfaces.DataSourceState,
+) interfaces.DataSourceStatus {
+	status := d.RequireStatus(t)
+	assert.Equal(t, string(newState), string(status.State))
+	// string conversion is due to a bug in assert with type aliases
+	return status
+}
+
+// RequireStatus blocks until a new data source status is available.
+func (d *MockStatusReporter) RequireStatus(t *testing.T) interfaces.DataSourceStatus {
+	return th.RequireValue(t, d.Statuses, time.Second, "timed out waiting for new data source status")
+}

--- a/ldcomponents/polling_data_source_builder_v2.go
+++ b/ldcomponents/polling_data_source_builder_v2.go
@@ -93,7 +93,8 @@ func (b *PollingDataSourceBuilderV2) Build(context subsystems.ClientContext) (su
 		PollInterval: b.pollInterval,
 		FilterKey:    filterKey,
 	}
-	return datasourcev2.NewPollingProcessor(context, context.GetDataSourceUpdateSink(), cfg), nil
+	return datasourcev2.NewPollingProcessor(context, context.GetDataDestination(),
+		context.GetDataSourceStatusReporter(), cfg), nil
 }
 
 // DescribeConfiguration is used internally by the SDK to inspect the configuration.

--- a/ldcomponents/polling_data_source_builder_v2_test.go
+++ b/ldcomponents/polling_data_source_builder_v2_test.go
@@ -59,9 +59,11 @@ func TestPollingDataSourceV2Builder(t *testing.T) {
 
 		p := PollingDataSourceV2()
 
-		dsu := mocks.NewMockDataSourceUpdates(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
+		dd := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
+		statusReporter := mocks.NewMockStatusReporter()
 		clientContext := makeTestContextWithBaseURIs(baseURI)
-		clientContext.BasicClientContext.DataSourceUpdateSink = dsu
+		clientContext.BasicClientContext.DataDestination = dd
+		clientContext.BasicClientContext.DataSourceStatusReporter = statusReporter
 		ds, err := p.Build(clientContext)
 		require.NoError(t, err)
 		require.NotNil(t, ds)
@@ -79,9 +81,11 @@ func TestPollingDataSourceV2Builder(t *testing.T) {
 
 		p := PollingDataSourceV2().PollInterval(interval).PayloadFilter(filter)
 
-		dsu := mocks.NewMockDataSourceUpdates(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
+		dd := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
+		statusReporter := mocks.NewMockStatusReporter()
 		clientContext := makeTestContextWithBaseURIs(baseURI)
-		clientContext.BasicClientContext.DataSourceUpdateSink = dsu
+		clientContext.BasicClientContext.DataDestination = dd
+		clientContext.BasicClientContext.DataSourceStatusReporter = statusReporter
 		ds, err := p.Build(clientContext)
 		require.NoError(t, err)
 		require.NotNil(t, ds)

--- a/ldcomponents/streaming_data_source_builder_v2.go
+++ b/ldcomponents/streaming_data_source_builder_v2.go
@@ -88,7 +88,8 @@ func (b *StreamingDataSourceBuilderV2) Build(context subsystems.ClientContext) (
 	}
 	return datasourcev2.NewStreamProcessor(
 		context,
-		context.GetDataSourceUpdateSink(),
+		context.GetDataDestination(),
+		context.GetDataSourceStatusReporter(),
 		cfg,
 	), nil
 }

--- a/ldcomponents/streaming_data_source_builder_v2_test.go
+++ b/ldcomponents/streaming_data_source_builder_v2_test.go
@@ -60,9 +60,11 @@ func TestStreamingDataSourceV2Builder(t *testing.T) {
 
 		s := StreamingDataSourceV2()
 
-		dsu := mocks.NewMockDataSourceUpdates(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
+		dsu := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
+		statusReporter := mocks.NewMockStatusReporter()
 		clientContext := makeTestContextWithBaseURIs(baseURI)
-		clientContext.BasicClientContext.DataSourceUpdateSink = dsu
+		clientContext.BasicClientContext.DataDestination = dsu
+		clientContext.BasicClientContext.DataSourceStatusReporter = statusReporter
 		ds, err := s.Build(clientContext)
 		require.NoError(t, err)
 		require.NotNil(t, ds)
@@ -81,9 +83,11 @@ func TestStreamingDataSourceV2Builder(t *testing.T) {
 
 		s := StreamingDataSourceV2().InitialReconnectDelay(delay).PayloadFilter(filter)
 
-		dsu := mocks.NewMockDataSourceUpdates(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
+		dsu := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
+		statusReporter := mocks.NewMockStatusReporter()
 		clientContext := makeTestContextWithBaseURIs(baseURI)
-		clientContext.BasicClientContext.DataSourceUpdateSink = dsu
+		clientContext.BasicClientContext.DataDestination = dsu
+		clientContext.BasicClientContext.DataSourceStatusReporter = statusReporter
 		ds, err := s.Build(clientContext)
 		require.NoError(t, err)
 		require.NotNil(t, ds)

--- a/ldcomponents/streaming_data_source_builder_v2_test.go
+++ b/ldcomponents/streaming_data_source_builder_v2_test.go
@@ -60,10 +60,10 @@ func TestStreamingDataSourceV2Builder(t *testing.T) {
 
 		s := StreamingDataSourceV2()
 
-		dsu := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
+		dd := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
 		statusReporter := mocks.NewMockStatusReporter()
 		clientContext := makeTestContextWithBaseURIs(baseURI)
-		clientContext.BasicClientContext.DataDestination = dsu
+		clientContext.BasicClientContext.DataDestination = dd
 		clientContext.BasicClientContext.DataSourceStatusReporter = statusReporter
 		ds, err := s.Build(clientContext)
 		require.NoError(t, err)
@@ -83,10 +83,10 @@ func TestStreamingDataSourceV2Builder(t *testing.T) {
 
 		s := StreamingDataSourceV2().InitialReconnectDelay(delay).PayloadFilter(filter)
 
-		dsu := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
+		dd := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
 		statusReporter := mocks.NewMockStatusReporter()
 		clientContext := makeTestContextWithBaseURIs(baseURI)
-		clientContext.BasicClientContext.DataDestination = dsu
+		clientContext.BasicClientContext.DataDestination = dd
 		clientContext.BasicClientContext.DataSourceStatusReporter = statusReporter
 		ds, err := s.Build(clientContext)
 		require.NoError(t, err)

--- a/subsystems/client_context.go
+++ b/subsystems/client_context.go
@@ -45,19 +45,29 @@ type ClientContext interface {
 	// This component is only available when the SDK is creating a DataStore. Otherwise the method
 	// returns nil.
 	GetDataStoreUpdateSink() DataStoreUpdateSink
+
+	// GetDataDestination is a FDV2 method, do not use. Not subject to semantic versioning.
+	// This method is a replacement for GetDataSourceUpdateSink when the SDK is in FDv2 mode.
+	GetDataDestination() DataDestination
+
+	// GetDataSourceStatusReporter is a FDV2 method, do not use. Not subject to semantic versioning.
+	// This method is a replacement for GetDataSourceUpdateSink when the SDK is in FDv2 mode.
+	GetDataSourceStatusReporter() DataSourceStatusReporter
 }
 
 // BasicClientContext is the basic implementation of the ClientContext interface, not including any
 // private fields that the SDK may use for implementation details.
 type BasicClientContext struct {
-	SDKKey               string
-	ApplicationInfo      interfaces.ApplicationInfo
-	HTTP                 HTTPConfiguration
-	Logging              LoggingConfiguration
-	Offline              bool
-	ServiceEndpoints     interfaces.ServiceEndpoints
-	DataSourceUpdateSink DataSourceUpdateSink
-	DataStoreUpdateSink  DataStoreUpdateSink
+	SDKKey                   string
+	ApplicationInfo          interfaces.ApplicationInfo
+	HTTP                     HTTPConfiguration
+	Logging                  LoggingConfiguration
+	Offline                  bool
+	ServiceEndpoints         interfaces.ServiceEndpoints
+	DataSourceUpdateSink     DataSourceUpdateSink
+	DataStoreUpdateSink      DataStoreUpdateSink
+	DataDestination          DataDestination
+	DataSourceStatusReporter DataSourceStatusReporter
 }
 
 func (b BasicClientContext) GetSDKKey() string { return b.SDKKey } //nolint:revive
@@ -89,4 +99,12 @@ func (b BasicClientContext) GetDataSourceUpdateSink() DataSourceUpdateSink { //n
 
 func (b BasicClientContext) GetDataStoreUpdateSink() DataStoreUpdateSink { //nolint:revive
 	return b.DataStoreUpdateSink
+}
+
+func (b BasicClientContext) GetDataDestination() DataDestination { //nolint:revive
+	return b.DataDestination
+}
+
+func (b BasicClientContext) GetDataSourceStatusReporter() DataSourceStatusReporter { //nolint:revive
+	return b.DataSourceStatusReporter
 }

--- a/subsystems/data_destination.go
+++ b/subsystems/data_destination.go
@@ -1,0 +1,34 @@
+package subsystems
+
+import (
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
+)
+
+// DataDestination represents a sink for data obtained from a data source.
+// This interface is not stable, and not subject to any backwards
+// compatibility guarantees or semantic versioning. It is not suitable for production usage.
+//
+// Do not use it.
+// You have been warned.
+type DataDestination interface {
+	// Init overwrites the current contents of the data store with a set of items for each collection.
+	//
+	// If the underlying data store returns an error during this operation, the SDK will log it,
+	// and set the data source state to DataSourceStateInterrupted with an error of
+	// DataSourceErrorKindStoreError. It will not return the error to the data source, but will
+	// return false to indicate that the operation failed.
+	Init(allData []ldstoretypes.Collection, payloadVersion *int) bool
+
+	// Upsert updates or inserts an item in the specified collection. For updates, the object will only be
+	// updated if the existing version is less than the new version.
+	//
+	// To mark an item as deleted, pass an ItemDescriptor with a nil Item and a nonzero version
+	// number. Deletions must be versioned so that they do not overwrite a later update in case updates
+	// are received out of order.
+	//
+	// If the underlying data store returns an error during this operation, the SDK will log it,
+	// and set the data source state to DataSourceStateInterrupted with an error of
+	// DataSourceErrorKindStoreError. It will not return the error to the data source, but will
+	// return false to indicate that the operation failed.
+	Upsert(kind ldstoretypes.DataKind, key string, item ldstoretypes.ItemDescriptor) bool
+}

--- a/subsystems/data_source_status_reporter.go
+++ b/subsystems/data_source_status_reporter.go
@@ -1,0 +1,29 @@
+package subsystems
+
+import (
+	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
+)
+
+// DataSourceStatusReporter allows a data source to report its status to the SDK.
+//
+// This interface is not stable, and not subject to any backwards
+// compatibility guarantees or semantic versioning. It is not suitable for production usage.
+//
+// Do not use it.
+// You have been warned.
+type DataSourceStatusReporter interface {
+	// UpdateStatus informs the SDK of a change in the data source's status.
+	//
+	// Data source implementations should use this method if they have any concept of being in a valid
+	// state, a temporarily disconnected state, or a permanently stopped state.
+	//
+	// If newState is different from the previous state, and/or newError is non-empty, the SDK
+	// will start returning the new status (adding a timestamp for the change) from
+	// DataSourceStatusProvider.GetStatus(), and will trigger status change events to any
+	// registered listeners.
+	//
+	// A special case is that if newState is DataSourceStateInterrupted, but the previous state was
+	// but the previous state was DataSourceStateInitializing, the state will remain at Initializing
+	// because Interrupted is only meaningful after a successful startup.
+	UpdateStatus(newState interfaces.DataSourceState, newError interfaces.DataSourceErrorInfo)
+}

--- a/subsystems/data_source_status_reporter.go
+++ b/subsystems/data_source_status_reporter.go
@@ -23,7 +23,7 @@ type DataSourceStatusReporter interface {
 	// registered listeners.
 	//
 	// A special case is that if newState is DataSourceStateInterrupted, but the previous state was
-	// but the previous state was DataSourceStateInitializing, the state will remain at Initializing
-	// because Interrupted is only meaningful after a successful startup.
+	// DataSourceStateInitializing, the state will remain at Initializing because Interrupted is
+	// only meaningful after a successful startup.
 	UpdateStatus(newState interfaces.DataSourceState, newError interfaces.DataSourceErrorInfo)
 }


### PR DESCRIPTION
This change splits up the monolithic `DataSourceUpdateSink` into two:
1. `DataDestination`: where data goes
2. `StatusReporter`: where statuses go

This makes it easier to mock them for testing, and also represents a cleaner separation of concerns. Finally, these interfaces are slightly different than the `DataSourceUpdateSink` for FDV1 vs FDV2. 

In the new system, we want to be able to do things like passing a payload version in `Init`. 

I've added doc comments that these interfaces are not stable, since they are public. 