### PR TITLE
refactor: insert items into fdv2 store in dependency order

### DIFF
--- a/internal/datasystem/store.go
+++ b/internal/datasystem/store.go
@@ -1,6 +1,7 @@
 package datasystem
 
 import (
+	"github.com/launchdarkly/go-server-sdk/v7/internal/toposort"
 	"sync"
 
 	"github.com/launchdarkly/go-server-sdk/v7/internal/memorystorev2"
@@ -164,9 +165,8 @@ func (s *Store) SetBasis(events []fdv2proto.Event, selector *fdv2proto.Selector,
 
 	if s.shouldPersist() {
 		//nolint:godox
-		// TODO(SDK-711): We need to sort the data in dependency order before inserting it.
-		// Also handle the error.
-		_ = s.persistentStore.impl.Init(collections)
+		// TODO: figure out where to handle/report the error.
+		_ = s.persistentStore.impl.Init(toposort.Sort(collections))
 	}
 }
 
@@ -194,9 +194,8 @@ func (s *Store) ApplyDelta(events []fdv2proto.Event, selector *fdv2proto.Selecto
 	// in the future.
 	if s.shouldPersist() {
 		//nolint:godox
-		// TODO(SDK-711): We need to sort the data in dependency order before inserting it.
-		// Also handle any upsert error.
-		for _, coll := range collections {
+		// TODO: figure out where to handle/report the error.
+		for _, coll := range toposort.Sort(collections) {
 			for _, item := range coll.Items {
 				_, err := s.persistentStore.impl.Upsert(coll.Kind, item.Key, item.Item)
 				if err != nil {

--- a/internal/sharedtest/mocks/mock_data_destination.go
+++ b/internal/sharedtest/mocks/mock_data_destination.go
@@ -1,6 +1,7 @@
 package mocks
 
 import (
+	"github.com/launchdarkly/go-server-sdk/v7/internal/toposort"
 	"sync"
 	"testing"
 	"time"
@@ -51,7 +52,7 @@ func (d *MockDataDestination) SetBasis(events []fdv2proto.Event, _ *fdv2proto.Se
 	for _, coll := range collections {
 		AssertNotNil(coll.Kind)
 	}
-	_ = d.DataStore.Init(collections)
+	_ = d.DataStore.Init(toposort.Sort(collections))
 }
 
 // ApplyDelta in this test implementation, delegates to d.DataStore.CapturedUpdates.
@@ -65,7 +66,7 @@ func (d *MockDataDestination) ApplyDelta(events []fdv2proto.Event, _ *fdv2proto.
 		AssertNotNil(coll.Kind)
 	}
 
-	for _, coll := range collections {
+	for _, coll := range toposort.Sort(collections) {
 		for _, item := range coll.Items {
 			if _, err := d.DataStore.Upsert(coll.Kind, item.Key, item.Item); err != nil {
 				return


### PR DESCRIPTION
Use the new `toposort` package to insert items int persistent store in dependency order.