### PR TITLE
chore: Add explicit permissions for common_ci

### DIFF
--- a/.github/workflows/common_ci.yml
+++ b/.github/workflows/common_ci.yml
@@ -6,6 +6,8 @@ on:
         description: "Go version to use for the jobs."
         required: true
         type: string
+permissions:
+  contents: read
 
 jobs:
   unit-test-and-coverage:


### PR DESCRIPTION
Potential fix for [https://github.com/launchdarkly/go-server-sdk/security/code-scanning/18](https://github.com/launchdarkly/go-server-sdk/security/code-scanning/18)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, `contents: read` is sufficient for most jobs, as they primarily involve testing and artifact uploads. If specific jobs require additional permissions, they can be set individually within the job.

The `permissions` block will be added at the root level of the workflow to apply to all jobs. If any job requires additional permissions, they can be overridden within the job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
