### PR TITLE
chore: Add explicit permissions for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: googleapis/release-please-action@v4
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,13 +4,14 @@ on:
   push:
     branches:
       - v7
-  workflow_dispatch: 
+  workflow_dispatch:
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: googleapis/release-please-action@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/launchdarkly/go-server-sdk/security/code-scanning/14](https://github.com/launchdarkly/go-server-sdk/security/code-scanning/14)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the `googleapis/release-please-action` to function correctly. Based on its functionality (creating releases), the workflow likely requires `contents: write`. Other permissions should be omitted unless explicitly needed.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`release-please`) to limit its scope. In this case, adding it to the job is preferable for clarity and precision.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
