### PR TITLE
chore: Drop v6 support for go version bump

### DIFF
--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        branch: ["v6", "v7"]
+        branch: ["v7"]
       fail-fast: false
     env:
       officialLatestVersion: ${{ needs.check-go-eol.outputs.latest }}


### PR DESCRIPTION
v6 reached EOL on 2024-10-11
