### PR TITLE
feat: add support for client-side prerequisite events

### DIFF
--- a/.github/workflows/common_ci.yml
+++ b/.github/workflows/common_ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: make workspace
       - name: Start test service in background
         run: make start-contract-test-service-bg
-      - uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1.0.0
+      - uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1.1.0
         continue-on-error: true
         with:
           test_service_port: ${{ env.TEST_SERVICE_PORT }}

--- a/interfaces/flagstate/flags_state.go
+++ b/interfaces/flagstate/flags_state.go
@@ -67,6 +67,10 @@ type FlagState struct {
 	// OmitDetails is true if, based on the options passed to AllFlagsState and the flag state, some of the
 	// metadata can be left out of the JSON representation.
 	OmitDetails bool
+
+	// Prerequisites is an ordered list of direct prerequisites that were evaluated in the process of evaluating this
+	// flag.
+	Prerequisites []string
 }
 
 // Option is the interface for optional parameters that can be passed to LDClient.AllFlagsState.
@@ -156,6 +160,13 @@ func (a AllFlags) MarshalJSON() ([]byte, error) {
 		flagObj.Maybe("trackEvents", flag.TrackEvents).Bool(flag.TrackEvents)
 		flagObj.Maybe("trackReason", flag.TrackReason).Bool(flag.TrackReason)
 		flagObj.Maybe("debugEventsUntilDate", flag.DebugEventsUntilDate > 0).Float64(float64(flag.DebugEventsUntilDate))
+		if len(flag.Prerequisites) > 0 {
+			prerequisites := flagObj.Name("prerequisites").Array()
+			for _, p := range flag.Prerequisites {
+				prerequisites.String(p)
+			}
+			prerequisites.End()
+		}
 		flagObj.End()
 	}
 	stateObj.End()

--- a/ldclient.go
+++ b/ldclient.go
@@ -684,7 +684,12 @@ func (client *LDClient) AllFlagsState(context ldcontext.Context, options ...flag
 					continue
 				}
 
-				result := client.evaluator.Evaluate(flag, context, nil)
+				var prerequisites []string
+				result := client.evaluator.Evaluate(flag, context, func(event ldeval.PrerequisiteFlagEvent) {
+					if event.TargetFlagKey == flag.Key {
+						prerequisites = append(prerequisites, event.PrerequisiteFlag.Key)
+					}
+				})
 
 				state.AddFlag(
 					item.Key,
@@ -696,6 +701,7 @@ func (client *LDClient) AllFlagsState(context ldcontext.Context, options ...flag
 						TrackEvents:          flag.TrackEvents || result.IsExperiment,
 						TrackReason:          result.IsExperiment,
 						DebugEventsUntilDate: flag.DebugEventsUntilDate,
+						Prerequisites:        prerequisites,
 					},
 				)
 			}

--- a/testservice/service.go
+++ b/testservice/service.go
@@ -43,6 +43,7 @@ var capabilities = []string{
 	servicedef.CapabilityOmitAnonymousContexts,
 	servicedef.CapabilityEventGzip,
 	servicedef.CapabilityOptionalEventGzip,
+	servicedef.CapabilityClientPrereqEvents,
 }
 
 // gets the specified environment variable, or the default if not set

--- a/testservice/servicedef/service_params.go
+++ b/testservice/servicedef/service_params.go
@@ -24,6 +24,7 @@ const (
 	CapabilityOmitAnonymousContexts = "omit-anonymous-contexts"
 	CapabilityEventGzip             = "event-gzip"
 	CapabilityOptionalEventGzip     = "optional-event-gzip"
+	CapabilityClientPrereqEvents    = "client-prereq-events"
 )
 
 type StatusRep struct {


### PR DESCRIPTION
This PR updates `AllFlagsState` to track prerequisite evaluations. 

This didn't require modifying the eval module, as it already exposes a `PrerequisiteEventRecorder` interface with the necessary info.

The `AllFlagsState` public API allows for fetching a flag's details (`FlagState`) from the top-level `AllFlags` object. This struct now has prerequisite information exposed. 

Additionally when the `AllFlags` is marshaled to JSON, it will now contain the prerequisite info for each flag.