### PR TITLE
chore: Add explicit permissions for check-go-versions

### DIFF
--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   check-go-eol:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       latest: ${{ steps.parse.outputs.latest }}


### PR DESCRIPTION
Potential fix for [https://github.com/launchdarkly/go-server-sdk/security/code-scanning/7](https://github.com/launchdarkly/go-server-sdk/security/code-scanning/7)

To fix the issue, we need to add a `permissions` block to the `check-go-eol` job, specifying the least privileges required. Since this job only fetches data from an external API and parses it, it does not require any write permissions. The minimal permissions required are `contents: read`, which allows the job to read repository contents if needed.

The `permissions` block should be added directly under the `check-go-eol` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
