### PR TITLE
remove golang.org/x/exp as depenency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/launchdarkly/go-test-helpers/v3 v3.0.2
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/stretchr/testify v1.9.0
-	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa
 	golang.org/x/sync v0.8.0
 	gopkg.in/ghodss/yaml.v1 v1.0.0
 )
@@ -30,6 +29,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
+	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/interfaces/flagstate/flags_state.go
+++ b/interfaces/flagstate/flags_state.go
@@ -8,7 +8,7 @@ import (
 	"github.com/launchdarkly/go-sdk-common/v3/ldtime"
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 
-	"golang.org/x/exp/maps"
+	"maps"
 )
 
 // AllFlags is a snapshot of the state of multiple feature flags with regard to a specific evaluation

--- a/internal/broadcasters.go
+++ b/internal/broadcasters.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"sync"
 
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 // This file defines the publish-subscribe model we use for various status/event types in the SDK.

--- a/internal/datasource/polling_http_request.go
+++ b/internal/datasource/polling_http_request.go
@@ -13,8 +13,9 @@ import (
 
 	"github.com/launchdarkly/go-jsonstream/v3/jreader"
 
+	"maps"
+
 	"github.com/gregjones/httpcache"
-	"golang.org/x/exp/maps"
 )
 
 // PollingRequester is the internal implementation of getting flag/segment data from the LD polling endpoints.

--- a/internal/datasource/streaming_data_source.go
+++ b/internal/datasource/streaming_data_source.go
@@ -17,7 +17,7 @@ import (
 
 	es "github.com/launchdarkly/eventsource"
 
-	"golang.org/x/exp/maps"
+	"maps"
 )
 
 // Implementation of the streaming data source, not including the lower-level SSE implementation which is in

--- a/internal/datasourcev2/polling_http_request.go
+++ b/internal/datasourcev2/polling_http_request.go
@@ -8,8 +8,9 @@ import (
 	"net/http"
 	"net/url"
 
+	"maps"
+
 	"github.com/gregjones/httpcache"
-	"golang.org/x/exp/maps"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
 	"github.com/launchdarkly/go-server-sdk/v7/internal/endpoints"

--- a/internal/datasourcev2/streaming_data_source.go
+++ b/internal/datasourcev2/streaming_data_source.go
@@ -21,7 +21,7 @@ import (
 	"github.com/launchdarkly/go-server-sdk/v7/internal/endpoints"
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
 
-	"golang.org/x/exp/maps"
+	"maps"
 )
 
 const (

--- a/internal/datastore/persistent_data_store_wrapper.go
+++ b/internal/datastore/persistent_data_store_wrapper.go
@@ -10,8 +10,9 @@ import (
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
 	st "github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
 
+	"slices"
+
 	"github.com/patrickmn/go-cache"
-	"golang.org/x/exp/slices"
 	"golang.org/x/sync/singleflight"
 )
 

--- a/internal/sharedtest/hooks.go
+++ b/internal/sharedtest/hooks.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/stretchr/testify/assert"
 

--- a/internal/sharedtest/mocks/mock_persistent_data_store.go
+++ b/internal/sharedtest/mocks/mock_persistent_data_store.go
@@ -5,8 +5,6 @@ import (
 	"time"
 
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
-
-	"golang.org/x/exp/maps"
 )
 
 // MockDatabaseInstance can be used with MockPersistentDataStore to simulate multiple data store
@@ -27,7 +25,9 @@ func NewMockDatabaseInstance() *MockDatabaseInstance {
 // Clear removes all shared data.
 func (db *MockDatabaseInstance) Clear(prefix string) {
 	for _, m := range db.dataByPrefix[prefix] {
-		maps.Clear(m)
+		for k := range m {
+			delete(m, k)
+		}
 	}
 	if v, ok := db.initedByPrefix[prefix]; ok {
 		*v = false
@@ -177,7 +177,9 @@ func (m *MockPersistentDataStore) Init(allData []ldstoretypes.SerializedCollecti
 		return m.fakeError
 	}
 	for _, mm := range m.data {
-		maps.Clear(mm)
+		for k := range mm {
+			delete(mm, k)
+		}
 	}
 	for _, coll := range allData {
 		AssertNotNil(coll.Kind)

--- a/ldai/config.go
+++ b/ldai/config.go
@@ -1,8 +1,9 @@
 package ldai
 
 import (
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
+	"maps"
+
+	"slices"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 	"github.com/launchdarkly/go-server-sdk/ldai/datamodel"

--- a/ldai/go.mod
+++ b/ldai/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/launchdarkly/go-sdk-common/v3 v3.3.0
 	github.com/launchdarkly/go-server-sdk/v7 v7.7.0
 	github.com/stretchr/testify v1.9.0
-	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa
 )
 
 require (
@@ -18,5 +17,6 @@ require (
 	github.com/launchdarkly/go-sdk-events/v3 v3.4.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/testhelpers/ldtestdata/test_data_source.go
+++ b/testhelpers/ldtestdata/test_data_source.go
@@ -9,7 +9,7 @@ import (
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoreimpl"
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
 
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 // TestDataSource is a test fixture that provides dynamically updatable feature flag state in a

--- a/testhelpers/ldtestdata/test_data_source_flag.go
+++ b/testhelpers/ldtestdata/test_data_source_flag.go
@@ -9,8 +9,9 @@ import (
 	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldbuilders"
 	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldmodel"
 
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
+	"maps"
+
+	"slices"
 )
 
 const (

--- a/testhelpers/ldtestdatav2/test_data_source_flag.go
+++ b/testhelpers/ldtestdatav2/test_data_source_flag.go
@@ -9,8 +9,9 @@ import (
 	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldbuilders"
 	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldmodel"
 
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
+	"maps"
+
+	"slices"
 )
 
 const (


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/v5/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions


Removed golang.org/x/exp as a dependency, and replaced it with standard library functions. 
Related to https://github.com/launchdarkly/go-sdk-common/pull/36