### PR TITLE
chore: release AI SDK

### DIFF
--- a/ldai/README.md
+++ b/ldai/README.md
@@ -1,5 +1,11 @@
 LaunchDarkly Server-side AI SDK for Go
 ==============================================
+
+# ⛔️⛔️⛔️⛔️
+> [!CAUTION]
+> This library is a alpha version and should not be considered ready for production use while this message is visible.
+# ☝️☝️☝️☝️☝️☝️
+
 [![Actions Status](https://github.com/launchdarkly/go-server-sdk/actions/workflows/ldai-ci.yml/badge.svg?branch=v7)](https://github.com/launchdarkly/go-server-sdk/actions/workflows/ldai-ci.yml)
 
 LaunchDarkly overview

--- a/ldai/package_info.go
+++ b/ldai/package_info.go
@@ -2,4 +2,4 @@
 package ldai
 
 // Version is the current version string of the ldai package. This is updated by our release scripts.
-const Version = "0.0.0" // {{ x-release-please-version }}
+const Version = "0.1.0" // {{ x-release-please-version }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -26,6 +26,17 @@
       "extra-files" : [
         "package_info.go"
       ]
+    },
+    "ldai" : {
+      "package-name": "ldai",
+      "release-type" : "go",
+      "bump-minor-pre-major" : true,
+      "release-as": "0.1.0",
+      "tag-separator": "/",
+      "versioning" : "default",
+      "extra-files" : [
+        "package_info.go"
+      ]
     }
   }
 }


### PR DESCRIPTION
Adds release-please config for `ldai`.

Additionally updates README with a large warning message about alpha quality software.