### PR TITLE
chore: Add explicit permissions to sdk ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Build and Test SDK
+permissions:
+  contents: read
 on:
   push:
     branches: [ 'v7', 'feat/**' ]


### PR DESCRIPTION
Potential fix for [https://github.com/launchdarkly/go-server-sdk/security/code-scanning/6](https://github.com/launchdarkly/go-server-sdk/security/code-scanning/6)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's functionality:
- The `actions/checkout` step requires `contents: read` to access the repository's code.
- The `go test` step does not require additional permissions beyond `contents: read`.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to individual jobs for finer control. In this case, adding it at the root level is sufficient and simplifies the configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
