### PR TITLE
fix: add prefix to Feedback constants

### DIFF
--- a/ldai/tracker.go
+++ b/ldai/tracker.go
@@ -57,10 +57,10 @@ type ProviderResponse struct {
 type Feedback string
 
 const (
-	// Positive feedback (result was good).
-	Positive Feedback = "positive"
-	// Negative feedback (result was bad).
-	Negative Feedback = "negative"
+	// FeedbackPositive is positive feedback.
+	FeedbackPositive Feedback = "positive"
+	// FeedbackNegative is negative feedback.
+	FeedbackNegative Feedback = "negative"
 )
 
 // EventSink represents the Tracker's requirements for delivering analytic events. This is generally satisfied
@@ -153,12 +153,12 @@ func (t *Tracker) TrackDuration(dur time.Duration) error {
 }
 
 // TrackFeedback tracks the feedback provided by a user for a model evaluation. If the feedback is not
-// Positive or Negative, returns an error and does not track anything.
+// FeedbackPositive or FeedbackNegative, returns an error and does not track anything.
 func (t *Tracker) TrackFeedback(feedback Feedback) error {
 	switch feedback {
-	case Positive:
+	case FeedbackPositive:
 		return t.events.TrackMetric(feedbackPositive, t.context, 1, t.trackData)
-	case Negative:
+	case FeedbackNegative:
 		return t.events.TrackMetric(feedbackNegative, t.context, 1, t.trackData)
 	default:
 		return fmt.Errorf("tracker: unexpected feedback value: %v", feedback)

--- a/ldai/tracker_test.go
+++ b/ldai/tracker_test.go
@@ -187,8 +187,8 @@ func TestTracker_TrackFeedback(t *testing.T) {
 	events := newMockEvents()
 	tracker := newTracker("key", "versionKey", events, &Config{}, ldcontext.New("key"), nil)
 
-	assert.NoError(t, tracker.TrackFeedback(Positive))
-	assert.NoError(t, tracker.TrackFeedback(Negative))
+	assert.NoError(t, tracker.TrackFeedback(FeedbackPositive))
+	assert.NoError(t, tracker.TrackFeedback(FeedbackNegative))
 	assert.Error(t, tracker.TrackFeedback("not a valid feedback value"))
 
 	expectedPositiveEvent := trackEvent{


### PR DESCRIPTION
Otherwise, these look like `ldai.Positive|Negative`, which is pretty confusing to see in isolation.