### PR TITLE
ci: remove megacheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,7 +22,6 @@ linters:
     - govet
     - ineffassign
     - lll
-    - megacheck
     - misspell
     - nakedret
     - nolintlint


### PR DESCRIPTION
It is deprecated and replaced with other linters we are already using.