### PR TITLE
chore: Remove data storage out of initializers and synchronizers

### DIFF
--- a/internal/datasourcev2/fdv1_polling_data_source.go
+++ b/internal/datasourcev2/fdv1_polling_data_source.go
@@ -80,12 +80,11 @@ func (r *fdv1ToFDv2Requester) FilterKey() string {
 // NewFDv1PollingProcessor creates the internal implementation of the polling data source.
 func NewFDv1PollingProcessor(
 	context subsystems.ClientContext,
-	dataDestination subsystems.DataDestination,
 	cfg datasource.PollingConfig,
 ) *PollingProcessor {
 	requester := &fdv1ToFDv2Requester{
 		requester: datasource.NewPollingRequester(context, context.GetHTTP().CreateHTTPClient(), cfg.BaseURI, cfg.FilterKey),
 		loggers:   context.GetLogging().Loggers,
 	}
-	return newPollingProcessor(context, dataDestination, requester, cfg.PollInterval)
+	return newPollingProcessor(context, requester, cfg.PollInterval)
 }

--- a/internal/datasourcev2/polling_data_source.go
+++ b/internal/datasourcev2/polling_data_source.go
@@ -30,38 +30,32 @@ type PollingRequester interface {
 // configuration. All other code outside of this package should interact with it only via the
 // DataSource interface.
 type PollingProcessor struct {
-	dataDestination subsystems.DataDestination
-	requester       PollingRequester
-	pollInterval    time.Duration
-	loggers         ldlog.Loggers
-	isInitialized   atomic.Bool
-	isClosed        atomic.Bool
-	quit            chan struct{}
+	requester    PollingRequester
+	pollInterval time.Duration
+	loggers      ldlog.Loggers
+	isClosed     atomic.Bool
+	quit         chan struct{}
 }
 
 // NewPollingProcessor creates the internal implementation of the polling data source.
 func NewPollingProcessor(
 	context subsystems.ClientContext,
-	dataDestination subsystems.DataDestination,
 	cfg datasource.PollingConfig,
 ) *PollingProcessor {
 	httpRequester := newPollingRequester(context, context.GetHTTP().CreateHTTPClient(), cfg.BaseURI, cfg.FilterKey)
-	return newPollingProcessor(context, dataDestination, httpRequester, cfg.PollInterval)
+	return newPollingProcessor(context, httpRequester, cfg.PollInterval)
 }
 
 func newPollingProcessor(
 	context subsystems.ClientContext,
-	dataDestination subsystems.DataDestination,
 	requester PollingRequester,
 	pollInterval time.Duration,
 ) *PollingProcessor {
 	pp := &PollingProcessor{
-		dataDestination: dataDestination,
-		requester:       requester,
-		pollInterval:    pollInterval,
-		loggers:         context.GetLogging().Loggers,
-		quit:            make(chan struct{}),
-		isInitialized:   atomic.Bool{},
+		requester:    requester,
+		pollInterval: pollInterval,
+		loggers:      context.GetLogging().Loggers,
+		quit:         make(chan struct{}),
 	}
 	return pp
 }
@@ -72,23 +66,23 @@ func (pp *PollingProcessor) Name() string {
 }
 
 //nolint:revive // DataInitializer method.
-func (pp *PollingProcessor) Fetch(ctx context.Context) (*subsystems.Basis, error) {
-	changeSet, err := pp.requester.Request(ctx, pp.dataDestination.Selector())
+func (pp *PollingProcessor) Fetch(ds subsystems.DataSelector, ctx context.Context) (*subsystems.Basis, error) {
+	changeSet, err := pp.requester.Request(ctx, ds.Selector())
 	if err != nil {
 		return nil, err
 	}
-	return &subsystems.Basis{Events: changeSet.Changes(), Selector: changeSet.Selector(), Persist: true}, nil
+	return &subsystems.Basis{ChangeSet: *changeSet, Persist: true}, nil
 }
 
 //nolint:revive // DataSynchronizer method.
-func (pp *PollingProcessor) Sync() <-chan interfaces.DataSynchronizerStatus {
-	statusChan := make(chan interfaces.DataSynchronizerStatus)
+func (pp *PollingProcessor) Sync(ds subsystems.DataSelector) <-chan subsystems.DataSynchronizerResult {
+	resultChan := make(chan subsystems.DataSynchronizerResult)
 	pp.loggers.Infof("Starting LaunchDarkly polling with interval: %+v", pp.pollInterval)
 
 	if pp.isClosed.Load() {
 		pp.loggers.Warnf("Polling processor is already closed, not starting polling")
-		close(statusChan)
-		return statusChan
+		close(resultChan)
+		return resultChan
 	}
 
 	// This process has a shared method serving both as an initializer and a synchronizer.
@@ -106,10 +100,10 @@ func (pp *PollingProcessor) Sync() <-chan interfaces.DataSynchronizerStatus {
 		for {
 			select {
 			case <-pp.quit:
-				close(statusChan)
+				close(resultChan)
 				return
 			case <-ticker.C:
-				if err := pp.poll(ctx, statusChan); err != nil {
+				if err := pp.poll(ctx, ds, resultChan); err != nil {
 					if hse, ok := err.(httpStatusError); ok {
 						errorInfo := interfaces.DataSourceErrorInfo{
 							Kind:       interfaces.DataSourceErrorKindErrorResponse,
@@ -118,7 +112,7 @@ func (pp *PollingProcessor) Sync() <-chan interfaces.DataSynchronizerStatus {
 						}
 
 						if hse.Header.Get("X-LD-FD-Fallback") == "true" {
-							statusChan <- interfaces.DataSynchronizerStatus{
+							resultChan <- subsystems.DataSynchronizerResult{
 								State:        interfaces.DataSourceStateOff,
 								Error:        errorInfo,
 								RevertToFDv1: true,
@@ -134,12 +128,12 @@ func (pp *PollingProcessor) Sync() <-chan interfaces.DataSynchronizerStatus {
 							pollingWillRetryMessage,
 						)
 						if recoverable {
-							statusChan <- interfaces.DataSynchronizerStatus{
+							resultChan <- subsystems.DataSynchronizerResult{
 								State: interfaces.DataSourceStateInterrupted,
 								Error: errorInfo,
 							}
 						} else {
-							statusChan <- interfaces.DataSynchronizerStatus{
+							resultChan <- subsystems.DataSynchronizerResult{
 								State: interfaces.DataSourceStateOff,
 								Error: errorInfo,
 							}
@@ -155,7 +149,7 @@ func (pp *PollingProcessor) Sync() <-chan interfaces.DataSynchronizerStatus {
 							errorInfo.Kind = interfaces.DataSourceErrorKindInvalidData
 						}
 						checkIfErrorIsRecoverableAndLog(pp.loggers, err.Error(), pollingErrorContext, 0, pollingWillRetryMessage)
-						statusChan <- interfaces.DataSynchronizerStatus{
+						resultChan <- subsystems.DataSynchronizerResult{
 							State: interfaces.DataSourceStateInterrupted,
 							Error: errorInfo,
 						}
@@ -166,32 +160,20 @@ func (pp *PollingProcessor) Sync() <-chan interfaces.DataSynchronizerStatus {
 		}
 	}()
 
-	return statusChan
+	return resultChan
 }
 
-func (pp *PollingProcessor) poll(ctx context.Context, statusChan chan<- interfaces.DataSynchronizerStatus) error {
-	changeSet, err := pp.requester.Request(ctx, pp.dataDestination.Selector())
+func (pp *PollingProcessor) poll(
+	ctx context.Context, ds subsystems.DataSelector, resultChan chan<- subsystems.DataSynchronizerResult,
+) error {
+	changeSet, err := pp.requester.Request(ctx, ds.Selector())
 	if err != nil {
 		return err
 	}
 
-	code := changeSet.IntentCode()
-	switch code {
-	case subsystems.IntentTransferFull:
-		pp.dataDestination.SetBasis(changeSet.Changes(), changeSet.Selector(), true)
-	case subsystems.IntentTransferChanges:
-		pp.dataDestination.ApplyDelta(changeSet.Changes(), changeSet.Selector(), true)
-	case subsystems.IntentNone:
-		// no-op, we are already up-to-date
-	default:
-		// this should never happen but we don't want to actually call this
-		// valid if it does.
-		return nil
-	}
-
-	pp.isInitialized.CompareAndSwap(false, true)
-	statusChan <- interfaces.DataSynchronizerStatus{
-		State: interfaces.DataSourceStateValid,
+	resultChan <- subsystems.DataSynchronizerResult{
+		ChangeSet: changeSet,
+		State:     interfaces.DataSourceStateValid,
 	}
 
 	return nil
@@ -203,11 +185,6 @@ func (pp *PollingProcessor) Close() error {
 		close(pp.quit)
 	}
 	return nil
-}
-
-//nolint:revive // no doc comment for standard method
-func (pp *PollingProcessor) IsInitialized() bool {
-	return pp.isInitialized.Load()
 }
 
 // GetBaseURI returns the configured polling base URI, for testing.

--- a/internal/datasourcev2/polling_data_source_test.go
+++ b/internal/datasourcev2/polling_data_source_test.go
@@ -170,7 +170,7 @@ func TestPollingProcessorSynchronizerClosingClosesResultChan(t *testing.T) {
 	ds := mocks.NewMockDataSelector(subsystems.NoSelector())
 	data := ldservicesv2.NewServerSDKData().Flags(alwaysTrueFlag).ToInitializerPayload()
 
-	handler, _ := httphelpers.RecordingHandler(ldservices.ServerSidePollingV2ServiceHandler(data))
+	handler, requestCh := httphelpers.RecordingHandler(ldservices.ServerSidePollingV2ServiceHandler(data))
 	httphelpers.WithServer(handler, func(ts *httptest.Server) {
 		processor := NewPollingProcessor(
 			sharedtest.BasicClientContext(),
@@ -181,6 +181,8 @@ func TestPollingProcessorSynchronizerClosingClosesResultChan(t *testing.T) {
 		)
 
 		resultChan := processor.Sync(ds)
+		<-requestCh  // Wait for the request to be made
+		<-resultChan // Discard the first result
 		processor.Close()
 
 		th.AssertChannelClosed(t, resultChan, time.Second, "starting a closed processor should not yield results")

--- a/internal/datasourcev2/polling_data_source_test.go
+++ b/internal/datasourcev2/polling_data_source_test.go
@@ -3,17 +3,18 @@ package datasourcev2
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
 	th "github.com/launchdarkly/go-test-helpers/v3"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldbuilders"
 	"github.com/launchdarkly/go-server-sdk/v7/internal/datasource"
-	"github.com/launchdarkly/go-server-sdk/v7/internal/datastore"
 	"github.com/launchdarkly/go-server-sdk/v7/internal/sharedtest"
 	"github.com/launchdarkly/go-server-sdk/v7/internal/sharedtest/mocks"
 	"github.com/launchdarkly/go-server-sdk/v7/testhelpers/ldservices"
@@ -22,108 +23,244 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var (
-	alwaysTrueFlag = ldbuilders.NewFlagBuilder("always-true-flag").SingleVariation(ldvalue.Bool(true)).Build()
-)
+var alwaysTrueFlag = ldbuilders.NewFlagBuilder("always-true-flag").SingleVariation(ldvalue.Bool(true)).Build()
 
-func TestPolllingProcessorAsInitializer(t *testing.T) {
-	dd := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
+func TestPollingProcessorInitializerCanMakeSuccessfulRequest(t *testing.T) {
+	ds := mocks.NewMockDataSelector(subsystems.NoSelector())
 	data := ldservicesv2.NewServerSDKData().Flags(alwaysTrueFlag).ToInitializerPayload()
 
-	t.Run("successful fetch does not change initialization status", func(t *testing.T) {
-		handler, requestsCh := httphelpers.RecordingHandler(ldservices.ServerSidePollingV2ServiceHandler(data))
-		httphelpers.WithServer(handler, func(ts *httptest.Server) {
-			processor := NewPollingProcessor(
-				sharedtest.BasicClientContext(),
-				dd,
-				datasource.PollingConfig{
-					BaseURI:      ts.URL,
-					PollInterval: time.Minute * 30,
-				},
-			)
-			basis, err := processor.Fetch(context.Background())
-			assert.NoError(t, err)
-			assert.Len(t, basis.Events, 1)
+	handler, requestsCh := httphelpers.RecordingHandler(ldservices.ServerSidePollingV2ServiceHandler(data))
+	httphelpers.WithServer(handler, func(ts *httptest.Server) {
+		processor := NewPollingProcessor(
+			sharedtest.BasicClientContext(),
+			datasource.PollingConfig{
+				BaseURI:      ts.URL,
+				PollInterval: time.Minute * 30,
+			},
+		)
+		defer processor.Close()
 
-			// Acting as an initializer does not actually affect the initialization
-			// status of the processor as a whole.
-			assert.False(t, processor.IsInitialized())
+		basis, err := processor.Fetch(ds, context.Background())
+		assert.NoError(t, err)
+		assert.Len(t, basis.ChangeSet.Changes(), 1)
+		assert.Equal(t, basis.ChangeSet.IntentCode(), subsystems.IntentTransferFull)
 
-			r := <-requestsCh
-			assert.Equal(t, "/sdk/poll", r.Request.URL.Path)
-		})
-	})
-
-	t.Run("appends filter parameter", func(t *testing.T) {
-		handler, requestsCh := httphelpers.RecordingHandler(ldservices.ServerSidePollingV2ServiceHandler(data))
-		httphelpers.WithServer(handler, func(ts *httptest.Server) {
-			processor := NewPollingProcessor(
-				sharedtest.BasicClientContext(),
-				dd,
-				datasource.PollingConfig{
-					BaseURI:      ts.URL,
-					FilterKey:    "filter-value",
-					PollInterval: time.Minute * 30,
-				},
-			)
-			_, err := processor.Fetch(context.Background())
-			assert.NoError(t, err)
-
-			r := <-requestsCh
-			assert.Equal(t, "/sdk/poll", r.Request.URL.Path)
-			assert.Equal(t, "filter-value", r.Request.URL.Query().Get("filter"))
-		})
+		r := <-requestsCh
+		assert.Equal(t, "/sdk/poll", r.Request.URL.Path)
 	})
 }
 
-func TestPollingProcessorAsSynchronizer(t *testing.T) {
-	t.Run("pre-closing should shutdown immediately", func(t *testing.T) {
-		dd := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
-		data := ldservicesv2.NewServerSDKData().Flags(alwaysTrueFlag).ToInitializerPayload()
+func TestPollingProcessorInitializerAppendsFilterParameter(t *testing.T) {
+	ds := mocks.NewMockDataSelector(subsystems.NoSelector())
+	data := ldservicesv2.NewServerSDKData().Flags(alwaysTrueFlag).ToInitializerPayload()
 
-		handler, _ := httphelpers.RecordingHandler(ldservices.ServerSidePollingV2ServiceHandler(data))
-		httphelpers.WithServer(handler, func(ts *httptest.Server) {
-			processor := NewPollingProcessor(
-				sharedtest.BasicClientContext(),
-				dd,
-				datasource.PollingConfig{
-					BaseURI:      ts.URL,
-					PollInterval: time.Minute * 30,
-				},
-			)
-			processor.Close()
+	handler, requestsCh := httphelpers.RecordingHandler(ldservices.ServerSidePollingV2ServiceHandler(data))
+	httphelpers.WithServer(handler, func(ts *httptest.Server) {
+		processor := NewPollingProcessor(
+			sharedtest.BasicClientContext(),
+			datasource.PollingConfig{
+				BaseURI:      ts.URL,
+				FilterKey:    "filter-value",
+				PollInterval: time.Minute * 30,
+			},
+		)
+		defer processor.Close()
+		_, err := processor.Fetch(ds, context.Background())
+		assert.NoError(t, err)
 
-			statusChan := processor.Sync()
-			th.AssertChannelClosed(t, statusChan, time.Second, "starting a closed processor should not yield results")
-		})
+		r := <-requestsCh
+		assert.Equal(t, "/sdk/poll", r.Request.URL.Path)
+		assert.Equal(t, "filter-value", r.Request.URL.Query().Get("filter"))
 	})
+}
 
-	t.Run("syncing should set initialization", func(t *testing.T) {
-		dd := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
-		data := ldservicesv2.NewServerSDKData().Flags(alwaysTrueFlag).ToInitializerPayload()
+func TestPollingProcessorInitializerAppendsBasisParameter(t *testing.T) {
+	data := ldservicesv2.NewServerSDKData().Flags(alwaysTrueFlag).ToInitializerPayload()
+	handler, requestsCh := httphelpers.RecordingHandler(ldservices.ServerSidePollingV2ServiceHandler(data))
+	httphelpers.WithServer(handler, func(ts *httptest.Server) {
+		processor := NewPollingProcessor(
+			sharedtest.BasicClientContext(),
+			datasource.PollingConfig{
+				BaseURI:      ts.URL,
+				PollInterval: time.Minute * 30,
+			},
+		)
+		defer processor.Close()
 
-		handler, _ := httphelpers.RecordingHandler(ldservices.ServerSidePollingV2ServiceHandler(data))
-		httphelpers.WithServer(handler, func(ts *httptest.Server) {
-			processor := NewPollingProcessor(
-				sharedtest.BasicClientContext(),
-				dd,
-				datasource.PollingConfig{
-					BaseURI:      ts.URL,
-					PollInterval: time.Minute * 30,
-				},
-			)
+		ds := mocks.NewMockDataSelector(subsystems.NewSelector("test-state", 1))
+		_, err := processor.Fetch(ds, context.Background())
+		assert.NoError(t, err)
 
-			statusChan := processor.Sync()
-			result := <-statusChan
-
-			assert.Equal(t, result.State, interfaces.DataSourceStateValid)
-			assert.True(t, processor.IsInitialized())
-		})
+		r := <-requestsCh
+		assert.Equal(t, "/sdk/poll", r.Request.URL.Path)
+		assert.Equal(t, "test-state", r.Request.URL.Query().Get("basis"))
 	})
+}
 
+func TestPollingProcessorSynchronizerAppendsFilterParameter(t *testing.T) {
+	ds := mocks.NewMockDataSelector(subsystems.NoSelector())
+	data := ldservicesv2.NewServerSDKData().Flags(alwaysTrueFlag).ToInitializerPayload()
+
+	handler, requestsCh := httphelpers.RecordingHandler(ldservices.ServerSidePollingV2ServiceHandler(data))
+	httphelpers.WithServer(handler, func(ts *httptest.Server) {
+		processor := NewPollingProcessor(
+			sharedtest.BasicClientContext(),
+			datasource.PollingConfig{
+				BaseURI:      ts.URL,
+				FilterKey:    "filter-value",
+				PollInterval: time.Minute * 30,
+			},
+		)
+		defer processor.Close()
+
+		_, err := processor.Fetch(ds, context.Background())
+		assert.NoError(t, err)
+
+		r := <-requestsCh
+		assert.Equal(t, "/sdk/poll", r.Request.URL.Path)
+		assert.Equal(t, "filter-value", r.Request.URL.Query().Get("filter"))
+	})
+}
+
+func TestPollingProcessorSynchronizerAppendsBasisParameter(t *testing.T) {
+	ds := mocks.NewMockDataSelector(subsystems.NewSelector("test-state", 1))
+	data := ldservicesv2.NewServerSDKData().Flags(alwaysTrueFlag).ToInitializerPayload()
+
+	handler, requestsCh := httphelpers.RecordingHandler(ldservices.ServerSidePollingV2ServiceHandler(data))
+	httphelpers.WithServer(handler, func(ts *httptest.Server) {
+		processor := NewPollingProcessor(
+			sharedtest.BasicClientContext(),
+			datasource.PollingConfig{
+				BaseURI:      ts.URL,
+				FilterKey:    "filter-value",
+				PollInterval: time.Minute * 30,
+			},
+		)
+		defer processor.Close()
+
+		_ = processor.Sync(ds)
+
+		r := <-requestsCh
+		assert.Equal(t, "/sdk/poll", r.Request.URL.Path)
+		assert.Equal(t, "test-state", r.Request.URL.Query().Get("basis"))
+	})
+}
+
+func TestPollingProcessorSynchronizerPreClosingShouldShutdownImmediately(t *testing.T) {
+	ds := mocks.NewMockDataSelector(subsystems.NoSelector())
+	data := ldservicesv2.NewServerSDKData().Flags(alwaysTrueFlag).ToInitializerPayload()
+
+	handler, _ := httphelpers.RecordingHandler(ldservices.ServerSidePollingV2ServiceHandler(data))
+	httphelpers.WithServer(handler, func(ts *httptest.Server) {
+		processor := NewPollingProcessor(
+			sharedtest.BasicClientContext(),
+			datasource.PollingConfig{
+				BaseURI:      ts.URL,
+				PollInterval: time.Minute * 30,
+			},
+		)
+		processor.Close()
+
+		resultChan := processor.Sync(ds)
+		th.AssertChannelClosed(t, resultChan, time.Second, "starting a closed processor should not yield results")
+	})
+}
+
+func TestPollingProcessorSynchronizerClosingClosesResultChan(t *testing.T) {
+	ds := mocks.NewMockDataSelector(subsystems.NoSelector())
+	data := ldservicesv2.NewServerSDKData().Flags(alwaysTrueFlag).ToInitializerPayload()
+
+	handler, _ := httphelpers.RecordingHandler(ldservices.ServerSidePollingV2ServiceHandler(data))
+	httphelpers.WithServer(handler, func(ts *httptest.Server) {
+		processor := NewPollingProcessor(
+			sharedtest.BasicClientContext(),
+			datasource.PollingConfig{
+				BaseURI:      ts.URL,
+				PollInterval: time.Minute * 30,
+			},
+		)
+
+		resultChan := processor.Sync(ds)
+		processor.Close()
+
+		th.AssertChannelClosed(t, resultChan, time.Second, "starting a closed processor should not yield results")
+	})
+}
+
+func TestPollingProcessorSynchronizerCanMakeSuccessfulRequest(t *testing.T) {
+	ds := mocks.NewMockDataSelector(subsystems.NoSelector())
+	data := ldservicesv2.NewServerSDKData().Flags(alwaysTrueFlag).ToInitializerPayload()
+
+	handler, _ := httphelpers.RecordingHandler(ldservices.ServerSidePollingV2ServiceHandler(data))
+	httphelpers.WithServer(handler, func(ts *httptest.Server) {
+		processor := NewPollingProcessor(
+			sharedtest.BasicClientContext(),
+			datasource.PollingConfig{
+				BaseURI:      ts.URL,
+				PollInterval: time.Minute * 30,
+			},
+		)
+		defer processor.Close()
+
+		resultChan := processor.Sync(ds)
+		result := <-resultChan
+
+		assert.Equal(t, result.State, interfaces.DataSourceStateValid)
+	})
+}
+
+func TestPollingProcessorSynchronizerHandlesInvalidJSON(t *testing.T) {
+	ds := mocks.NewMockDataSelector(subsystems.NoSelector())
+
+	handler, _ := httphelpers.RecordingHandler(httphelpers.HandlerWithResponse(200, nil, []byte("invalid json")))
+	httphelpers.WithServer(handler, func(ts *httptest.Server) {
+		processor := NewPollingProcessor(
+			sharedtest.BasicClientContext(),
+			datasource.PollingConfig{
+				BaseURI:      ts.URL,
+				PollInterval: time.Minute * 30,
+			},
+		)
+		defer processor.Close()
+
+		resultChan := processor.Sync(ds)
+		result := <-resultChan
+
+		assert.Equal(t, result.State, interfaces.DataSourceStateInterrupted)
+		assert.Equal(t, result.Error.Kind, interfaces.DataSourceErrorKindInvalidData)
+	})
+}
+
+func TestPollingProcessorSynchronizerHandlesFallbackToFDv2(t *testing.T) {
+	ds := mocks.NewMockDataSelector(subsystems.NoSelector())
+
+	header := http.Header{
+		"X-LD-FD-Fallback": []string{"true"},
+	}
+	handler, _ := httphelpers.RecordingHandler(httphelpers.HandlerWithResponse(500, header, nil))
+	httphelpers.WithServer(handler, func(ts *httptest.Server) {
+		processor := NewPollingProcessor(
+			sharedtest.BasicClientContext(),
+			datasource.PollingConfig{
+				BaseURI:      ts.URL,
+				PollInterval: time.Minute * 30,
+			},
+		)
+		defer processor.Close()
+
+		resultChan := processor.Sync(ds)
+		result := <-resultChan
+
+		assert.Equal(t, result.State, interfaces.DataSourceStateOff)
+		assert.Equal(t, result.Error.Kind, interfaces.DataSourceErrorKindErrorResponse)
+		assert.True(t, result.RevertToFDv1)
+	})
+}
+
+func TestPollingProcessorSynchronizerHandlesRecoverableErrors(t *testing.T) {
 	for _, statusCode := range []int{400, 408, 429, 500, 503} {
 		t.Run(fmt.Sprintf("handles recoverable error %d", statusCode), func(t *testing.T) {
-			dd := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
+			ds := mocks.NewMockDataSelector(subsystems.NoSelector())
 			data := ldservicesv2.NewServerSDKData().Flags(alwaysTrueFlag).ToInitializerPayload()
 
 			handler, requestsCh := httphelpers.RecordingHandler(
@@ -135,78 +272,55 @@ func TestPollingProcessorAsSynchronizer(t *testing.T) {
 			httphelpers.WithServer(handler, func(ts *httptest.Server) {
 				processor := NewPollingProcessor(
 					sharedtest.BasicClientContext(),
-					dd,
 					datasource.PollingConfig{
 						BaseURI:      ts.URL,
 						PollInterval: time.Millisecond,
 					},
 				)
-				statusChan := processor.Sync()
+				defer processor.Close()
+
+				resultChan := processor.Sync(ds)
 
 				<-requestsCh
-				result := <-statusChan
+				result := <-resultChan
 				assert.Equal(t, interfaces.DataSourceStateInterrupted, result.State)
-				assert.False(t, processor.IsInitialized())
 
 				<-requestsCh
-				result = <-statusChan
+				result = <-resultChan
 				assert.Equal(t, interfaces.DataSourceStateValid, result.State)
-				assert.True(t, processor.IsInitialized())
+				assert.Len(t, result.ChangeSet.Changes(), 1)
 			})
 		})
 	}
+}
 
+func TestPollingProcessorSynchronizerHandlesUnrecoverableErrors(t *testing.T) {
 	for _, statusCode := range []int{401, 403, 404, 405} {
 		t.Run(fmt.Sprintf("handles unrecoverable error %d", statusCode), func(t *testing.T) {
-			dd := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
+			ds := mocks.NewMockDataSelector(subsystems.NoSelector())
 
 			handler, requestsCh := httphelpers.RecordingHandler(httphelpers.HandlerWithStatus(statusCode))
 			httphelpers.WithServer(handler, func(ts *httptest.Server) {
 				processor := NewPollingProcessor(
 					sharedtest.BasicClientContext(),
-					dd,
 					datasource.PollingConfig{
 						BaseURI:      ts.URL,
 						PollInterval: time.Minute * 30,
 					},
 				)
-				statusChan := processor.Sync()
+				defer processor.Close()
+
+				resultChan := processor.Sync(ds)
 
 				<-requestsCh
-				result := <-statusChan
+				result := <-resultChan
 
 				assert.Equal(t, interfaces.DataSourceStateOff, result.State)
 				_ = func(errorInfo interfaces.DataSourceErrorInfo) {
 					assert.Equal(t, interfaces.DataSourceErrorKindErrorResponse, errorInfo.Kind)
 					assert.Equal(t, statusCode, errorInfo.StatusCode)
 				}
-
-				assert.False(t, processor.IsInitialized())
 			})
 		})
 	}
-
-	t.Run("appends filter parameter", func(t *testing.T) {
-		dd := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
-		data := ldservicesv2.NewServerSDKData().Flags(alwaysTrueFlag).ToInitializerPayload()
-
-		handler, requestsCh := httphelpers.RecordingHandler(ldservices.ServerSidePollingV2ServiceHandler(data))
-		httphelpers.WithServer(handler, func(ts *httptest.Server) {
-			processor := NewPollingProcessor(
-				sharedtest.BasicClientContext(),
-				dd,
-				datasource.PollingConfig{
-					BaseURI:      ts.URL,
-					FilterKey:    "filter-value",
-					PollInterval: time.Minute * 30,
-				},
-			)
-			_, err := processor.Fetch(context.Background())
-			assert.NoError(t, err)
-
-			r := <-requestsCh
-			assert.Equal(t, "/sdk/poll", r.Request.URL.Path)
-			assert.Equal(t, "filter-value", r.Request.URL.Query().Get("filter"))
-		})
-	})
 }

--- a/internal/datasourcev2/streaming_data_source.go
+++ b/internal/datasourcev2/streaming_data_source.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	es "github.com/launchdarkly/eventsource"
@@ -64,30 +65,26 @@ const (
 // DataSource interface.
 type StreamProcessor struct {
 	cfg                        datasource.StreamConfig
-	dataDestination            subsystems.DataDestination
 	client                     *http.Client
 	headers                    http.Header
 	diagnosticsManager         *ldevents.DiagnosticsManager
 	loggers                    ldlog.Loggers
-	isInitialized              internal.AtomicBoolean
-	halt                       chan struct{}
 	connectionAttemptStartTime ldtime.UnixMillisecondTime
 	connectionAttemptLock      sync.Mutex
-	closeOnce                  sync.Once
+	isClosed                   atomic.Bool
+	halt                       chan struct{}
 }
 
 // NewStreamProcessor creates the internal implementation of the streaming data source.
 func NewStreamProcessor(
 	context subsystems.ClientContext,
-	dataDestination subsystems.DataDestination,
 	cfg datasource.StreamConfig,
 ) *StreamProcessor {
 	sp := &StreamProcessor{
-		dataDestination: dataDestination,
-		headers:         context.GetHTTP().DefaultHeaders,
-		loggers:         context.GetLogging().Loggers,
-		halt:            make(chan struct{}),
-		cfg:             cfg,
+		headers: context.GetHTTP().DefaultHeaders,
+		loggers: context.GetLogging().Loggers,
+		halt:    make(chan struct{}),
+		cfg:     cfg,
 	}
 	if cci, ok := context.(*internal.ClientContextImpl); ok {
 		sp.diagnosticsManager = cci.DiagnosticsManager
@@ -109,26 +106,27 @@ func (sp *StreamProcessor) Name() string {
 }
 
 //nolint:revive // DataInitializer method.
-func (sp *StreamProcessor) Fetch(_ context.Context) (*subsystems.Basis, error) {
+func (sp *StreamProcessor) Fetch(ds subsystems.DataSelector, _ context.Context) (*subsystems.Basis, error) {
 	return nil, errors.New("StreamProcessor does not implement Fetch capability")
 }
 
-//nolint:revive // no doc comment for standard method
-func (sp *StreamProcessor) IsInitialized() bool {
-	return sp.isInitialized.Get()
-}
-
 //nolint:revive // DataSynchronizer method.
-func (sp *StreamProcessor) Sync() <-chan interfaces.DataSynchronizerStatus {
-	sp.loggers.Info("Starting LaunchDarkly streaming connection")
-	statusChan := make(chan interfaces.DataSynchronizerStatus, 100)
-	go sp.subscribe(statusChan)
+func (sp *StreamProcessor) Sync(ds subsystems.DataSelector) <-chan subsystems.DataSynchronizerResult {
+	resultChan := make(chan subsystems.DataSynchronizerResult, 100)
 
-	return statusChan
+	if sp.isClosed.Load() {
+		sp.loggers.Warnf("Streaming processor is already closed, not starting streaming")
+		close(resultChan)
+		return resultChan
+	}
+
+	sp.loggers.Info("Starting LaunchDarkly streaming connection")
+	go sp.subscribe(ds, resultChan)
+
+	return resultChan
 }
 
-//nolint:gocyclo
-func (sp *StreamProcessor) consumeStream(stream *es.Stream, statusChan chan<- interfaces.DataSynchronizerStatus) {
+func (sp *StreamProcessor) consumeStream(stream *es.Stream, resultChan chan<- subsystems.DataSynchronizerResult) {
 	// Consume remaining Events and Errors so we can garbage collect
 	defer func() {
 		for range stream.Events {
@@ -145,7 +143,7 @@ func (sp *StreamProcessor) consumeStream(stream *es.Stream, statusChan chan<- in
 		select {
 		case event, ok := <-stream.Events:
 			if !ok {
-				close(statusChan)
+				close(resultChan)
 				// COVERAGE: stream.Events is only closed if the EventSource has been closed. However, that
 				// only happens when we have received from sp.halt, in which case we return immediately
 				// after calling stream.Close(), terminating the for loop-- so we should not actually reach
@@ -180,7 +178,7 @@ func (sp *StreamProcessor) consumeStream(stream *es.Stream, statusChan chan<- in
 					Message: err.Error(),
 					Time:    time.Now(),
 				}
-				statusChan <- interfaces.DataSynchronizerStatus{
+				resultChan <- subsystems.DataSynchronizerResult{
 					State: interfaces.DataSourceStateInterrupted,
 					Error: errorInfo,
 				}
@@ -213,10 +211,9 @@ func (sp *StreamProcessor) consumeStream(stream *es.Stream, statusChan chan<- in
 						break
 					}
 
-					statusChan <- interfaces.DataSynchronizerStatus{
+					resultChan <- subsystems.DataSynchronizerResult{
 						State: interfaces.DataSourceStateValid,
 					}
-					sp.setInitialized(true)
 					break
 				}
 
@@ -280,24 +277,10 @@ func (sp *StreamProcessor) consumeStream(stream *es.Stream, statusChan chan<- in
 					break
 				}
 
-				code := changeSet.IntentCode()
-				switch code {
-				case subsystems.IntentTransferFull:
-					sp.dataDestination.SetBasis(changeSet.Changes(), changeSet.Selector(), true)
-				case subsystems.IntentTransferChanges:
-					sp.dataDestination.ApplyDelta(changeSet.Changes(), changeSet.Selector(), true)
-				case subsystems.IntentNone:
-					/* We don't expect to receive this, but it could be possible. In that case, it should be
-					equivalent to transferring no changes - a no-op.
-					*/
-				default:
-					continue
+				resultChan <- subsystems.DataSynchronizerResult{
+					ChangeSet: changeSet,
+					State:     interfaces.DataSourceStateValid,
 				}
-
-				statusChan <- interfaces.DataSynchronizerStatus{
-					State: interfaces.DataSourceStateValid,
-				}
-				sp.setInitialized(true)
 
 			default:
 				sp.loggers.Infof("Unexpected event found in stream: %s", event.Event())
@@ -314,7 +297,7 @@ func (sp *StreamProcessor) consumeStream(stream *es.Stream, statusChan chan<- in
 	}
 }
 
-func (sp *StreamProcessor) subscribe(statusChan chan<- interfaces.DataSynchronizerStatus) {
+func (sp *StreamProcessor) subscribe(ds subsystems.DataSelector, resultChan chan<- subsystems.DataSynchronizerResult) {
 	path := endpoints.AddPath(sp.cfg.URI, endpoints.StreamingRequestV2Path)
 	req, reqErr := http.NewRequest("GET", path, nil)
 	if reqErr != nil {
@@ -322,7 +305,7 @@ func (sp *StreamProcessor) subscribe(statusChan chan<- interfaces.DataSynchroniz
 			"Unable to create a stream request; this is not a network problem, most likely a bad base URI: %s",
 			reqErr,
 		)
-		statusChan <- interfaces.DataSynchronizerStatus{
+		resultChan <- subsystems.DataSynchronizerResult{
 			State: interfaces.DataSourceStateOff,
 			Error: interfaces.DataSourceErrorInfo{
 				Kind:    interfaces.DataSourceErrorKindUnknown,
@@ -330,6 +313,7 @@ func (sp *StreamProcessor) subscribe(statusChan chan<- interfaces.DataSynchroniz
 				Time:    time.Now(),
 			},
 		}
+		close(resultChan)
 		sp.logConnectionResult(false)
 		return
 	}
@@ -363,7 +347,7 @@ func (sp *StreamProcessor) subscribe(statusChan chan<- interfaces.DataSynchroniz
 			}
 
 			if se.Header.Get("X-LD-FD-Fallback") == "true" {
-				statusChan <- interfaces.DataSynchronizerStatus{
+				resultChan <- subsystems.DataSynchronizerResult{
 					State:        interfaces.DataSourceStateOff,
 					Error:        errorInfo,
 					RevertToFDv1: true,
@@ -380,13 +364,13 @@ func (sp *StreamProcessor) subscribe(statusChan chan<- interfaces.DataSynchroniz
 			)
 			if recoverable {
 				sp.logConnectionStarted()
-				statusChan <- interfaces.DataSynchronizerStatus{
+				resultChan <- subsystems.DataSynchronizerResult{
 					State: interfaces.DataSourceStateInterrupted,
 					Error: errorInfo,
 				}
 				return es.StreamErrorHandlerResult{CloseNow: false}
 			}
-			statusChan <- interfaces.DataSynchronizerStatus{
+			resultChan <- subsystems.DataSynchronizerResult{
 				State: interfaces.DataSourceStateOff,
 				Error: errorInfo,
 			}
@@ -405,7 +389,7 @@ func (sp *StreamProcessor) subscribe(statusChan chan<- interfaces.DataSynchroniz
 			Message: err.Error(),
 			Time:    time.Now(),
 		}
-		statusChan <- interfaces.DataSynchronizerStatus{
+		resultChan <- subsystems.DataSynchronizerResult{
 			State: interfaces.DataSourceStateInterrupted,
 			Error: errorInfo,
 		}
@@ -415,7 +399,7 @@ func (sp *StreamProcessor) subscribe(statusChan chan<- interfaces.DataSynchroniz
 
 	stream, err := es.SubscribeWithRequestAndOptions(req,
 		es.StreamOptionDynamicQueryParams(func(existing url.Values) url.Values {
-			if selector := sp.dataDestination.Selector(); selector.IsDefined() {
+			if selector := ds.Selector(); selector.IsDefined() {
 				existing.Set("basis", selector.State())
 			}
 
@@ -434,7 +418,7 @@ func (sp *StreamProcessor) subscribe(statusChan chan<- interfaces.DataSynchroniz
 	if err != nil {
 		sp.logConnectionResult(false)
 
-		statusChan <- interfaces.DataSynchronizerStatus{
+		resultChan <- subsystems.DataSynchronizerResult{
 			State: interfaces.DataSourceStateOff,
 			Error: interfaces.DataSourceErrorInfo{
 				Kind:    interfaces.DataSourceErrorKindUnknown,
@@ -442,20 +426,12 @@ func (sp *StreamProcessor) subscribe(statusChan chan<- interfaces.DataSynchroniz
 				Time:    time.Now(),
 			},
 		}
+		close(resultChan)
 
 		return
 	}
 
-	sp.consumeStream(stream, statusChan)
-}
-
-func (sp *StreamProcessor) setInitialized(success bool) {
-	if success {
-		wasAlreadyInitialized := sp.isInitialized.GetAndSet(true)
-		if !wasAlreadyInitialized {
-			sp.loggers.Info("LaunchDarkly streaming is active")
-		}
-	}
+	sp.consumeStream(stream, resultChan)
 }
 
 func (sp *StreamProcessor) logConnectionStarted() {
@@ -478,9 +454,9 @@ func (sp *StreamProcessor) logConnectionResult(success bool) {
 
 //nolint:revive // no doc comment for standard method
 func (sp *StreamProcessor) Close() error {
-	sp.closeOnce.Do(func() {
+	if swapped := sp.isClosed.CompareAndSwap(false, true); swapped {
 		close(sp.halt)
-	})
+	}
 	return nil
 }
 

--- a/internal/datasourcev2/streaming_data_source_test.go
+++ b/internal/datasourcev2/streaming_data_source_test.go
@@ -1,6 +1,7 @@
 package datasourcev2
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -41,58 +42,55 @@ const (
 type streamingTestParams struct {
 	events     chan<- eventsource.Event
 	protocol   *ldservicesv2.StreamingProtocol
-	statusChan <-chan interfaces.DataSynchronizerStatus
+	resultChan <-chan subsystems.DataSynchronizerResult
 	stream     httphelpers.SSEStreamControl
 	requests   <-chan httphelpers.HTTPRequestInfo
 	mockLog    *ldlogtest.MockLog
 }
 
-func PreclosingShouldShutdownImmediately(t *testing.T) {
-	dd := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
-	sp := NewStreamProcessor(
-		sharedtest.BasicClientContext(),
-		dd,
-		datasource.StreamConfig{
-			URI:                   ":/",
-			InitialReconnectDelay: time.Millisecond * 50,
-			FilterKey:             "filter-value",
-		},
-	)
-
-	sp.Close()
-	statusChan := sp.Sync()
-	th.AssertChannelClosed(t, statusChan, time.Second, "starting a closed processor should not yield results")
-}
-
-func TestMalformedStreamBaseURI(t *testing.T) {
-	dd := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
+func TestStreamingDoesNotWorkAsInitializer(t *testing.T) {
+	ds := mocks.NewMockDataSelector(subsystems.NoSelector())
 
 	sp := NewStreamProcessor(
 		sharedtest.BasicClientContext(),
-		dd,
 		datasource.StreamConfig{
-			URI:                   ":/",
+			URI:                   "http://example.com/stream",
 			InitialReconnectDelay: time.Millisecond * 50,
-			FilterKey:             "filter-value",
 		},
 	)
 
 	defer sp.Close()
-	statusChan := sp.Sync()
+	basis, err := sp.Fetch(ds, context.Background())
+	assert.Nil(t, basis)
+	assert.NotNil(t, err)
+}
 
-	result := <-statusChan
+func TestMalformedStreamBaseURI(t *testing.T) {
+	ds := mocks.NewMockDataSelector(subsystems.NoSelector())
+
+	sp := NewStreamProcessor(
+		sharedtest.BasicClientContext(),
+		datasource.StreamConfig{
+			URI:                   ":/",
+			InitialReconnectDelay: time.Millisecond * 50,
+		},
+	)
+
+	defer sp.Close()
+	resultChan := sp.Sync(ds)
+
+	result := <-resultChan
 	assert.Equal(t, interfaces.DataSourceStateOff, result.State)
 	assert.Equal(t, interfaces.DataSourceErrorKindUnknown, result.Error.Kind)
 }
 
 func TestStreamingProcessorAppendsFilterParameter(t *testing.T) {
-	dd := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
+	ds := mocks.NewMockDataSelector(subsystems.NoSelector())
 
 	handler, requestsCh := httphelpers.RecordingHandler(httphelpers.HandlerWithStatus(401)) // we don't care about getting valid stream data
 	httphelpers.WithServer(handler, func(ts *httptest.Server) {
 		sp := NewStreamProcessor(
 			sharedtest.BasicClientContext(),
-			dd,
 			datasource.StreamConfig{
 				URI:                   ts.URL,
 				InitialReconnectDelay: time.Millisecond * 50,
@@ -101,11 +99,132 @@ func TestStreamingProcessorAppendsFilterParameter(t *testing.T) {
 		)
 
 		defer sp.Close()
-		sp.Sync()
+		sp.Sync(ds)
 
 		r := <-requestsCh
 
 		assert.Equal(t, "filter-value", r.Request.URL.Query().Get("filter"))
+	})
+}
+
+func TestStreamingProcessorAppendsBasisParameter(t *testing.T) {
+	ds := mocks.NewMockDataSelector(subsystems.NewSelector("test-state", 1))
+	handler, requestsCh := httphelpers.RecordingHandler(httphelpers.HandlerWithStatus(401)) // we don't care about getting valid stream data
+	httphelpers.WithServer(handler, func(ts *httptest.Server) {
+		sp := NewStreamProcessor(
+			sharedtest.BasicClientContext(),
+			datasource.StreamConfig{
+				URI:                   ts.URL,
+				InitialReconnectDelay: time.Millisecond * 50,
+			},
+		)
+
+		defer sp.Close()
+		sp.Sync(ds)
+
+		r := <-requestsCh
+
+		assert.Equal(t, "test-state", r.Request.URL.Query().Get("basis"))
+	})
+}
+
+func TestStreamingProcessorCanMakeSuccessfulRequest(t *testing.T) {
+	data := ldservicesv2.NewServerSDKData().Flags(alwaysTrueFlag)
+	protocol := ldservicesv2.NewStreamingProtocol().
+		WithIntent(subsystems.ServerIntent{Payload: subsystems.Payload{
+			ID: "something-id", Target: 0, Code: "xfer-full", Reason: "payload-missing",
+		}}).
+		WithPutObjects(data.ToPutObjects()).
+		WithTransferred("updated-state", 2)
+	streamHandler, _ := ldservices.ServerSideStreamingV2ServiceProtocolHandler(protocol)
+
+	ds := mocks.NewMockDataSelector(subsystems.NoSelector())
+	handler, _ := httphelpers.RecordingHandler(streamHandler) // we don't care about getting valid stream data
+	httphelpers.WithServer(handler, func(ts *httptest.Server) {
+		sp := NewStreamProcessor(
+			sharedtest.BasicClientContext(),
+			datasource.StreamConfig{
+				URI:                   ts.URL,
+				InitialReconnectDelay: time.Millisecond * 50,
+			},
+		)
+
+		defer sp.Close()
+		resultChan := sp.Sync(ds)
+		result := <-resultChan
+
+		assert.Equal(t, interfaces.DataSourceStateValid, result.State)
+		assert.NotNil(t, result.ChangeSet)
+		assert.Len(t, result.ChangeSet.Changes(), 1)
+	})
+}
+
+func TestStreamingProcessorHandlesFallbackToFDv1(t *testing.T) {
+	ds := mocks.NewMockDataSelector(subsystems.NoSelector())
+
+	header := http.Header{
+		"X-LD-FD-Fallback": []string{"true"},
+	}
+	handler, _ := httphelpers.RecordingHandler(httphelpers.HandlerWithResponse(500, header, nil))
+	httphelpers.WithServer(handler, func(ts *httptest.Server) {
+		sp := NewStreamProcessor(
+			sharedtest.BasicClientContext(),
+			datasource.StreamConfig{
+				URI:                   ts.URL,
+				InitialReconnectDelay: time.Millisecond * 50,
+			},
+		)
+
+		defer sp.Close()
+		resultChan := sp.Sync(ds)
+		result := <-resultChan
+
+		assert.Equal(t, result.State, interfaces.DataSourceStateOff)
+		assert.Equal(t, result.Error.Kind, interfaces.DataSourceErrorKindErrorResponse)
+		assert.True(t, result.RevertToFDv1)
+	})
+}
+
+func TestStreamingProcessorPreClosingShouldShutdownImmediately(t *testing.T) {
+	ds := mocks.NewMockDataSelector(subsystems.NoSelector())
+	handler, _ := httphelpers.RecordingHandler(httphelpers.HandlerWithStatus(401)) // we don't care about getting valid stream data
+	httphelpers.WithServer(handler, func(ts *httptest.Server) {
+		sp := NewStreamProcessor(
+			sharedtest.BasicClientContext(),
+			datasource.StreamConfig{
+				URI:                   ts.URL,
+				InitialReconnectDelay: time.Millisecond * 50,
+			},
+		)
+
+		sp.Close()
+		resultChan := sp.Sync(ds)
+
+		// Assert the channel is closed
+		th.AssertChannelClosed(t, resultChan, time.Second, "starting a closed processor should not yield results")
+	})
+}
+
+func TestStreamingProcessorClosingClosesResultChan(t *testing.T) {
+	ds := mocks.NewMockDataSelector(subsystems.NoSelector())
+	handler, _ := httphelpers.RecordingHandler(httphelpers.HandlerWithStatus(401)) // we don't care about getting valid stream data
+	httphelpers.WithServer(handler, func(ts *httptest.Server) {
+		sp := NewStreamProcessor(
+			sharedtest.BasicClientContext(),
+			datasource.StreamConfig{
+				URI:                   ts.URL,
+				InitialReconnectDelay: time.Millisecond * 50,
+			},
+		)
+
+		resultChan := sp.Sync(ds)
+		sp.Close()
+
+		<-resultChan // Ignore the first close when the error handler deals with the 401
+		<-resultChan // Ignore the redundant off returned because the SSE client failed to start
+
+		// Assert the channel is closed
+		th.AssertChannelClosed(t, resultChan, time.Second, "starting a closed processor should not yield results")
 	})
 }
 
@@ -118,7 +237,7 @@ func TestStreamingProcessorDoesNotUseConfiguredTimeoutAsReadTimeout(t *testing.T
 		WithTransferred("state", 1)
 	streamHandler, _ := ldservices.ServerSideStreamingV2ServiceProtocolHandler(protocol)
 
-	dd := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
+	ds := mocks.NewMockDataSelector(subsystems.NoSelector())
 
 	handler, requestsCh := httphelpers.RecordingHandler(streamHandler) // we don't care about getting valid stream data
 	httphelpers.WithServer(handler, func(ts *httptest.Server) {
@@ -132,16 +251,14 @@ func TestStreamingProcessorDoesNotUseConfiguredTimeoutAsReadTimeout(t *testing.T
 
 		sp := NewStreamProcessor(
 			context,
-			dd,
 			datasource.StreamConfig{
 				URI:                   ts.URL,
 				InitialReconnectDelay: time.Millisecond * 50,
-				FilterKey:             "filter-value",
 			},
 		)
 
 		defer sp.Close()
-		sp.Sync()
+		sp.Sync(ds)
 
 		<-time.After(500 * time.Millisecond)
 		assert.Equal(t, 1, len(requestsCh))
@@ -175,7 +292,7 @@ func TestStreamProcessorRecoverableErrorsCauseStreamRestart(t *testing.T) {
 			case <-timer.C:
 				assert.Fail(t, "timed out waiting for stream to restart")
 				return
-			case status := <-p.statusChan:
+			case status := <-p.resultChan:
 				if isValid && status.State == interfaces.DataSourceStateInterrupted {
 					isValid = false
 				} else if !isValid && status.State == interfaces.DataSourceStateValid {
@@ -205,7 +322,7 @@ func TestStreamProcessorRecoverableErrorsCauseStreamRestart(t *testing.T) {
 			p.stream.Send(httphelpers.SSEEvent{Event: putEvent, Data: `{"path": "/", "data": }"`})
 			p.stream.EndAll()
 			<-time.After(300 * time.Millisecond)
-			<-p.statusChan
+			<-p.resultChan
 			p.mockLog.AssertMessageMatch(t, true, ldlog.Info, "Unexpected event found in stream")
 		})
 	})
@@ -274,11 +391,10 @@ func runStreamingTest(
 	httphelpers.WithServer(
 		handler,
 		func(streamServer *httptest.Server) {
-			dd := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
+			ds := mocks.NewMockDataSelector(subsystems.NoSelector())
 
 			sp := NewStreamProcessor(
 				context,
-				dd,
 				datasource.StreamConfig{
 					URI:                   streamServer.URL,
 					InitialReconnectDelay: briefDelay,
@@ -286,15 +402,15 @@ func runStreamingTest(
 			)
 			defer sp.Close()
 
-			statusChan := sp.Sync()
+			resultChan := sp.Sync(ds)
 
-			status := <-statusChan
+			status := <-resultChan
 			assert.Equal(t, interfaces.DataSourceStateValid, status.State)
 
 			params := streamingTestParams{
 				events:     events,
 				protocol:   protocol,
-				statusChan: statusChan,
+				resultChan: resultChan,
 				stream:     stream,
 				requests:   requestsCh,
 				mockLog:    mockLog,
@@ -322,7 +438,7 @@ func testStreamProcessorRecoverableHTTPError(t *testing.T, statusCode int) {
 	mockLog := ldlogtest.NewMockLog()
 	defer mockLog.DumpIfTestFailed(t)
 	httphelpers.WithServer(sequentialHandler, func(ts *httptest.Server) {
-		dd := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
+		ds := mocks.NewMockDataSelector(subsystems.NoSelector())
 
 		id := ldevents.NewDiagnosticID(sharedtest.TestSDKKey)
 		diagnosticsManager := ldevents.NewDiagnosticsManager(id, ldvalue.Null(), ldvalue.Null(), time.Now(), nil)
@@ -334,19 +450,19 @@ func testStreamProcessorRecoverableHTTPError(t *testing.T, statusCode int) {
 			DiagnosticsManager: diagnosticsManager,
 		}
 
-		sp := NewStreamProcessor(context, dd, datasource.StreamConfig{URI: ts.URL, InitialReconnectDelay: briefDelay})
+		sp := NewStreamProcessor(context, datasource.StreamConfig{URI: ts.URL, InitialReconnectDelay: briefDelay})
 		defer sp.Close()
 
 		// should have gotten two status updates: first for the error, then the success - note that we're checking
 		// here for Interrupted because that's how the StreamProcessor reports the error, even though in the public
 		// API it would show up as Initializing because it was still initializing
-		statusChan := sp.Sync()
-		result := <-statusChan
+		resultChan := sp.Sync(ds)
+		result := <-resultChan
 
 		assert.Equal(t, interfaces.DataSourceStateInterrupted, result.State)
 		assert.Equal(t, statusCode, result.Error.StatusCode)
 
-		result = <-statusChan
+		result = <-resultChan
 		assert.Equal(t, interfaces.DataSourceStateValid, result.State)
 
 		event := diagnosticsManager.CreateStatsEventAndReset(0, 0, 0)
@@ -360,7 +476,7 @@ func testStreamProcessorUnrecoverableHTTPError(t *testing.T, statusCode int) {
 	mockLog := ldlogtest.NewMockLog()
 	defer mockLog.DumpIfTestFailed(t)
 	httphelpers.WithServer(httphelpers.HandlerWithStatus(statusCode), func(ts *httptest.Server) {
-		dd := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
+		ds := mocks.NewMockDataSelector(subsystems.NoSelector())
 
 		id := ldevents.NewDiagnosticID(sharedtest.TestSDKKey)
 		diagnosticsManager := ldevents.NewDiagnosticsManager(id, ldvalue.Null(), ldvalue.Null(), time.Now(), nil)
@@ -372,11 +488,11 @@ func testStreamProcessorUnrecoverableHTTPError(t *testing.T, statusCode int) {
 			DiagnosticsManager: diagnosticsManager,
 		}
 
-		sp := NewStreamProcessor(context, dd, datasource.StreamConfig{URI: ts.URL, InitialReconnectDelay: time.Second})
+		sp := NewStreamProcessor(context, datasource.StreamConfig{URI: ts.URL, InitialReconnectDelay: time.Second})
 		defer sp.Close()
 
-		statusChan := sp.Sync()
-		result := <-statusChan
+		resultChan := sp.Sync(ds)
+		result := <-resultChan
 
 		event := diagnosticsManager.CreateStatsEventAndReset(0, 0, 0)
 		assert.Equal(t, 1, event.GetByKey("streamInits").Count())
@@ -419,14 +535,14 @@ func TestStreamingDataSourceHandlesUpToDateAndSubsequentChanges(t *testing.T) {
 			httpConfig := subsystems.HTTPConfiguration{CreateHTTPClient: httpClientFactory}
 			context := sharedtest.NewTestContext(sharedtest.TestSDKKey, &httpConfig, nil)
 
-			sp := NewStreamProcessor(context, dd, datasource.StreamConfig{URI: streamServer.URL})
+			sp := NewStreamProcessor(context, datasource.StreamConfig{URI: streamServer.URL})
 			defer sp.Close()
 
 			// Start the stream and verify the data source is initialized, but the flag doesn't exist.
-			statusChan := sp.Sync()
-			status := <-statusChan
+			resultChan := sp.Sync(dd)
+			status := <-resultChan
 			assert.Equal(t, interfaces.DataSourceStateValid, status.State)
-			assert.True(t, sp.IsInitialized(), "Data source should be initialized after receiving up-to-date intent")
+			assert.Nil(t, status.ChangeSet)
 
 			flag, err := dd.DataStore.Get(datakinds.Features, "test-flag")
 			assert.NoError(t, err)
@@ -444,8 +560,11 @@ func TestStreamingDataSourceHandlesUpToDateAndSubsequentChanges(t *testing.T) {
 			protocol.Enqueue(stream)
 
 			// Verify the change is successfully received and applied
-			status = <-statusChan
+			status = <-resultChan
 			assert.Equal(t, interfaces.DataSourceStateValid, status.State)
+			assert.NotNil(t, status.ChangeSet)
+			dd.SetBasis(status.ChangeSet.Changes(), status.ChangeSet.Selector(), true)
+
 			flag, err = dd.DataStore.Get(datakinds.Features, "test-flag")
 			assert.NoError(t, err)
 			assert.Equal(t, 1, flag.Version)

--- a/internal/datasystem/fdv2_datasystem.go
+++ b/internal/datasystem/fdv2_datasystem.go
@@ -101,12 +101,6 @@ func NewFDv2(disabled bool, cfgBuilder subsystems.ComponentConfigurer[subsystems
 	}
 
 	store := NewStore(clientContext.GetLogging().Loggers, bcasters.flagChangeEvent)
-	var dd subsystems.DataDestination
-	if ldRelayWrapper != nil {
-		dd = ldRelayWrapper(store, store)
-	} else {
-		dd = store
-	}
 
 	fdv2 := &FDv2{
 		store:                    store,
@@ -121,7 +115,6 @@ func NewFDv2(disabled bool, cfgBuilder subsystems.ComponentConfigurer[subsystems
 	dataStoreUpdateSink := datastore.NewDataStoreUpdateSinkImpl(bcasters.dataStoreStatus)
 	clientContextCopy := *clientContext
 	clientContextCopy.DataStoreUpdateSink = dataStoreUpdateSink
-	clientContextCopy.DataDestination = dd
 	clientContextCopy.DataSourceStatusReporter = fdv2
 
 	cfg, err := cfgBuilder.Build(clientContextCopy)
@@ -233,7 +226,7 @@ func (f *FDv2) runPersistentStoreOutageRecovery(ctx context.Context, statuses <-
 func (f *FDv2) runInitializers(ctx context.Context, closeWhenReady chan struct{}) {
 	for _, initializer := range f.initializers {
 		f.loggers.Infof("Attempting to initialize via %s", initializer.Name())
-		basis, err := initializer.Fetch(ctx)
+		basis, err := initializer.Fetch(f.store, ctx)
 		if errors.Is(err, context.Canceled) {
 			return
 		}
@@ -242,7 +235,7 @@ func (f *FDv2) runInitializers(ctx context.Context, closeWhenReady chan struct{}
 			continue
 		}
 		f.loggers.Infof("Initialized via %s", initializer.Name())
-		f.store.SetBasis(basis.Events, basis.Selector, basis.Persist)
+		f.store.SetBasis(basis.ChangeSet.Changes(), basis.ChangeSet.Selector(), basis.Persist)
 		f.readyOnce.Do(func() {
 			close(closeWhenReady)
 		})
@@ -274,8 +267,8 @@ func (f *FDv2) runSynchronizers(ctx context.Context, closeWhenReady chan struct{
 			}
 
 			f.loggers.Debugf("Primary synchronizer %s is starting", primarySync.Name())
-			statusChan := primarySync.Sync()
-			removeSync, fallbackv1, err := f.consumeSynchronizerResults(ctx, statusChan, f.fallbackCond, closeWhenReady)
+			resultChan := primarySync.Sync(f.store)
+			removeSync, fallbackv1, err := f.consumeSynchronizerResults(ctx, resultChan, f.fallbackCond, closeWhenReady)
 			if errors.Is(err, context.Canceled) {
 				return
 			} else if err := primarySync.Close(); err != nil {
@@ -313,8 +306,8 @@ func (f *FDv2) runSynchronizers(ctx context.Context, closeWhenReady chan struct{
 			}
 			f.loggers.Debugf("Secondary synchronizer %s is starting", secondarySync.Name())
 
-			statusChan = secondarySync.Sync()
-			removeSync, fallbackv1, err = f.consumeSynchronizerResults(ctx, statusChan, f.recoveryCond, closeWhenReady)
+			resultChan = secondarySync.Sync(f.store)
+			removeSync, fallbackv1, err = f.consumeSynchronizerResults(ctx, resultChan, f.recoveryCond, closeWhenReady)
 			if errors.Is(err, context.Canceled) {
 				return
 			} else if err := secondarySync.Close(); err != nil {
@@ -350,7 +343,7 @@ func (f *FDv2) runSynchronizers(ctx context.Context, closeWhenReady chan struct{
 
 func (f *FDv2) consumeSynchronizerResults(
 	ctx context.Context,
-	statusChan <-chan interfaces.DataSynchronizerStatus,
+	resultChan <-chan subsystems.DataSynchronizerResult,
 	cond func(status interfaces.DataSourceStatus) bool,
 	closeWhenReady chan<- struct{},
 ) (bool, bool, error) {
@@ -361,7 +354,7 @@ func (f *FDv2) consumeSynchronizerResults(
 		select {
 		case <-ctx.Done():
 			return false, false, ctx.Err()
-		case result, ok := <-statusChan:
+		case result, ok := <-resultChan:
 			// The status channel being closed means that we won't be receiving
 			// any more information from that synchronizer and we should
 			// probably fall back.
@@ -371,9 +364,21 @@ func (f *FDv2) consumeSynchronizerResults(
 
 			switch result.State {
 			case interfaces.DataSourceStateValid:
+				if result.ChangeSet != nil {
+					switch result.ChangeSet.IntentCode() {
+					case subsystems.IntentTransferFull:
+						f.store.SetBasis(result.ChangeSet.Changes(), result.ChangeSet.Selector(), true)
+					case subsystems.IntentTransferChanges:
+						f.store.ApplyDelta(result.ChangeSet.Changes(), result.ChangeSet.Selector(), true)
+					default:
+						f.loggers.Warnf("Received unexpected intent code %s from synchronizer", result.ChangeSet.IntentCode())
+					}
+				}
+
 				f.readyOnce.Do(func() {
 					close(closeWhenReady)
 				})
+
 				f.UpdateStatus(result.State, result.Error)
 			case interfaces.DataSourceStateInterrupted:
 				f.UpdateStatus(result.State, result.Error)

--- a/internal/sharedtest/mocks/mock_data_selector.go
+++ b/internal/sharedtest/mocks/mock_data_selector.go
@@ -1,0 +1,34 @@
+package mocks
+
+import (
+	"sync"
+
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+)
+
+// MockDataSelector is a mock implementation of the DataSelector interface.
+type MockDataSelector struct {
+	mutex    sync.Mutex
+	selector subsystems.Selector
+}
+
+// NewMockDataSelector creates a new MockDataSelector with the given selector.
+func NewMockDataSelector(selector subsystems.Selector) *MockDataSelector {
+	return &MockDataSelector{
+		selector: selector,
+	}
+}
+
+// Selector returns the selector that this mock data selector holds.
+func (m *MockDataSelector) Selector() subsystems.Selector {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	return m.selector
+}
+
+// SetSelector safely updates the selector.
+func (m *MockDataSelector) SetSelector(selector subsystems.Selector) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.selector = selector
+}

--- a/ldclient_listeners_fdv2_test.go
+++ b/ldclient_listeners_fdv2_test.go
@@ -90,7 +90,7 @@ func TestFlagTrackerV2(t *testing.T) {
 				Key:     alwaysTrueFlag.Key,
 				Object:  jsonFlag,
 			})
-			p.protocol.WithTransferred("state", 1)
+			p.protocol.WithTransferred("state", 2)
 			p.protocol.Enqueue(p.control)
 
 			sharedtest.ExpectFlagChangeEvents(t, ch1, alwaysTrueFlag.Key)

--- a/ldcomponents/fdv1_polling_data_source_builder.go
+++ b/ldcomponents/fdv1_polling_data_source_builder.go
@@ -78,7 +78,7 @@ func (b *FDv1PollingDataSourceBuilderV2) Build(context subsystems.ClientContext)
 		PollInterval: b.pollInterval,
 		FilterKey:    filterKey,
 	}
-	return datasourcev2.NewFDv1PollingProcessor(context, context.GetDataDestination(), cfg), nil
+	return datasourcev2.NewFDv1PollingProcessor(context, cfg), nil
 }
 
 // DescribeConfiguration is used internally by the SDK to inspect the configuration.

--- a/ldcomponents/polling_data_source_builder_v2.go
+++ b/ldcomponents/polling_data_source_builder_v2.go
@@ -95,7 +95,7 @@ func (b *PollingDataSourceBuilderV2) Build(context subsystems.ClientContext) (su
 		PollInterval: b.pollInterval,
 		FilterKey:    filterKey,
 	}
-	return datasourcev2.NewPollingProcessor(context, context.GetDataDestination(), cfg), nil
+	return datasourcev2.NewPollingProcessor(context, cfg), nil
 }
 
 // AsInitializer converts the builder into a component configurer for a data initializer. The purpose

--- a/ldcomponents/polling_data_source_builder_v2_test.go
+++ b/ldcomponents/polling_data_source_builder_v2_test.go
@@ -8,9 +8,6 @@ import (
 
 	"github.com/launchdarkly/go-server-sdk/v7/internal/sharedtest/mocks"
 
-	"github.com/launchdarkly/go-server-sdk/v7/internal/datastore"
-	"github.com/launchdarkly/go-server-sdk/v7/internal/sharedtest"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -62,11 +59,9 @@ func TestPollingDataSourceV2Builder(t *testing.T) {
 		// custom endpoints are injected within the Data System config.
 		p := PollingDataSourceV2()
 
-		dd := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
 		statusReporter := mocks.NewMockStatusReporter()
 
 		clientContext := makeTestContextWithBaseURIs(fdv1BaseURI)
-		clientContext.BasicClientContext.DataDestination = dd
 		clientContext.BasicClientContext.DataSourceStatusReporter = statusReporter
 
 		ds, err := p.Build(clientContext)
@@ -86,11 +81,9 @@ func TestPollingDataSourceV2Builder(t *testing.T) {
 
 		p := PollingDataSourceV2().PollInterval(interval).PayloadFilter(filter).BaseURI(baseURI)
 
-		dd := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
 		statusReporter := mocks.NewMockStatusReporter()
 
 		clientContext := makeTestContextWithBaseURIs(baseURI)
-		clientContext.BasicClientContext.DataDestination = dd
 		clientContext.BasicClientContext.DataSourceStatusReporter = statusReporter
 
 		ds, err := p.Build(clientContext)

--- a/ldcomponents/streaming_data_source_builder_v2.go
+++ b/ldcomponents/streaming_data_source_builder_v2.go
@@ -90,7 +90,6 @@ func (b *StreamingDataSourceBuilderV2) Build(context subsystems.ClientContext) (
 	}
 	return datasourcev2.NewStreamProcessor(
 		context,
-		context.GetDataDestination(),
 		cfg,
 	), nil
 }

--- a/ldcomponents/streaming_data_source_builder_v2_test.go
+++ b/ldcomponents/streaming_data_source_builder_v2_test.go
@@ -8,9 +8,6 @@ import (
 
 	"github.com/launchdarkly/go-server-sdk/v7/internal/sharedtest/mocks"
 
-	"github.com/launchdarkly/go-server-sdk/v7/internal/datastore"
-	"github.com/launchdarkly/go-server-sdk/v7/internal/sharedtest"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -63,11 +60,9 @@ func TestStreamingDataSourceV2Builder(t *testing.T) {
 		// custom endpoints are injected within the Data System config.
 		s := StreamingDataSourceV2()
 
-		dd := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
 		statusReporter := mocks.NewMockStatusReporter()
 
 		clientContext := makeTestContextWithBaseURIs(fdv1BaseURI)
-		clientContext.BasicClientContext.DataDestination = dd
 		clientContext.BasicClientContext.DataSourceStatusReporter = statusReporter
 
 		ds, err := s.Build(clientContext)
@@ -88,10 +83,8 @@ func TestStreamingDataSourceV2Builder(t *testing.T) {
 
 		s := StreamingDataSourceV2().InitialReconnectDelay(delay).PayloadFilter(filter).BaseURI(baseURI)
 
-		dd := mocks.NewMockDataDestination(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))
 		statusReporter := mocks.NewMockStatusReporter()
 		clientContext := makeTestContextWithBaseURIs("not-used")
-		clientContext.BasicClientContext.DataDestination = dd
 		clientContext.BasicClientContext.DataSourceStatusReporter = statusReporter
 		ds, err := s.Build(clientContext)
 		require.NoError(t, err)

--- a/subsystems/client_context.go
+++ b/subsystems/client_context.go
@@ -46,10 +46,6 @@ type ClientContext interface {
 	// returns nil.
 	GetDataStoreUpdateSink() DataStoreUpdateSink
 
-	// GetDataDestination is a FDV2 method, do not use. Not subject to semantic versioning.
-	// This method is a replacement for GetDataSourceUpdateSink when the SDK is in FDv2 mode.
-	GetDataDestination() DataDestination
-
 	// GetDataSourceStatusReporter is a FDV2 method, do not use. Not subject to semantic versioning.
 	// This method is a replacement for GetDataSourceUpdateSink when the SDK is in FDv2 mode.
 	GetDataSourceStatusReporter() DataSourceStatusReporter
@@ -66,7 +62,6 @@ type BasicClientContext struct {
 	ServiceEndpoints         interfaces.ServiceEndpoints
 	DataSourceUpdateSink     DataSourceUpdateSink
 	DataStoreUpdateSink      DataStoreUpdateSink
-	DataDestination          DataDestination
 	DataSourceStatusReporter DataSourceStatusReporter
 }
 
@@ -99,10 +94,6 @@ func (b BasicClientContext) GetDataSourceUpdateSink() DataSourceUpdateSink { //n
 
 func (b BasicClientContext) GetDataStoreUpdateSink() DataStoreUpdateSink { //nolint:revive
 	return b.DataStoreUpdateSink
-}
-
-func (b BasicClientContext) GetDataDestination() DataDestination { //nolint:revive
-	return b.DataDestination
 }
 
 func (b BasicClientContext) GetDataSourceStatusReporter() DataSourceStatusReporter { //nolint:revive

--- a/subsystems/data_source.go
+++ b/subsystems/data_source.go
@@ -27,13 +27,16 @@ type DataSource interface {
 // Basis represents the initial payload of data that a data source can provide. Initializers provide this
 // via Fetch, whereas Synchronizers provide it asynchronously via the injected DataDestination.
 type Basis struct {
-	// Events is a series of events representing actions applied to data items.
-	Events []Change
-	// Selector identifies this basis.
-	Selector Selector
+	ChangeSet ChangeSet
 	// Persist is true if the data source requests that the data store persist the items to any connected
 	// Persistent Stores.
 	Persist bool
+}
+
+// DataSelector is an interface that provides a Selector, which is used by synchronizers and initializers to
+// the basis of data to fetch.
+type DataSelector interface {
+	Selector() Selector
 }
 
 // DataInitializer represents a component capable of obtaining a Basis via a synchronous call.
@@ -42,18 +45,22 @@ type DataInitializer interface {
 	Name() string
 	// Fetch returns a Basis, or an error if the Basis could not be retrieved. If the context has expired,
 	// return the context's error.
-	Fetch(ctx context.Context) (*Basis, error)
+	Fetch(ds DataSelector, ctx context.Context) (*Basis, error)
+}
+
+// DataSynchronizerResult represents the results of a Synchronizer's ongoing Sync method.
+type DataSynchronizerResult struct {
+	ChangeSet    *ChangeSet
+	State        interfaces.DataSourceState
+	Error        interfaces.DataSourceErrorInfo
+	RevertToFDv1 bool
 }
 
 // DataSynchronizer represents a component capable of obtaining a Basis and subsequent delta updates asynchronously.
 type DataSynchronizer interface {
 	DataInitializer
 	// Sync tells the data synchronizer to begin synchronizing data.
-	Sync() <-chan interfaces.DataSynchronizerStatus
-	// IsInitialized returns true if the data source has successfully initialized at some point.
-	//
-	// Once this is true, it should remain true even if a problem occurs later.
-	IsInitialized() bool
+	Sync(DataSelector) <-chan DataSynchronizerResult
 	io.Closer
 }
 


### PR DESCRIPTION
The initializers and synchronizers are now required to return the data
they have retrieved instead of persisting it directly to the data
destination. This provides for a better separation of concerns where the
synchronizers only have to worry about their data formats, and not
persistent.

We do update each initializers or synchronizers with access to the
current selector using the `DataSelector` interface.
