### PR TITLE
chore: Add explicit permissions for ldai ci

### DIFF
--- a/.github/workflows/ldai-ci.yml
+++ b/.github/workflows/ldai-ci.yml
@@ -1,4 +1,6 @@
 name: Build and Test ldai
+permissions:
+  contents: read
 on:
   push:
     branches: [ 'v7', 'feat/**' ]


### PR DESCRIPTION
Potential fix for [https://github.com/launchdarkly/go-server-sdk/security/code-scanning/12](https://github.com/launchdarkly/go-server-sdk/security/code-scanning/12)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow primarily performs CI tasks like checking out code, setting up Go, running unit tests, and generating coverage reports, it only requires `contents: read` permissions. This ensures the workflow adheres to the principle of least privilege.

The `permissions` block should be added at the root level of the workflow to apply to all jobs. Alternatively, it can be added to individual jobs if different permissions are required for specific jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
