### PR TITLE
fix: pass parsed versionKey to Tracker

### DIFF
--- a/ldai/client.go
+++ b/ldai/client.go
@@ -76,13 +76,13 @@ func (c *Client) Config(
 	// empty object.)
 	if result.Type() != ldvalue.ObjectType {
 		c.logConfigWarning(key, "unmarshalling failed, expected JSON object but got %s", result.Type().String())
-		return defaultValue, newTracker(key, c.sdk, &defaultValue, context, c.logger)
+		return defaultValue, newTracker(key, "", c.sdk, &defaultValue, context, c.logger)
 	}
 
 	var parsed datamodel.Config
 	if err := json.Unmarshal([]byte(result.JSONString()), &parsed); err != nil {
 		c.logConfigWarning(key, "unmarshalling failed: %v", err)
-		return defaultValue, newTracker(key, c.sdk, &defaultValue, context, c.logger)
+		return defaultValue, newTracker(key, "", c.sdk, &defaultValue, context, c.logger)
 	}
 
 	mergedVariables := map[string]interface{}{
@@ -114,7 +114,7 @@ func (c *Client) Config(
 	}
 
 	cfg := builder.Build()
-	return cfg, newTracker(key, c.sdk, &cfg, context, c.logger)
+	return cfg, newTracker(key, parsed.Meta.VersionKey, c.sdk, &cfg, context, c.logger)
 }
 
 func getAllAttributes(context ldcontext.Context) map[string]interface{} {

--- a/ldai/tracker.go
+++ b/ldai/tracker.go
@@ -114,19 +114,19 @@ func (d *defaultStopwatch) Stop() time.Duration {
 }
 
 // newTracker creates a new Tracker with the specified key, event sink, config, context, and loggers.
-func newTracker(key string, events EventSink, config *Config, ctx ldcontext.Context, loggers interfaces.LDLoggers) *Tracker {
-	return newTrackerWithStopwatch(key, events, config, ctx, loggers, &defaultStopwatch{})
+func newTracker(key string, versionKey string, events EventSink, config *Config, ctx ldcontext.Context, loggers interfaces.LDLoggers) *Tracker {
+	return newTrackerWithStopwatch(key, versionKey, events, config, ctx, loggers, &defaultStopwatch{})
 }
 
 // newTrackerWithStopwatch creates a new Tracker with the specified key, event sink, config, context, loggers, and
 // stopwatch. This method is used for testing purposes.
-func newTrackerWithStopwatch(key string, events EventSink, config *Config, ctx ldcontext.Context, loggers interfaces.LDLoggers, stopwatch Stopwatch) *Tracker {
+func newTrackerWithStopwatch(key string, versionKey string, events EventSink, config *Config, ctx ldcontext.Context, loggers interfaces.LDLoggers, stopwatch Stopwatch) *Tracker {
 	if config == nil {
 		panic("LaunchDarkly SDK programmer error: config must never be nil")
 	}
 
 	trackData := ldvalue.ObjectBuild().
-		Set("versionKey", ldvalue.String(config.VersionKey())).
+		Set("versionKey", ldvalue.String(versionKey)).
 		Set("configKey", ldvalue.String(key)).Build()
 
 	return &Tracker{

--- a/ldai/tracker_test.go
+++ b/ldai/tracker_test.go
@@ -34,13 +34,13 @@ func (m *mockEvents) TrackMetric(eventName string, context ldcontext.Context, me
 
 func TestTracker_NewPanicsWithNilConfig(t *testing.T) {
 	assert.Panics(t, func() {
-		newTracker("key", newMockEvents(), nil, ldcontext.New("key"), nil)
+		newTracker("key", "versionKey", newMockEvents(), nil, ldcontext.New("key"), nil)
 	})
 }
 
 func TestTracker_NewDoesNotPanicWithConfig(t *testing.T) {
 	assert.NotPanics(t, func() {
-		newTracker("key", newMockEvents(), &Config{}, ldcontext.New("key"), nil)
+		newTracker("key", "versionKey", newMockEvents(), &Config{}, ldcontext.New("key"), nil)
 	})
 }
 
@@ -52,14 +52,14 @@ func makeTrackData(configKey, versionKey string) ldvalue.Value {
 
 func TestTracker_TrackSuccess(t *testing.T) {
 	events := newMockEvents()
-	tracker := newTracker("key", events, &Config{}, ldcontext.New("key"), nil)
+	tracker := newTracker("key", "versionKey", events, &Config{}, ldcontext.New("key"), nil)
 	assert.NoError(t, tracker.TrackSuccess())
 
 	expectedEvent := trackEvent{
 		name:        "$ld:ai:generation",
 		context:     ldcontext.New("key"),
 		metricValue: 1.0,
-		data:        makeTrackData("key", ""),
+		data:        makeTrackData("key", "versionKey"),
 	}
 
 	assert.ElementsMatch(t, []trackEvent{expectedEvent}, events.events)
@@ -67,7 +67,7 @@ func TestTracker_TrackSuccess(t *testing.T) {
 
 func TestTracker_TrackRequest(t *testing.T) {
 	events := newMockEvents()
-	tracker := newTracker("key", events, &Config{}, ldcontext.New("key"), nil)
+	tracker := newTracker("key", "versionKey", events, &Config{}, ldcontext.New("key"), nil)
 
 	expectedResponse := ProviderResponse{
 		Usage: TokenUsage{
@@ -89,21 +89,21 @@ func TestTracker_TrackRequest(t *testing.T) {
 		name:        "$ld:ai:generation",
 		context:     ldcontext.New("key"),
 		metricValue: 1,
-		data:        makeTrackData("key", ""),
+		data:        makeTrackData("key", "versionKey"),
 	}
 
 	expectedDurationEvent := trackEvent{
 		name:        "$ld:ai:duration:total",
 		context:     ldcontext.New("key"),
 		metricValue: 10.0,
-		data:        makeTrackData("key", ""),
+		data:        makeTrackData("key", "versionKey"),
 	}
 
 	expectedTokenUsageEvent := trackEvent{
 		name:        "$ld:ai:tokens:total",
 		context:     ldcontext.New("key"),
 		metricValue: 1,
-		data:        makeTrackData("key", ""),
+		data:        makeTrackData("key", "versionKey"),
 	}
 
 	expectedEvents := []trackEvent{expectedSuccessEvent, expectedDurationEvent, expectedTokenUsageEvent}
@@ -122,7 +122,7 @@ func TestTracker_LatencyMeasuredIfNotProvided(t *testing.T) {
 	events := newMockEvents()
 
 	tracker := newTrackerWithStopwatch(
-		"key", events, &Config{}, ldcontext.New("key"), nil, mockStopwatch(42*time.Millisecond))
+		"key", "versionKey", events, &Config{}, ldcontext.New("key"), nil, mockStopwatch(42*time.Millisecond))
 
 	expectedResponse := ProviderResponse{
 		Usage: TokenUsage{
@@ -145,7 +145,7 @@ func TestTracker_LatencyMeasuredIfNotProvided(t *testing.T) {
 
 func TestTracker_TrackDuration(t *testing.T) {
 	events := newMockEvents()
-	tracker := newTracker("key", events, &Config{}, ldcontext.New("key"), nil)
+	tracker := newTracker("key", "versionKey", events, &Config{}, ldcontext.New("key"), nil)
 
 	assert.NoError(t, tracker.TrackDuration(time.Millisecond*10))
 
@@ -153,7 +153,7 @@ func TestTracker_TrackDuration(t *testing.T) {
 		name:        "$ld:ai:duration:total",
 		context:     ldcontext.New("key"),
 		metricValue: 10.0,
-		data:        makeTrackData("key", ""),
+		data:        makeTrackData("key", "versionKey"),
 	}
 
 	assert.ElementsMatch(t, []trackEvent{expectedEvent}, events.events)
@@ -161,7 +161,7 @@ func TestTracker_TrackDuration(t *testing.T) {
 
 func TestTracker_TrackFeedback(t *testing.T) {
 	events := newMockEvents()
-	tracker := newTracker("key", events, &Config{}, ldcontext.New("key"), nil)
+	tracker := newTracker("key", "versionKey", events, &Config{}, ldcontext.New("key"), nil)
 
 	assert.NoError(t, tracker.TrackFeedback(Positive))
 	assert.NoError(t, tracker.TrackFeedback(Negative))
@@ -171,14 +171,14 @@ func TestTracker_TrackFeedback(t *testing.T) {
 		name:        "$ld:ai:feedback:user:positive",
 		context:     ldcontext.New("key"),
 		metricValue: 1.0,
-		data:        makeTrackData("key", ""),
+		data:        makeTrackData("key", "versionKey"),
 	}
 
 	expectedNegativeEvent := trackEvent{
 		name:        "$ld:ai:feedback:user:negative",
 		context:     ldcontext.New("key"),
 		metricValue: 1.0,
-		data:        makeTrackData("key", ""),
+		data:        makeTrackData("key", "versionKey"),
 	}
 
 	assert.ElementsMatch(t, []trackEvent{expectedPositiveEvent, expectedNegativeEvent}, events.events)
@@ -187,7 +187,7 @@ func TestTracker_TrackFeedback(t *testing.T) {
 func TestTracker_TrackUsage(t *testing.T) {
 	t.Run("only one field set, only one event", func(t *testing.T) {
 		events := newMockEvents()
-		tracker := newTracker("key", events, &Config{}, ldcontext.New("key"), nil)
+		tracker := newTracker("key", "versionKey", events, &Config{}, ldcontext.New("key"), nil)
 
 		assert.NoError(t, tracker.TrackUsage(TokenUsage{
 			Total: 42,
@@ -197,7 +197,7 @@ func TestTracker_TrackUsage(t *testing.T) {
 			name:        "$ld:ai:tokens:total",
 			context:     ldcontext.New("key"),
 			metricValue: 42.0,
-			data:        makeTrackData("key", ""),
+			data:        makeTrackData("key", "versionKey"),
 		}
 
 		assert.ElementsMatch(t, []trackEvent{expectedEvent}, events.events)
@@ -205,7 +205,7 @@ func TestTracker_TrackUsage(t *testing.T) {
 
 	t.Run("all fields set, all events", func(t *testing.T) {
 		events := newMockEvents()
-		tracker := newTracker("key", events, &Config{}, ldcontext.New("key"), nil)
+		tracker := newTracker("key", "versionKey", events, &Config{}, ldcontext.New("key"), nil)
 
 		assert.NoError(t, tracker.TrackUsage(TokenUsage{
 			Total:  42,
@@ -217,21 +217,21 @@ func TestTracker_TrackUsage(t *testing.T) {
 			name:        "$ld:ai:tokens:total",
 			context:     ldcontext.New("key"),
 			metricValue: 42.0,
-			data:        makeTrackData("key", ""),
+			data:        makeTrackData("key", "versionKey"),
 		}
 
 		expectedInput := trackEvent{
 			name:        "$ld:ai:tokens:input",
 			context:     ldcontext.New("key"),
 			metricValue: 20.0,
-			data:        makeTrackData("key", ""),
+			data:        makeTrackData("key", "versionKey"),
 		}
 
 		expectedOutput := trackEvent{
 			name:        "$ld:ai:tokens:output",
 			context:     ldcontext.New("key"),
 			metricValue: 22.0,
-			data:        makeTrackData("key", ""),
+			data:        makeTrackData("key", "versionKey"),
 		}
 
 		assert.ElementsMatch(t, []trackEvent{expectedTotal, expectedInput, expectedOutput}, events.events)


### PR DESCRIPTION
The AI client wasn't passing the parsed `_ldMeta.versionKey` into newly created `Tracker`s. The tests didn't catch it because the default value of strings are `""`, and that's what the tests asserted against.

I've updated the tests to pass in a non-default string to make sure it is being plumbed through.