### PR TITLE
chore: Add explicit permissions for go-versions

### DIFF
--- a/.github/workflows/go-versions.yml
+++ b/.github/workflows/go-versions.yml
@@ -18,6 +18,8 @@
 #    matrix: ${{ fromJSON(this-job.outputs.latest-matrix) }}
 #
 name: Go Versions
+permissions:
+  contents: read
 on:
   workflow_call:
     outputs:


### PR DESCRIPTION
Potential fix for [https://github.com/launchdarkly/go-server-sdk/security/code-scanning/10](https://github.com/launchdarkly/go-server-sdk/security/code-scanning/10)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow only reads a file and sets outputs, it only requires `contents: read` permissions. The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is no indication that any job requires additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
