### PR TITLE
chore: remove release-as from ai SDK

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -31,7 +31,6 @@
       "package-name": "ldai",
       "release-type" : "go",
       "bump-minor-pre-major" : true,
-      "release-as": "0.1.0",
       "tag-separator": "/",
       "versioning" : "default",
       "extra-files" : [


### PR DESCRIPTION
Now that we've released 0.1.0, we should remove `release-as` from the release please config.