### PR TITLE
chore: Add explicit permissions for ldotel ci

### DIFF
--- a/.github/workflows/ldotel-ci.yml
+++ b/.github/workflows/ldotel-ci.yml
@@ -1,4 +1,6 @@
 name: Build and Test ldotel
+permissions:
+  contents: read
 on:
   push:
     branches: [ 'v7', 'feat/**' ]


### PR DESCRIPTION
Potential fix for [https://github.com/launchdarkly/go-server-sdk/security/code-scanning/16](https://github.com/launchdarkly/go-server-sdk/security/code-scanning/16)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow performs basic CI tasks (unit tests, linting, and coverage checks), it likely only requires `contents: read` permissions. 

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to individual jobs if different jobs require different permissions. In this case, adding it at the root level is sufficient and simplifies the configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
