### PR TITLE
refactor: add fallback/recovery additions [prototype]

### DIFF
--- a/internal/datasourcev2/polling_http_request.go
+++ b/internal/datasourcev2/polling_http_request.go
@@ -72,12 +72,9 @@ func (r *pollingRequester) Request() (*fdv2proto.ChangeSet, error) {
 		r.loggers.Debug("Polling LaunchDarkly for feature flag updates")
 	}
 
-	body, cached, err := r.makeRequest(endpoints.PollingRequestPath)
+	body, _, err := r.makeRequest(endpoints.PollingRequestPath)
 	if err != nil {
 		return nil, err
-	}
-	if cached {
-		return fdv2proto.NewChangeSetBuilder().NoChanges(), nil
 	}
 
 	var payload fdv2proto.PollingPayload

--- a/internal/datasourcev2/streaming_data_source.go
+++ b/internal/datasourcev2/streaming_data_source.go
@@ -287,6 +287,7 @@ func (sp *StreamProcessor) consumeStream(stream *es.Stream, closeWhenReady chan<
 				sp.setInitializedAndNotifyClient(true, closeWhenReady)
 
 			default:
+				processedEvent = false
 				sp.loggers.Infof("Unexpected event found in stream: %s", event.Event())
 			}
 

--- a/internal/datasystem/fdv2_datasystem.go
+++ b/internal/datasystem/fdv2_datasystem.go
@@ -114,6 +114,7 @@ func NewFDv2(disabled bool, cfgBuilder subsystems.ComponentConfigurer[subsystems
 	fdv2.disabled = disabled
 	fdv2.fallbackCond = func() bool {
 		status := fdv2.getStatus()
+		fdv2.loggers.Debugf("Status: %s", status.String())
 		interruptedAtRuntime := status.State == interfaces.DataSourceStateInterrupted && time.Since(status.StateSince) > 1*time.Minute
 		cannotInitialize := status.State == interfaces.DataSourceStateInitializing && time.Since(status.StateSince) > 30*time.Second
 		return interruptedAtRuntime || cannotInitialize
@@ -284,6 +285,7 @@ func (f *FDv2) evaluateCond(ctx context.Context, cond func() bool) error {
 			if cond() {
 				return nil
 			}
+			f.loggers.Debugf("Condition check succeeded, continue with current synchronizer")
 		}
 	}
 }

--- a/internal/datasystem/fdv2_datasystem.go
+++ b/internal/datasystem/fdv2_datasystem.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/launchdarkly/go-server-sdk/v7/internal/fdv2proto"
-
 	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
 	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
 	"github.com/launchdarkly/go-server-sdk/v7/internal"
@@ -72,6 +70,9 @@ type FDv2 struct {
 	// Protects status.
 	mu     sync.Mutex
 	status interfaces.DataSourceStatus
+
+	fallbackCond func() bool
+	recoveryCond func() bool
 }
 
 // NewFDv2 creates a new instance of the FDv2 data system. The first argument indicates if the system is enabled or
@@ -111,6 +112,15 @@ func NewFDv2(disabled bool, cfgBuilder subsystems.ComponentConfigurer[subsystems
 	fdv2.primarySync = cfg.Synchronizers.Primary
 	fdv2.secondarySync = cfg.Synchronizers.Secondary
 	fdv2.disabled = disabled
+	fdv2.fallbackCond = func() bool {
+		status := fdv2.getStatus()
+		return status.State == interfaces.DataSourceStateInterrupted && time.Since(status.StateSince) > 1*time.Minute
+	}
+	fdv2.recoveryCond = func() bool {
+		status := fdv2.getStatus()
+		return status.State == interfaces.DataSourceStateInterrupted && time.Since(status.StateSince) > 1*time.Minute ||
+			status.State == interfaces.DataSourceStateValid && time.Since(status.StateSince) > 5*time.Minute
+	}
 
 	if cfg.Store != nil && !disabled {
 		// If there's a persistent Store, we should provide a status monitor and inform Store that it's present.
@@ -159,7 +169,7 @@ func (f *FDv2) hasDataSources() bool {
 }
 
 func (f *FDv2) run(ctx context.Context, closeWhenReady chan struct{}) {
-	selector := f.runInitializers(ctx, closeWhenReady)
+	f.runInitializers(ctx, closeWhenReady)
 
 	if f.hasDataSources() && f.dataStoreStatusProvider.IsStatusMonitoringEnabled() {
 		f.launchTask(func() {
@@ -167,7 +177,7 @@ func (f *FDv2) run(ctx context.Context, closeWhenReady chan struct{}) {
 		})
 	}
 
-	f.runSynchronizers(ctx, closeWhenReady, selector)
+	f.runSynchronizers(ctx, closeWhenReady)
 }
 
 func (f *FDv2) runPersistentStoreOutageRecovery(ctx context.Context, statuses <-chan interfaces.DataStoreStatus) {
@@ -189,12 +199,12 @@ func (f *FDv2) runPersistentStoreOutageRecovery(ctx context.Context, statuses <-
 	}
 }
 
-func (f *FDv2) runInitializers(ctx context.Context, closeWhenReady chan struct{}) fdv2proto.Selector {
+func (f *FDv2) runInitializers(ctx context.Context, closeWhenReady chan struct{}) {
 	for _, initializer := range f.initializers {
 		f.loggers.Infof("Attempting to initialize via %s", initializer.Name())
 		basis, err := initializer.Fetch(ctx)
 		if errors.Is(err, context.Canceled) {
-			return fdv2proto.NoSelector()
+			return
 		}
 		if err != nil {
 			f.loggers.Warnf("Initializer %s failed: %v", initializer.Name(), err)
@@ -205,12 +215,10 @@ func (f *FDv2) runInitializers(ctx context.Context, closeWhenReady chan struct{}
 		f.readyOnce.Do(func() {
 			close(closeWhenReady)
 		})
-		return basis.Selector
 	}
-	return fdv2proto.NoSelector()
 }
 
-func (f *FDv2) runSynchronizers(ctx context.Context, closeWhenReady chan struct{}, selector fdv2proto.Selector) {
+func (f *FDv2) runSynchronizers(ctx context.Context, closeWhenReady chan struct{}) {
 	// If the SDK was configured with no synchronizer, then (assuming no initializer succeeded), we should
 	// trigger the ready signal to let the call to MakeClient unblock immediately.
 	if f.primarySync == nil {
@@ -224,16 +232,51 @@ func (f *FDv2) runSynchronizers(ctx context.Context, closeWhenReady chan struct{
 	// Instead, create a "proxy" channel just for the data source; if that is closed, we close the real one
 	// using the sync.Once.
 	ready := make(chan struct{})
-	f.primarySync.Sync(ready, selector)
 
+	f.launchTask(func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ready:
+				f.readyOnce.Do(func() {
+					close(closeWhenReady)
+				})
+			}
+		}
+	})
+
+	f.launchTask(func() {
+		for {
+			f.primarySync.Sync(ready, f.store.Selector())
+			if err := f.evaluateCond(ctx, f.fallbackCond); errors.Is(err, context.Canceled) {
+				return
+			}
+			f.secondarySync.Sync(ready, f.store.Selector())
+			if err := f.evaluateCond(ctx, f.recoveryCond); errors.Is(err, context.Canceled) {
+				return
+			}
+
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+		}
+	})
+}
+
+func (f *FDv2) evaluateCond(ctx context.Context, cond func() bool) error {
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
 	for {
 		select {
-		case <-ready:
-			f.readyOnce.Do(func() {
-				close(closeWhenReady)
-			})
 		case <-ctx.Done():
-			return
+			return ctx.Err()
+		case <-ticker.C:
+			if cond() {
+				return nil
+			}
 		}
 	}
 }

--- a/internal/datasystem/fdv2_datasystem.go
+++ b/internal/datasystem/fdv2_datasystem.go
@@ -116,14 +116,18 @@ func NewFDv2(disabled bool, cfgBuilder subsystems.ComponentConfigurer[subsystems
 		status := fdv2.getStatus()
 		fdv2.loggers.Debugf("Status: %s", status.String())
 		interruptedAtRuntime := status.State == interfaces.DataSourceStateInterrupted && time.Since(status.StateSince) > 1*time.Minute
-		cannotInitialize := status.State == interfaces.DataSourceStateInitializing && time.Since(status.StateSince) > 30*time.Second
-		return interruptedAtRuntime || cannotInitialize
+		cannotInitialize := status.State == interfaces.DataSourceStateInitializing && time.Since(status.StateSince) > 10*time.Second
+		healthyForTooLong := status.State == interfaces.DataSourceStateValid && time.Since(status.StateSince) > 30*time.Second
+
+		return interruptedAtRuntime || cannotInitialize || healthyForTooLong
 	}
 	fdv2.recoveryCond = func() bool {
 		status := fdv2.getStatus()
+		fdv2.loggers.Debugf("Status: %s", status.String())
+
 		interruptedAtRuntime := status.State == interfaces.DataSourceStateInterrupted && time.Since(status.StateSince) > 1*time.Minute
 		healthyForTooLong := status.State == interfaces.DataSourceStateValid && time.Since(status.StateSince) > 5*time.Minute
-		cannotInitialize := status.State == interfaces.DataSourceStateInitializing && time.Since(status.StateSince) > 30*time.Second
+		cannotInitialize := status.State == interfaces.DataSourceStateInitializing && time.Since(status.StateSince) > 10*time.Second
 		return interruptedAtRuntime || healthyForTooLong || cannotInitialize
 	}
 
@@ -174,6 +178,9 @@ func (f *FDv2) hasDataSources() bool {
 }
 
 func (f *FDv2) run(ctx context.Context, closeWhenReady chan struct{}) {
+
+	f.UpdateStatus(interfaces.DataSourceStateInitializing, interfaces.DataSourceErrorInfo{})
+
 	f.runInitializers(ctx, closeWhenReady)
 
 	if f.hasDataSources() && f.dataStoreStatusProvider.IsStatusMonitoringEnabled() {
@@ -238,6 +245,8 @@ func (f *FDv2) runSynchronizers(ctx context.Context, closeWhenReady chan struct{
 	// using the sync.Once.
 	ready := make(chan struct{})
 
+	// This doesn't work because the channel is still closed and when we flip flop, we might close again.
+	// Either change this to putting something in the channel, or figure out a better way to signal "ready".
 	f.launchTask(func() {
 		for {
 			select {
@@ -253,16 +262,25 @@ func (f *FDv2) runSynchronizers(ctx context.Context, closeWhenReady chan struct{
 
 	f.launchTask(func() {
 		for {
-			f.loggers.Debugf("Synchronizer %s is starting", f.primarySync.Name())
+			f.loggers.Debugf("Primary synchronizer %s is starting", f.primarySync.Name())
 			f.primarySync.Sync(ready, f.store.Selector())
 			if err := f.evaluateCond(ctx, f.fallbackCond); errors.Is(err, context.Canceled) {
 				return
 			}
+			if err := f.primarySync.Close(); err != nil {
+				f.loggers.Errorf("Primary synchronizer %s failed to gracefully close: %v", f.primarySync.Name(), err)
+			}
 			f.loggers.Debugf("Fallback condition met")
-			f.loggers.Debugf("Synchronizer %s is starting", f.secondarySync.Name())
+			f.loggers.Debugf("Secondary synchronizer %s is starting", f.secondarySync.Name())
+
+			f.UpdateStatus(interfaces.DataSourceStateInterrupted, interfaces.DataSourceErrorInfo{})
+
 			f.secondarySync.Sync(ready, f.store.Selector())
 			if err := f.evaluateCond(ctx, f.recoveryCond); errors.Is(err, context.Canceled) {
 				return
+			}
+			if err := f.secondarySync.Close(); err != nil {
+				f.loggers.Errorf("Secondary synchronizer %s failed to gracefully close: %v", f.secondarySync.Name(), err)
 			}
 			f.loggers.Debugf("Recovery condition met")
 			select {
@@ -357,10 +375,16 @@ func (f *FDv2) Offline() bool {
 func (f *FDv2) UpdateStatus(status interfaces.DataSourceState, err interfaces.DataSourceErrorInfo) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+
+	oldState := f.status.State
+
 	f.status = interfaces.DataSourceStatus{
-		State:      status,
-		LastError:  err,
-		StateSince: time.Now(),
+		State:     status,
+		LastError: err,
+	}
+
+	if status != oldState {
+		f.status.StateSince = time.Now()
 	}
 }
 

--- a/internal/datasystem/fdv2_datasystem.go
+++ b/internal/datasystem/fdv2_datasystem.go
@@ -386,19 +386,17 @@ func (f *FDv2) Offline() bool {
 }
 
 //nolint:revive // DataSourceStatusReporter method.
-func (f *FDv2) UpdateStatus(status interfaces.DataSourceState, err interfaces.DataSourceErrorInfo) {
+func (f *FDv2) UpdateStatus(state interfaces.DataSourceState, err interfaces.DataSourceErrorInfo) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	oldState := f.status.State
-
-	f.status = interfaces.DataSourceStatus{
-		State:     status,
-		LastError: err,
+	if state != f.status.State {
+		f.status.State = state
+		f.status.StateSince = time.Now()
 	}
 
-	if status != oldState {
-		f.status.StateSince = time.Now()
+	if err != f.status.LastError {
+		f.status.LastError = err
 	}
 }
 

--- a/internal/datasystem/fdv2_datasystem.go
+++ b/internal/datasystem/fdv2_datasystem.go
@@ -114,12 +114,16 @@ func NewFDv2(disabled bool, cfgBuilder subsystems.ComponentConfigurer[subsystems
 	fdv2.disabled = disabled
 	fdv2.fallbackCond = func() bool {
 		status := fdv2.getStatus()
-		return status.State == interfaces.DataSourceStateInterrupted && time.Since(status.StateSince) > 1*time.Minute
+		interruptedAtRuntime := status.State == interfaces.DataSourceStateInterrupted && time.Since(status.StateSince) > 1*time.Minute
+		cannotInitialize := status.State == interfaces.DataSourceStateInitializing && time.Since(status.StateSince) > 30*time.Second
+		return interruptedAtRuntime || cannotInitialize
 	}
 	fdv2.recoveryCond = func() bool {
 		status := fdv2.getStatus()
-		return status.State == interfaces.DataSourceStateInterrupted && time.Since(status.StateSince) > 1*time.Minute ||
-			status.State == interfaces.DataSourceStateValid && time.Since(status.StateSince) > 5*time.Minute
+		interruptedAtRuntime := status.State == interfaces.DataSourceStateInterrupted && time.Since(status.StateSince) > 1*time.Minute
+		healthyForTooLong := status.State == interfaces.DataSourceStateValid && time.Since(status.StateSince) > 5*time.Minute
+		cannotInitialize := status.State == interfaces.DataSourceStateInitializing && time.Since(status.StateSince) > 30*time.Second
+		return interruptedAtRuntime || healthyForTooLong || cannotInitialize
 	}
 
 	if cfg.Store != nil && !disabled {
@@ -248,15 +252,18 @@ func (f *FDv2) runSynchronizers(ctx context.Context, closeWhenReady chan struct{
 
 	f.launchTask(func() {
 		for {
+			f.loggers.Debugf("Synchronizer %s is starting", f.primarySync.Name())
 			f.primarySync.Sync(ready, f.store.Selector())
 			if err := f.evaluateCond(ctx, f.fallbackCond); errors.Is(err, context.Canceled) {
 				return
 			}
+			f.loggers.Debugf("Fallback condition met")
+			f.loggers.Debugf("Synchronizer %s is starting", f.secondarySync.Name())
 			f.secondarySync.Sync(ready, f.store.Selector())
 			if err := f.evaluateCond(ctx, f.recoveryCond); errors.Is(err, context.Canceled) {
 				return
 			}
-
+			f.loggers.Debugf("Recovery condition met")
 			select {
 			case <-ctx.Done():
 				return

--- a/internal/datasystem/fdv2_datasystem.go
+++ b/internal/datasystem/fdv2_datasystem.go
@@ -71,8 +71,8 @@ type FDv2 struct {
 	mu     sync.Mutex
 	status interfaces.DataSourceStatus
 
-	fallbackCond func() bool
-	recoveryCond func() bool
+	fallbackCond func(status interfaces.DataSourceStatus) bool
+	recoveryCond func(status interfaces.DataSourceStatus) bool
 }
 
 // NewFDv2 creates a new instance of the FDv2 data system. The first argument indicates if the system is enabled or
@@ -112,19 +112,14 @@ func NewFDv2(disabled bool, cfgBuilder subsystems.ComponentConfigurer[subsystems
 	fdv2.primarySync = cfg.Synchronizers.Primary
 	fdv2.secondarySync = cfg.Synchronizers.Secondary
 	fdv2.disabled = disabled
-	fdv2.fallbackCond = func() bool {
-		status := fdv2.getStatus()
-		fdv2.loggers.Debugf("Status: %s", status.String())
+	fdv2.fallbackCond = func(status interfaces.DataSourceStatus) bool {
 		interruptedAtRuntime := status.State == interfaces.DataSourceStateInterrupted && time.Since(status.StateSince) > 1*time.Minute
 		cannotInitialize := status.State == interfaces.DataSourceStateInitializing && time.Since(status.StateSince) > 10*time.Second
 		healthyForTooLong := status.State == interfaces.DataSourceStateValid && time.Since(status.StateSince) > 30*time.Second
 
 		return interruptedAtRuntime || cannotInitialize || healthyForTooLong
 	}
-	fdv2.recoveryCond = func() bool {
-		status := fdv2.getStatus()
-		fdv2.loggers.Debugf("Status: %s", status.String())
-
+	fdv2.recoveryCond = func(status interfaces.DataSourceStatus) bool {
 		interruptedAtRuntime := status.State == interfaces.DataSourceStateInterrupted && time.Since(status.StateSince) > 1*time.Minute
 		healthyForTooLong := status.State == interfaces.DataSourceStateValid && time.Since(status.StateSince) > 5*time.Minute
 		cannotInitialize := status.State == interfaces.DataSourceStateInitializing && time.Since(status.StateSince) > 10*time.Second
@@ -306,7 +301,7 @@ func (f *FDv2) runSynchronizers(ctx context.Context, closeWhenReady chan struct{
 	})
 }
 
-func (f *FDv2) evaluateCond(ctx context.Context, cond func() bool) error {
+func (f *FDv2) evaluateCond(ctx context.Context, cond func(status interfaces.DataSourceStatus) bool) error {
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
 	for {
@@ -314,7 +309,9 @@ func (f *FDv2) evaluateCond(ctx context.Context, cond func() bool) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			if cond() {
+			status := f.getStatus()
+			f.loggers.Debugf("Data source status used to evaluate condition: %s", status.String())
+			if cond(status) {
 				return nil
 			}
 			f.loggers.Debugf("Condition check succeeded, continue with current synchronizer")

--- a/internal/datasystem/fdv2_datasystem.go
+++ b/internal/datasystem/fdv2_datasystem.go
@@ -230,9 +230,43 @@ func (f *FDv2) runInitializers(ctx context.Context, closeWhenReady chan struct{}
 	}
 }
 
+// The Go SDK is architected in such a way that a "closeWhenReady" channel is passed into the Data System by means
+// of MakeClient. MakeClient is able to block the user until the client reaches a terminal state in regard to
+// its initialization status - either initialized with data, or run out of time initializing, or some fatal error.
+//
+// By closing this channel, the SDK's data sources indicate that MakeClient should unblock.
+//
+// In the FDv2 world, we have the possibility that a synchronizer fails or we fall back to a secondary synchronizer.
+// Perhaps we've already closed the channel, and now a new synchronizer is attempting to do the same.
+//
+// In that case, we need to guarantee that the channel is closed only once. To do this, we "wrap" channel that is passed
+// directly into the synchronizer with another channel. The wrapper is responsible for actually closing the underlying
+// closeWhenReady, and it uses a sync.Once to ensure that happens only once.
+//
+// This design could be improved significantly. Some ideas:
+// 1) Refactor the SDK to listen to Data Source status rather than the special closeWhenReady channel. It's unclear why
+// this isn't currently the case, but there may be good reasons.
+// 2) Use callbacks. Somewhat equivalent to (1), but instead of needing to wrap the channel, we just proxy directly to
+// calling the sync.Once.
+// 3) Make the channel multi-use. Instead of the contract being "close when ready", have it be "send a value when ready".
+func (f *FDv2) closeChannelWrapper(ctx context.Context, closeWhenReady chan struct{}) chan struct{} {
+	ch := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ch:
+			f.readyOnce.Do(func() {
+				close(closeWhenReady)
+			})
+		}
+	}()
+	return ch
+}
+
 func (f *FDv2) runSynchronizers(ctx context.Context, closeWhenReady chan struct{}) {
-	// If the SDK was configured with no synchronizer, then (assuming no initializer succeeded), we should
-	// trigger the ready signal to let the call to MakeClient unblock immediately.
+	// If the SDK was configured with no synchronizer, then (assuming no initializer succeeded, which would have
+	// already closed the channel), we should close it now so that MakeClient unblocks.
 	if f.primarySync == nil {
 		f.readyOnce.Do(func() {
 			close(closeWhenReady)
@@ -240,30 +274,10 @@ func (f *FDv2) runSynchronizers(ctx context.Context, closeWhenReady chan struct{
 		return
 	}
 
-	// We can't pass closeWhenReady to the data source, because it might have already been closed.
-	// Instead, create a "proxy" channel just for the data source; if that is closed, we close the real one
-	// using the sync.Once.
-	ready := make(chan struct{})
-
-	// This doesn't work because the channel is still closed and when we flip flop, we might close again.
-	// Either change this to putting something in the channel, or figure out a better way to signal "ready".
-	f.launchTask(func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ready:
-				f.readyOnce.Do(func() {
-					close(closeWhenReady)
-				})
-			}
-		}
-	})
-
 	f.launchTask(func() {
 		for {
 			f.loggers.Debugf("Primary synchronizer %s is starting", f.primarySync.Name())
-			f.primarySync.Sync(ready, f.store.Selector())
+			f.primarySync.Sync(f.closeChannelWrapper(ctx, closeWhenReady), f.store.Selector())
 			if err := f.evaluateCond(ctx, f.fallbackCond); errors.Is(err, context.Canceled) {
 				return
 			}
@@ -275,7 +289,7 @@ func (f *FDv2) runSynchronizers(ctx context.Context, closeWhenReady chan struct{
 
 			f.UpdateStatus(interfaces.DataSourceStateInterrupted, interfaces.DataSourceErrorInfo{})
 
-			f.secondarySync.Sync(ready, f.store.Selector())
+			f.secondarySync.Sync(f.closeChannelWrapper(ctx, closeWhenReady), f.store.Selector())
 			if err := f.evaluateCond(ctx, f.recoveryCond); errors.Is(err, context.Canceled) {
 				return
 			}


### PR DESCRIPTION
This PR attempts to demonstrate how fallback/recovery conditions might be implemented in FDv2.

The main idea is that the SDK can fallback to a secondary synchronizer, and then recover to the primary synchronizer at a later date.

Some challenges I've identified when implementing this PR:
1. Conditions require accurate status information to be evaluated correctly. For example, a condition that executes "when the data source is interrupted for 5 seconds" needs to know that the status is "interrupted" and that it has been interrupted for 5 seconds. So these need to be accessible to the condition, and it's important they be set correctly. 
2. We'll need some way of specifying the conditions in our configuration system. We can start off with simple conditions like:   `fallback { unhealthy_duration: duration } / recover { healthy_duration: duration, unhealthy_duration: duration}`, and specify some reasonable defaults. 
3. The current data sources aren't setup for being restarted. That is, they expect to be started and then closed - they aren't designed specifically to have `Sync(..)` called multiple times. This means we can't be sure they are safe for the current way I'm using them in the PR. 
    - A better design would be having a `Run(ctx context.Context, selector)` method that is synchronous from the perspective of the Data System algorithm. When the function returns, we know for sure that the data source is closed. Then we can simply call `Run` again. Another option is to keep the existing `Sync/Close` pattern, but make sure it is safe for multiple usage (that is, once `Close` is called, it is safe to call `Sync` again.)

4. The existing pattern of `closeWhenReady` channel is difficult to use in a world with > 1 data source (and ones that can be restarted.) I've added some thoughts about that in the code comments.