### PR TITLE
feat: pass tracker's config into TrackRequest

### DIFF
--- a/ldai/client.go
+++ b/ldai/client.go
@@ -76,13 +76,13 @@ func (c *Client) Config(
 	// empty object.)
 	if result.Type() != ldvalue.ObjectType {
 		c.logConfigWarning(key, "unmarshalling failed, expected JSON object but got %s", result.Type().String())
-		return defaultValue, newTracker(key, c.sdk, &defaultValue, context, c.logger)
+		return defaultValue, newTracker(key, "", c.sdk, &defaultValue, context, c.logger)
 	}
 
 	var parsed datamodel.Config
 	if err := json.Unmarshal([]byte(result.JSONString()), &parsed); err != nil {
 		c.logConfigWarning(key, "unmarshalling failed: %v", err)
-		return defaultValue, newTracker(key, c.sdk, &defaultValue, context, c.logger)
+		return defaultValue, newTracker(key, "", c.sdk, &defaultValue, context, c.logger)
 	}
 
 	mergedVariables := map[string]interface{}{
@@ -114,7 +114,7 @@ func (c *Client) Config(
 	}
 
 	cfg := builder.Build()
-	return cfg, newTracker(key, c.sdk, &cfg, context, c.logger)
+	return cfg, newTracker(key, parsed.Meta.VersionKey, c.sdk, &cfg, context, c.logger)
 }
 
 func getAllAttributes(context ldcontext.Context) map[string]interface{} {

--- a/ldai/tracker.go
+++ b/ldai/tracker.go
@@ -200,16 +200,17 @@ func (t *Tracker) TrackUsage(usage TokenUsage) error {
 	return nil
 }
 
-func measureDurationOfTask[T any](stopwatch Stopwatch, task func() (T, error)) (T, time.Duration, error) {
+func measureDurationOfTask[T any, A any](stopwatch Stopwatch, arg A, task func(A) (T, error)) (T, time.Duration, error) {
 	stopwatch.Start()
-	result, err := task()
+	result, err := task(arg)
 	return result, stopwatch.Stop(), err
 }
 
 // TrackRequest tracks metrics for a model evaluation request. The task function should return a ProviderResponse
-// which can be used to specify request metrics and token usage.
+// which can be used to specify request metrics and token usage. All fields of the returned ProviderResponse are optional.
 //
-// All fields of the ProviderResponse are optional.
+// The task function will be passed the current AI config, which can be used to obtain any parameters or messages
+// relevant to the request.
 //
 // If the task returns an error, then the request is not considered successful and no metrics are tracked.
 // Otherwise, the following metrics are tracked:
@@ -217,8 +218,8 @@ func measureDurationOfTask[T any](stopwatch Stopwatch, task func() (T, error)) (
 //  2. Any metrics that were that set in the ProviderResponse
 //     2a) If Latency was not set in the ProviderResponse's Metrics field, an automatically measured duration.
 //  3. Any token usage that was set in the ProviderResponse.
-func (t *Tracker) TrackRequest(task func() (ProviderResponse, error)) (ProviderResponse, error) {
-	usage, duration, err := measureDurationOfTask(t.stopwatch, task)
+func (t *Tracker) TrackRequest(task func(c *Config) (ProviderResponse, error)) (ProviderResponse, error) {
+	usage, duration, err := measureDurationOfTask(t.stopwatch, t.config, task)
 
 	if err != nil {
 		t.logWarning("error executing request: %v", err)

--- a/ldai/tracker.go
+++ b/ldai/tracker.go
@@ -114,19 +114,19 @@ func (d *defaultStopwatch) Stop() time.Duration {
 }
 
 // newTracker creates a new Tracker with the specified key, event sink, config, context, and loggers.
-func newTracker(key string, events EventSink, config *Config, ctx ldcontext.Context, loggers interfaces.LDLoggers) *Tracker {
-	return newTrackerWithStopwatch(key, events, config, ctx, loggers, &defaultStopwatch{})
+func newTracker(key string, versionKey string, events EventSink, config *Config, ctx ldcontext.Context, loggers interfaces.LDLoggers) *Tracker {
+	return newTrackerWithStopwatch(key, versionKey, events, config, ctx, loggers, &defaultStopwatch{})
 }
 
 // newTrackerWithStopwatch creates a new Tracker with the specified key, event sink, config, context, loggers, and
 // stopwatch. This method is used for testing purposes.
-func newTrackerWithStopwatch(key string, events EventSink, config *Config, ctx ldcontext.Context, loggers interfaces.LDLoggers, stopwatch Stopwatch) *Tracker {
+func newTrackerWithStopwatch(key string, versionKey string, events EventSink, config *Config, ctx ldcontext.Context, loggers interfaces.LDLoggers, stopwatch Stopwatch) *Tracker {
 	if config == nil {
 		panic("LaunchDarkly SDK programmer error: config must never be nil")
 	}
 
 	trackData := ldvalue.ObjectBuild().
-		Set("versionKey", ldvalue.String(config.VersionKey())).
+		Set("versionKey", ldvalue.String(versionKey)).
 		Set("configKey", ldvalue.String(key)).Build()
 
 	return &Tracker{

--- a/ldai/tracker_test.go
+++ b/ldai/tracker_test.go
@@ -1,6 +1,7 @@
 package ldai
 
 import (
+	"github.com/launchdarkly/go-server-sdk/ldai/datamodel"
 	"testing"
 	"time"
 
@@ -78,7 +79,7 @@ func TestTracker_TrackRequest(t *testing.T) {
 		},
 	}
 
-	r, err := tracker.TrackRequest(func() (ProviderResponse, error) {
+	r, err := tracker.TrackRequest(func(c *Config) (ProviderResponse, error) {
 		return expectedResponse, nil
 	})
 
@@ -110,6 +111,47 @@ func TestTracker_TrackRequest(t *testing.T) {
 	assert.ElementsMatch(t, expectedEvents, events.events)
 }
 
+func TestTracker_TrackRequestReceivesConfig(t *testing.T) {
+	events := newMockEvents()
+
+	expectedConfig := &Config{
+		c: datamodel.Config{
+			Messages: []datamodel.Message{
+				{
+					Content: "hello",
+					Role:    datamodel.Assistant,
+				},
+			},
+			Meta: datamodel.Meta{
+				VersionKey: "version",
+				Enabled:    true,
+			},
+			Model: datamodel.Model{
+				Id: "model",
+				Parameters: map[string]ldvalue.Value{
+					"param": ldvalue.String("value"),
+				},
+				Custom: map[string]ldvalue.Value{
+					"custom": ldvalue.String("value"),
+				},
+			},
+			Provider: datamodel.Provider{
+				Id: "provider",
+			},
+		},
+	}
+
+	tracker := newTracker("key", events, expectedConfig, ldcontext.New("key"), nil)
+
+	var gotConfig *Config
+	_, _ = tracker.TrackRequest(func(c *Config) (ProviderResponse, error) {
+		gotConfig = c
+		return ProviderResponse{}, nil
+	})
+
+	assert.Equal(t, expectedConfig, gotConfig)
+}
+
 type mockStopwatch time.Duration
 
 func (m mockStopwatch) Start() {}
@@ -130,7 +172,7 @@ func TestTracker_LatencyMeasuredIfNotProvided(t *testing.T) {
 		},
 	}
 
-	r, err := tracker.TrackRequest(func() (ProviderResponse, error) {
+	r, err := tracker.TrackRequest(func(c *Config) (ProviderResponse, error) {
 		return expectedResponse, nil
 	})
 

--- a/ldai/tracker_test.go
+++ b/ldai/tracker_test.go
@@ -34,13 +34,13 @@ func (m *mockEvents) TrackMetric(eventName string, context ldcontext.Context, me
 
 func TestTracker_NewPanicsWithNilConfig(t *testing.T) {
 	assert.Panics(t, func() {
-		newTracker("key", newMockEvents(), nil, ldcontext.New("key"), nil)
+		newTracker("key", "versionKey", newMockEvents(), nil, ldcontext.New("key"), nil)
 	})
 }
 
 func TestTracker_NewDoesNotPanicWithConfig(t *testing.T) {
 	assert.NotPanics(t, func() {
-		newTracker("key", newMockEvents(), &Config{}, ldcontext.New("key"), nil)
+		newTracker("key", "versionKey", newMockEvents(), &Config{}, ldcontext.New("key"), nil)
 	})
 }
 
@@ -52,14 +52,14 @@ func makeTrackData(configKey, versionKey string) ldvalue.Value {
 
 func TestTracker_TrackSuccess(t *testing.T) {
 	events := newMockEvents()
-	tracker := newTracker("key", events, &Config{}, ldcontext.New("key"), nil)
+	tracker := newTracker("key", "versionKey", events, &Config{}, ldcontext.New("key"), nil)
 	assert.NoError(t, tracker.TrackSuccess())
 
 	expectedEvent := trackEvent{
 		name:        "$ld:ai:generation",
 		context:     ldcontext.New("key"),
 		metricValue: 1.0,
-		data:        makeTrackData("key", ""),
+		data:        makeTrackData("key", "versionKey"),
 	}
 
 	assert.ElementsMatch(t, []trackEvent{expectedEvent}, events.events)
@@ -67,7 +67,7 @@ func TestTracker_TrackSuccess(t *testing.T) {
 
 func TestTracker_TrackRequest(t *testing.T) {
 	events := newMockEvents()
-	tracker := newTracker("key", events, &Config{}, ldcontext.New("key"), nil)
+	tracker := newTracker("key", "versionKey", events, &Config{}, ldcontext.New("key"), nil)
 
 	expectedResponse := ProviderResponse{
 		Usage: TokenUsage{
@@ -89,21 +89,21 @@ func TestTracker_TrackRequest(t *testing.T) {
 		name:        "$ld:ai:generation",
 		context:     ldcontext.New("key"),
 		metricValue: 1,
-		data:        makeTrackData("key", ""),
+		data:        makeTrackData("key", "versionKey"),
 	}
 
 	expectedDurationEvent := trackEvent{
 		name:        "$ld:ai:duration:total",
 		context:     ldcontext.New("key"),
 		metricValue: 10.0,
-		data:        makeTrackData("key", ""),
+		data:        makeTrackData("key", "versionKey"),
 	}
 
 	expectedTokenUsageEvent := trackEvent{
 		name:        "$ld:ai:tokens:total",
 		context:     ldcontext.New("key"),
 		metricValue: 1,
-		data:        makeTrackData("key", ""),
+		data:        makeTrackData("key", "versionKey"),
 	}
 
 	expectedEvents := []trackEvent{expectedSuccessEvent, expectedDurationEvent, expectedTokenUsageEvent}
@@ -122,7 +122,7 @@ func TestTracker_LatencyMeasuredIfNotProvided(t *testing.T) {
 	events := newMockEvents()
 
 	tracker := newTrackerWithStopwatch(
-		"key", events, &Config{}, ldcontext.New("key"), nil, mockStopwatch(42*time.Millisecond))
+		"key", "versionKey", events, &Config{}, ldcontext.New("key"), nil, mockStopwatch(42*time.Millisecond))
 
 	expectedResponse := ProviderResponse{
 		Usage: TokenUsage{
@@ -145,7 +145,7 @@ func TestTracker_LatencyMeasuredIfNotProvided(t *testing.T) {
 
 func TestTracker_TrackDuration(t *testing.T) {
 	events := newMockEvents()
-	tracker := newTracker("key", events, &Config{}, ldcontext.New("key"), nil)
+	tracker := newTracker("key", "versionKey", events, &Config{}, ldcontext.New("key"), nil)
 
 	assert.NoError(t, tracker.TrackDuration(time.Millisecond*10))
 
@@ -153,7 +153,7 @@ func TestTracker_TrackDuration(t *testing.T) {
 		name:        "$ld:ai:duration:total",
 		context:     ldcontext.New("key"),
 		metricValue: 10.0,
-		data:        makeTrackData("key", ""),
+		data:        makeTrackData("key", "versionKey"),
 	}
 
 	assert.ElementsMatch(t, []trackEvent{expectedEvent}, events.events)
@@ -161,7 +161,7 @@ func TestTracker_TrackDuration(t *testing.T) {
 
 func TestTracker_TrackFeedback(t *testing.T) {
 	events := newMockEvents()
-	tracker := newTracker("key", events, &Config{}, ldcontext.New("key"), nil)
+	tracker := newTracker("key", "versionKey", events, &Config{}, ldcontext.New("key"), nil)
 
 	assert.NoError(t, tracker.TrackFeedback(Positive))
 	assert.NoError(t, tracker.TrackFeedback(Negative))
@@ -171,14 +171,14 @@ func TestTracker_TrackFeedback(t *testing.T) {
 		name:        "$ld:ai:feedback:user:positive",
 		context:     ldcontext.New("key"),
 		metricValue: 1.0,
-		data:        makeTrackData("key", ""),
+		data:        makeTrackData("key", "versionKey"),
 	}
 
 	expectedNegativeEvent := trackEvent{
 		name:        "$ld:ai:feedback:user:negative",
 		context:     ldcontext.New("key"),
 		metricValue: 1.0,
-		data:        makeTrackData("key", ""),
+		data:        makeTrackData("key", "versionKey"),
 	}
 
 	assert.ElementsMatch(t, []trackEvent{expectedPositiveEvent, expectedNegativeEvent}, events.events)
@@ -187,7 +187,7 @@ func TestTracker_TrackFeedback(t *testing.T) {
 func TestTracker_TrackUsage(t *testing.T) {
 	t.Run("only one field set, only one event", func(t *testing.T) {
 		events := newMockEvents()
-		tracker := newTracker("key", events, &Config{}, ldcontext.New("key"), nil)
+		tracker := newTracker("key", "versionKey", events, &Config{}, ldcontext.New("key"), nil)
 
 		assert.NoError(t, tracker.TrackUsage(TokenUsage{
 			Total: 42,
@@ -197,7 +197,7 @@ func TestTracker_TrackUsage(t *testing.T) {
 			name:        "$ld:ai:tokens:total",
 			context:     ldcontext.New("key"),
 			metricValue: 42.0,
-			data:        makeTrackData("key", ""),
+			data:        makeTrackData("key", "versionKey"),
 		}
 
 		assert.ElementsMatch(t, []trackEvent{expectedEvent}, events.events)
@@ -205,7 +205,7 @@ func TestTracker_TrackUsage(t *testing.T) {
 
 	t.Run("all fields set, all events", func(t *testing.T) {
 		events := newMockEvents()
-		tracker := newTracker("key", events, &Config{}, ldcontext.New("key"), nil)
+		tracker := newTracker("key", "versionKey", events, &Config{}, ldcontext.New("key"), nil)
 
 		assert.NoError(t, tracker.TrackUsage(TokenUsage{
 			Total:  42,
@@ -217,21 +217,21 @@ func TestTracker_TrackUsage(t *testing.T) {
 			name:        "$ld:ai:tokens:total",
 			context:     ldcontext.New("key"),
 			metricValue: 42.0,
-			data:        makeTrackData("key", ""),
+			data:        makeTrackData("key", "versionKey"),
 		}
 
 		expectedInput := trackEvent{
 			name:        "$ld:ai:tokens:input",
 			context:     ldcontext.New("key"),
 			metricValue: 20.0,
-			data:        makeTrackData("key", ""),
+			data:        makeTrackData("key", "versionKey"),
 		}
 
 		expectedOutput := trackEvent{
 			name:        "$ld:ai:tokens:output",
 			context:     ldcontext.New("key"),
 			metricValue: 22.0,
-			data:        makeTrackData("key", ""),
+			data:        makeTrackData("key", "versionKey"),
 		}
 
 		assert.ElementsMatch(t, []trackEvent{expectedTotal, expectedInput, expectedOutput}, events.events)

--- a/ldai/tracker_test.go
+++ b/ldai/tracker_test.go
@@ -114,34 +114,16 @@ func TestTracker_TrackRequest(t *testing.T) {
 func TestTracker_TrackRequestReceivesConfig(t *testing.T) {
 	events := newMockEvents()
 
-	expectedConfig := &Config{
-		c: datamodel.Config{
-			Messages: []datamodel.Message{
-				{
-					Content: "hello",
-					Role:    datamodel.Assistant,
-				},
-			},
-			Meta: datamodel.Meta{
-				VersionKey: "version",
-				Enabled:    true,
-			},
-			Model: datamodel.Model{
-				Id: "model",
-				Parameters: map[string]ldvalue.Value{
-					"param": ldvalue.String("value"),
-				},
-				Custom: map[string]ldvalue.Value{
-					"custom": ldvalue.String("value"),
-				},
-			},
-			Provider: datamodel.Provider{
-				Id: "provider",
-			},
-		},
-	}
+	expectedConfig := NewConfig().
+		WithMessage("hello", datamodel.Assistant).
+		WithModelId("model").
+		WithProviderId("provider").
+		WithModelParam("param", ldvalue.String("value")).
+		WithCustomModelParam("custom", ldvalue.String("value")).
+		Enable().
+		Build()
 
-	tracker := newTracker("key", events, expectedConfig, ldcontext.New("key"), nil)
+	tracker := newTracker("key", "versionKey", events, &expectedConfig, ldcontext.New("key"), nil)
 
 	var gotConfig *Config
 	_, _ = tracker.TrackRequest(func(c *Config) (ProviderResponse, error) {
@@ -149,7 +131,7 @@ func TestTracker_TrackRequestReceivesConfig(t *testing.T) {
 		return ProviderResponse{}, nil
 	})
 
-	assert.Equal(t, expectedConfig, gotConfig)
+	assert.Equal(t, expectedConfig, *gotConfig)
 }
 
 type mockStopwatch time.Duration


### PR DESCRIPTION
This PR improves the ergonomics of `TrackRequest`. The user callback now receives a `Config` directly, which can be accessed to provide parameters for the request.

An alternative would be directly exposing the `Config` as a public variable of `Tracker`, or forcing the user to instead reference the config returned from a call to `cfg, tracker := client.Config(..)`. 

Those alternatives are not great, because they make the user carry around the config and manually inject it into the callback. This way, the callback can be defined wherever and not need to worry about how to receive the config.

