### PR TITLE
chore: Add explicit permissions for stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,6 @@
-name: 'Close stale issues and PRs'
+name: "Close stale issues and PRs"
 permissions:
+  actions: write
   contents: read
   issues: write
   pull-requests: write
@@ -7,7 +8,7 @@ on:
   workflow_dispatch:
   schedule:
     # Happen once per day at 1:30 AM
-    - cron: '30 1 * * *'
+    - cron: "30 1 * * *"
 
 jobs:
   sdk-close-stale:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,8 @@
 name: 'Close stale issues and PRs'
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/launchdarkly/go-server-sdk/security/code-scanning/17](https://github.com/launchdarkly/go-server-sdk/security/code-scanning/17)

To fix the issue, add a `permissions` block at the root level of the workflow to explicitly define the least privileges required. Since the workflow is used to close stale issues and pull requests, it likely requires `issues: write` and `pull-requests: write` permissions. Other permissions should be set to `read` or omitted entirely if not needed.

The fix involves adding the following permissions block:
```yaml
permissions:
  contents: read
  issues: write
  pull-requests: write
```

This block ensures that the workflow has only the necessary permissions to perform its tasks, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
