### PR TITLE
fix(experimental): Add experimental LDScopedClient for incrementally building and propagating contexts

### DIFF
--- a/ldclient_scoped.go
+++ b/ldclient_scoped.go
@@ -10,7 +10,6 @@ import (
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 	ldevents "github.com/launchdarkly/go-sdk-events/v3"
 	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
-	"github.com/launchdarkly/go-server-sdk/v7/interfaces/flagstate"
 )
 
 // TODO:
@@ -237,12 +236,6 @@ func (c *LDScopedClient) MigrationVariationCtx(
 	defaultStage ldmigration.Stage,
 ) (ldmigration.Stage, interfaces.LDMigrationOpTracker, error) {
 	return c.client.MigrationVariationCtx(ctx, key, c.CurrentContext(), defaultStage)
-}
-
-func (c *LDScopedClient) AllFlagsState(
-	options ...flagstate.Option,
-) flagstate.AllFlags {
-	return c.client.AllFlagsState(c.CurrentContext(), options...)
 }
 
 func (c *LDScopedClient) Identify() error {

--- a/ldclient_scoped.go
+++ b/ldclient_scoped.go
@@ -131,17 +131,18 @@ func (c *LDScopedClient) overwriteIndividualContextByKind(context ldcontext.Cont
 // OverwriteContextByKind overwrites an existing context in the scoped client, affecting all future
 // operations on it, like flag evaluations and event tracking.
 //
-// You may pass a multi-context, or multiple individual contexts, to OverwriteContextByKind.
-// Any existing contexts with the same kind as any of the new contexts will be overwritten.
-//
-// If the scoped client had multiple contexts, only the context with the same kind as the new context
-// will be overwritten. Any other existing contexts will remain unchanged:
+// If the scoped client already has multiple contexts, only the individual
+// context with the same kind as the new context will be overwritten. Any other
+// existing contexts will remain unchanged:
 //
 //	company := ldcontext.NewWithKind("company", "acme")
 //	scopedClient := ld.NewScopedClient(client, company)
 //	scopedClient.AddContext(ldcontext.New("user-key"))
 //	scopedClient.OverwriteContextByKind(ldcontext.NewWithKind("company", "monsoon"))
 //	scopedClient.CurrentContext() // returns a multi-context with "monsoon" and "user-key"
+//
+// Passing a multi-context to OverwriteContextByKind is equivalent to passing in
+// all of its individual contexts separately.
 func (c *LDScopedClient) OverwriteContextByKind(contexts ...ldcontext.Context) {
 	c.Lock()
 	defer c.Unlock()

--- a/ldclient_scoped.go
+++ b/ldclient_scoped.go
@@ -18,11 +18,11 @@ import (
 // create a new scoped client for each logical scope where the evaluation context
 // should be isolated from other scopes, like a web request.
 //
-// An LDScopedClient is created by calling [LDClient.ForContext]. This sets the
+// An LDScopedClient is created by calling [NewScopedClient]. This sets the
 // initial context to be used for all operations:
 //
 //	userContext := ldcontext.New("user-key")
-//	scopedClient := client.ForContext(userContext)
+//	scopedClient := ld.NewScopedClient(client, userContext)
 //	scopedClient.BoolVariation("flag-key", false)
 //
 // A scoped client contains one or more contexts, each with a unique kind. You
@@ -30,7 +30,7 @@ import (
 // new contexts' kinds are not already present. The "current context" is the
 // combination of all contexts added so far, as a multi-context.
 //
-//	scopedClient := client.ForContext(userContext)
+//	scopedClient := ld.NewScopedClient(client, userContext)
 //	scopedClient.CurrentContext() // returns the single "user" context
 //	scopedClient.AddContext(ldcontext.NewWithKind("company", "acme"))
 //	scopedClient.CurrentContext() // returns a multi-context with a "user" and "company" context
@@ -40,7 +40,7 @@ import (
 // available early in the request, but you also want to evaluate flags with a
 // `company` context that is only available later:
 //
-//	scopedClient := client.ForContext(ldcontext.New("user-key"))
+//	scopedClient := ld.NewScopedClient(client, ldcontext.New("user-key"))
 //	company := fetchCompanyForUser(user)
 //	scopedClient.AddContext(ldcontext.NewWithKind("company", company.Id))
 //	scopedClient.BoolVariation("enterprise-features", false)
@@ -67,22 +67,20 @@ type LDScopedClient struct {
 	rebuild bool
 }
 
-// ForContext creates a new LDScopedClient, a wrapper of LDClient that uses a
+// NewScopedClient creates a new LDScopedClient, a wrapper of LDClient that uses a
 // certain LaunchDarkly evaluation context for all operations, like evaluating
 // feature flags or sending events. The scoped client supports most of the same
 // methods as LDClient, like BoolVariation et al., but without the
 // ldcontext.Context parameter.
 //
-// You may pass a multi-context, or multiple individual contexts, to ForContext.
-// All of the contexts passed in will be combined into a multi-context when the
-// scoped client is used.
+// You may pass one or more contexts to NewScopedClient. All contexts will be
+// combined into a multi-context when the scoped client is used. Passing in one
+// multi-context is equivalent to passing in all of its individual contexts
+// separately.
 //
-// You should create a new scoped client for each logical scope where the
-// contexts are isolated from each other, like a web request.
-//
-// For more info on how to use the scoped client, see the documentation for
-// LDScopedClient.
-func (client *LDClient) ForContext(contexts ...ldcontext.Context) *LDScopedClient {
+// For more information on how to use the scoped client, read the documentation
+// for LDScopedClient.
+func NewScopedClient(client *LDClient, contexts ...ldcontext.Context) *LDScopedClient {
 	cc := &LDScopedClient{
 		client:   client,
 		contexts: make(map[ldcontext.Kind]ldcontext.Context),
@@ -140,7 +138,7 @@ func (c *LDScopedClient) overwriteIndividualContextByKind(context ldcontext.Cont
 // will be overwritten. Any other existing contexts will remain unchanged:
 //
 //	company := ldcontext.NewWithKind("company", "acme")
-//	scopedClient := client.ForContext(company)
+//	scopedClient := ld.NewScopedClient(client, company)
 //	scopedClient.AddContext(ldcontext.New("user-key"))
 //	scopedClient.OverwriteContextByKind(ldcontext.NewWithKind("company", "monsoon"))
 //	scopedClient.CurrentContext() // returns a multi-context with "monsoon" and "user-key"

--- a/ldclient_scoped.go
+++ b/ldclient_scoped.go
@@ -18,6 +18,10 @@ import (
 // create a new scoped client for each logical scope where the evaluation context
 // should be isolated from other scopes, like a web request.
 //
+// This type is not stable, and not subject to any backwards compatibility
+// guarantees or semantic versioning. It is not suitable for production usage. Do
+// not use it. You have been warned.
+//
 // An LDScopedClient is created by calling [NewScopedClient]. This sets the
 // initial context to be used for all operations:
 //
@@ -80,6 +84,10 @@ type LDScopedClient struct {
 //
 // For more information on how to use the scoped client, read the documentation
 // for LDScopedClient.
+//
+// This function is not stable, and not subject to any backwards compatibility
+// guarantees or semantic versioning. It is not suitable for production usage. Do
+// not use it. You have been warned.
 func NewScopedClient(client *LDClient, contexts ...ldcontext.Context) *LDScopedClient {
 	cc := &LDScopedClient{
 		client:   client,

--- a/ldclient_scoped.go
+++ b/ldclient_scoped.go
@@ -514,14 +514,6 @@ func (c *LDScopedClient) MigrationVariationCtx(
 	return c.client.MigrationVariationCtx(ctx, key, c.CurrentContext(), defaultStage)
 }
 
-// Identify sends an identify event for the current evaluation context.
-//
-// For more information, see the Reference Guide:
-// https://docs.launchdarkly.com/sdk/features/identify#go
-func (c *LDScopedClient) Identify() error {
-	return c.client.Identify(c.CurrentContext())
-}
-
 // TrackEvent sends a custom event for the current evaluation context.
 //
 // The eventName parameter is defined by the application and will be shown in

--- a/ldclient_scoped.go
+++ b/ldclient_scoped.go
@@ -12,9 +12,9 @@ import (
 	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
 )
 
-// LDScopedClient is a wrapper around LDClient that lets you specify the context
-// to be used for all operations, rather than taking a context as a parameter
-// every time you call a method.
+// LDScopedClient is a wrapper around LDClient that lets you specify the
+// evaluation context to be used for all operations, rather than taking the
+// evaluation context as a parameter every time you call a method.
 //
 // A LDScopedClient is created by calling [LDClient.ForContext]. This sets the
 // initial context to be used for all operations:
@@ -24,13 +24,13 @@ import (
 //	scopedClient.BoolVariation("flag-key", false)
 //
 // Scoped contexts are mutable, to facilitate incrementally building up a
-// multi-context representing the current scope. However, you should create a
-// new scoped client for each logical scope where the contexts are different. For
-// instance, if you are using a scoped client in an HTTP request handler, you
-// should create a new scoped client for each request. You should only use the
-// mutable features of LDScopedClient to add new contexts, not to change or
-// remove existing data. A scoped client is thread-safe, so you can safely use it
-// from multiple goroutines.
+// multi-context representing the current scope. You should create a new scoped
+// client for each logical scope where the contexts are different. For instance,
+// if you are using a scoped client in an HTTP request handler, you should create
+// a new scoped client for each request. You should only use the mutable features
+// of LDScopedClient to add new contexts, not to change or remove existing data.
+// A scoped client is thread-safe, so you can safely use it from multiple
+// goroutines.
 //
 // You may add new contexts with [LDScopedClient.AddContext]. The scoped client's
 // contexts so far are combined into a multi-context whenever the scoped client
@@ -61,11 +61,11 @@ type LDScopedClient struct {
 	rebuild bool
 }
 
-// ForContext creates a new LDScopedClient with an initial context. This scoped
-// client wraps the original client, using the specified context for all
-// operations, like evaluating feature flags or sending events. The scoped client
-// supports most of the same methods as LDClient, like BoolVariation et al., but
-// without the context parameter.
+// ForContext creates a new LDScopedClient, a wrapper of LDClient that uses a
+// certain LaunchDarkly evaluation context for all operations, like evaluating
+// feature flags or sending events. The scoped client supports most of the same
+// methods as LDClient, like BoolVariation et al., but without the
+// ldcontext.Context parameter.
 //
 // You may pass a multi-context, or multiple individual contexts, to ForContext.
 // All of the contexts passed in will be combined into a multi-context when the
@@ -94,8 +94,8 @@ func (c *LDScopedClient) addIndividualContext(context ldcontext.Context) {
 	c.contexts[context.Kind()] = context
 }
 
-// AddContext adds additional contexts to the scoped client, affecting all future
-// operations on it, like flag evaluations and event tracking.
+// AddContext adds additional evaluation contexts to the scoped client, affecting
+// all future operations on it, like flag evaluations and event tracking.
 //
 // All of the contexts added must have kinds that are not already present. If you
 // try to add a context with a duplicate kind, the new context will not be added
@@ -154,8 +154,8 @@ func (c *LDScopedClient) OverwriteContextByKind(contexts ...ldcontext.Context) {
 	}
 }
 
-// CurrentContext returns the current context for the scoped client. This is the
-// combination of all the contexts that have been added so far, as a
+// CurrentContext returns the current LaunchDarkly context for the scoped client.
+// This is the combination of all the contexts that have been added so far, as a
 // multi-context.
 func (c *LDScopedClient) CurrentContext() ldcontext.Context {
 	c.Lock()

--- a/ldclient_scoped.go
+++ b/ldclient_scoped.go
@@ -76,9 +76,9 @@ type LDScopedClient struct {
 //
 // For more info on how to use the scoped client, see the documentation for
 // LDScopedClient.
-func (c *LDClient) ForContext(contexts ...ldcontext.Context) *LDScopedClient {
+func (client *LDClient) ForContext(contexts ...ldcontext.Context) *LDScopedClient {
 	cc := &LDScopedClient{
-		client:   c,
+		client:   client,
 		contexts: make(map[ldcontext.Kind]ldcontext.Context),
 		rebuild:  true,
 	}
@@ -322,7 +322,10 @@ func (c *LDScopedClient) Float64VariationCtx(
 //
 // For more information, see the Reference Guide:
 // https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
-func (c *LDScopedClient) Float64VariationDetail(key string, defaultVal float64) (float64, ldreason.EvaluationDetail, error) {
+func (c *LDScopedClient) Float64VariationDetail(
+	key string,
+	defaultVal float64,
+) (float64, ldreason.EvaluationDetail, error) {
 	return c.client.Float64VariationDetail(key, c.CurrentContext(), defaultVal)
 }
 
@@ -377,7 +380,10 @@ func (c *LDScopedClient) StringVariationCtx(
 //
 // For more information, see the Reference Guide:
 // https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
-func (c *LDScopedClient) StringVariationDetail(key string, defaultVal string) (string, ldreason.EvaluationDetail, error) {
+func (c *LDScopedClient) StringVariationDetail(
+	key string,
+	defaultVal string,
+) (string, ldreason.EvaluationDetail, error) {
 	return c.client.StringVariationDetail(key, c.CurrentContext(), defaultVal)
 }
 
@@ -450,7 +456,10 @@ func (c *LDScopedClient) JSONVariationCtx(
 //
 // For more information, see the Reference Guide:
 // https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
-func (c *LDScopedClient) JSONVariationDetail(key string, defaultVal ldvalue.Value) (ldvalue.Value, ldreason.EvaluationDetail, error) {
+func (c *LDScopedClient) JSONVariationDetail(
+	key string,
+	defaultVal ldvalue.Value,
+) (ldvalue.Value, ldreason.EvaluationDetail, error) {
 	return c.client.JSONVariationDetail(key, c.CurrentContext(), defaultVal)
 }
 

--- a/ldclient_scoped.go
+++ b/ldclient_scoped.go
@@ -98,16 +98,16 @@ func (c *LDScopedClient) addIndividualContext(context ldcontext.Context) {
 	c.contexts[context.Kind()] = context
 }
 
-// AddContext adds additional evaluation contexts to the scoped client, affecting
-// all future operations on it, like flag evaluations and event tracking.
+// AddContext adds additional evaluation contexts to the scoped client's current context.
+// This affects all future operations on it, like flag evaluations and event tracking.
 //
-// All of the contexts added must have kinds that are not already present. If you
-// try to add a context with a duplicate kind, the new context will not be added
-// and a warning will be logged. If you want to replace an existing context, use
+// Each context added must have a kind that is not already present. If you try to
+// add a context with a duplicate kind, the new context will not be added and a
+// warning will be logged. If you want to replace an existing context, use
 // [LDScopedClient.OverwriteContextByKind] instead.
 //
-// The scoped client's contexts so far are combined into a multi-context whenever the
-// scoped client is used.
+// Passing a multi-context to AddContext is equivalent to passing in all of its
+// individual contexts separately.
 func (c *LDScopedClient) AddContext(contexts ...ldcontext.Context) {
 	c.Lock()
 	defer c.Unlock()

--- a/ldclient_scoped.go
+++ b/ldclient_scoped.go
@@ -13,6 +13,11 @@ import (
 	"github.com/launchdarkly/go-server-sdk/v7/interfaces/flagstate"
 )
 
+// TODO:
+// - add docstrings to everything
+// - e2e tests (ld_client_end_to_end_test.go?)
+// - unit tests for context collector piece
+
 type LDScopedClient struct {
 	sync.Mutex
 	client *LDClient
@@ -34,6 +39,14 @@ func (c *LDClient) ForContext(contexts ...ldcontext.Context) *LDScopedClient {
 	return cc
 }
 
+func (c *LDScopedClient) addIndividualContext(context ldcontext.Context) {
+	if _, ok := c.contexts[context.Kind()]; ok {
+		c.client.loggers.Warnf("Tried to add a duplicate %s context to LDScopedClient", context.Kind())
+		return
+	}
+	c.contexts[context.Kind()] = context
+}
+
 func (c *LDScopedClient) AddContext(contexts ...ldcontext.Context) {
 	c.Lock()
 	defer c.Unlock()
@@ -41,14 +54,12 @@ func (c *LDScopedClient) AddContext(contexts ...ldcontext.Context) {
 
 	for _, ctx := range contexts {
 		if ctx.Multiple() {
-			c.AddContext(ctx.GetAllIndividualContexts(nil)...)
+			for _, individual := range ctx.GetAllIndividualContexts(nil) {
+				c.addIndividualContext(individual)
+			}
 			continue
 		}
-		if _, ok := c.contexts[ctx.Kind()]; ok {
-			c.client.loggers.Warnf("Tried to add a duplicate %s context to LDScopedClient", ctx.Kind())
-			continue
-		}
-		c.contexts[ctx.Kind()] = ctx
+		c.addIndividualContext(ctx)
 	}
 }
 

--- a/ldclient_scoped.go
+++ b/ldclient_scoped.go
@@ -1,0 +1,75 @@
+package ldclient
+
+import (
+	"sync"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+)
+
+type LDScopedClient struct {
+	sync.Mutex
+	client *LDClient
+
+	contexts map[ldcontext.Kind]ldcontext.Context
+
+	// Caching mechanism to avoid rebuilding the context every time
+	context ldcontext.Context
+	rebuild bool
+}
+
+func (c *LDClient) ForContext(contexts ...ldcontext.Context) *LDScopedClient {
+	cc := &LDScopedClient{
+		client:   c,
+		contexts: make(map[ldcontext.Kind]ldcontext.Context),
+		rebuild:  true,
+	}
+	cc.AddContext(contexts...)
+	return cc
+}
+
+func (c *LDScopedClient) AddContext(contexts ...ldcontext.Context) {
+	c.Lock()
+	defer c.Unlock()
+	c.rebuild = true
+
+	for _, ctx := range contexts {
+		if ctx.Multiple() {
+			c.AddContext(ctx.GetAllIndividualContexts(nil)...)
+			continue
+		}
+		if _, ok := c.contexts[ctx.Kind()]; ok {
+			c.client.loggers.Warnf("Tried to add a duplicate %s context to LDScopedClient", ctx.Kind())
+			continue
+		}
+		c.contexts[ctx.Kind()] = ctx
+	}
+}
+
+func (c *LDScopedClient) OverwriteContextByKind(contexts ...ldcontext.Context) {
+	c.Lock()
+	defer c.Unlock()
+	c.rebuild = true
+
+	for _, ctx := range contexts {
+		if ctx.Multiple() {
+			c.OverwriteContextByKind(ctx.GetAllIndividualContexts(nil)...)
+			continue
+		}
+		c.contexts[ctx.Kind()] = ctx
+	}
+}
+
+func (c *LDScopedClient) CurrentContext() ldcontext.Context {
+	c.Lock()
+	defer c.Unlock()
+	if !c.rebuild {
+		return c.context
+	}
+	c.rebuild = false
+	b := ldcontext.NewMultiBuilder()
+	for _, ctx := range c.contexts {
+		b.Add(ctx)
+	}
+	c.context = b.Build()
+	return c.context
+}

--- a/ldclient_scoped.go
+++ b/ldclient_scoped.go
@@ -74,9 +74,9 @@ type LDScopedClient struct {
 // ldcontext.Context parameter.
 //
 // You may pass one or more contexts to NewScopedClient. All contexts will be
-// combined into a multi-context when the scoped client is used. Passing in one
-// multi-context is equivalent to passing in all of its individual contexts
-// separately.
+// combined into a multi-context when the scoped client is used. Providing a
+// multi-context to NewScopedClient is equivalent to providing all of its
+// individual contexts separately.
 //
 // For more information on how to use the scoped client, read the documentation
 // for LDScopedClient.
@@ -106,7 +106,7 @@ func (c *LDScopedClient) addIndividualContext(context ldcontext.Context) {
 // warning will be logged. If you want to replace an existing context, use
 // [LDScopedClient.OverwriteContextByKind] instead.
 //
-// Passing a multi-context to AddContext is equivalent to passing in all of its
+// Providing a multi-context to AddContext is equivalent to adding all of its
 // individual contexts separately.
 func (c *LDScopedClient) AddContext(contexts ...ldcontext.Context) {
 	c.Lock()
@@ -141,8 +141,8 @@ func (c *LDScopedClient) overwriteIndividualContextByKind(context ldcontext.Cont
 //	scopedClient.OverwriteContextByKind(ldcontext.NewWithKind("company", "monsoon"))
 //	scopedClient.CurrentContext() // returns a multi-context with "monsoon" and "user-key"
 //
-// Passing a multi-context to OverwriteContextByKind is equivalent to passing in
-// all of its individual contexts separately.
+// Providing a multi-context to OverwriteContextByKind is equivalent to calling
+// OverwriteContextByKind on each of the multi-context's individual contexts.
 func (c *LDScopedClient) OverwriteContextByKind(contexts ...ldcontext.Context) {
 	c.Lock()
 	defer c.Unlock()

--- a/ldclient_scoped.go
+++ b/ldclient_scoped.go
@@ -179,7 +179,8 @@ func (c *LDScopedClient) Client() *LDClient {
 
 // Contextual methods: equivalent to calling the same method on the underlying client with the current context
 
-// BoolVariation returns the value of a boolean feature flag for the current evaluation context.
+// BoolVariation returns the value of a boolean feature flag for the current
+// evaluation context.
 //
 // Returns defaultVal if there is an error, if the flag doesn't exist, or the feature is turned off and
 // has no off variation.
@@ -189,10 +190,11 @@ func (c *LDScopedClient) BoolVariation(key string, defaultVal bool) (bool, error
 	return c.client.BoolVariation(key, c.CurrentContext(), defaultVal)
 }
 
-// BoolVariationCtx is the same as [LDScopedClient.BoolVariation], but accepts a context.Context.
+// BoolVariationCtx is the same as [LDScopedClient.BoolVariation], but accepts a
+// context.Context.
 //
-// Cancelling the context.Context will not cause the evaluation to be cancelled. The context.Context is used
-// by hook implementations refer to [ldhooks.Hook].
+// Cancelling the context.Context will not cause the evaluation to be cancelled.
+// The context.Context is used by hook implementations refer to [ldhooks.Hook].
 //
 // For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluating#go
 func (c *LDScopedClient) BoolVariationCtx(
@@ -203,19 +205,22 @@ func (c *LDScopedClient) BoolVariationCtx(
 	return c.client.BoolVariationCtx(ctx, key, c.CurrentContext(), defaultVal)
 }
 
-// BoolVariationDetail is the same as [LDScopedClient.BoolVariation], but also returns further information about how
-// the value was calculated. The "reason" data will also be included in analytics events.
+// BoolVariationDetail is the same as [LDScopedClient.BoolVariation], but also
+// returns further information about how the value was calculated. The "reason"
+// data will also be included in analytics events.
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
 func (c *LDScopedClient) BoolVariationDetail(key string, defaultVal bool) (bool, ldreason.EvaluationDetail, error) {
 	return c.client.BoolVariationDetail(key, c.CurrentContext(), defaultVal)
 }
 
-// BoolVariationDetailCtx is the same as [LDScopedClient.BoolVariationCtx], but also returns further information about how
-// the value was calculated. The "reason" data will also be included in analytics events.
+// BoolVariationDetailCtx is the same as [LDScopedClient.BoolVariationCtx], but
+// also returns further information about how the value was calculated. The
+// "reason" data will also be included in analytics events.
 //
-// Cancelling the context.Context will not cause the evaluation to be cancelled. The context.Context is used
-// by hook implementations refer to [ldhooks.Hook].
+// Cancelling the context.Context will not cause the evaluation to be cancelled.
+// The context.Context is used by hook implementations refer to [ldhooks.Hook].
 //
 // For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
 func (c *LDScopedClient) BoolVariationDetailCtx(
@@ -226,24 +231,29 @@ func (c *LDScopedClient) BoolVariationDetailCtx(
 	return c.client.BoolVariationDetailCtx(ctx, key, c.CurrentContext(), defaultVal)
 }
 
-// IntVariation returns the value of a feature flag (whose variations are integers) for the current evaluation context.
+// IntVariation returns the value of a feature flag (whose variations are
+// integers) for the current evaluation context.
 //
-// Returns defaultVal if there is an error, if the flag doesn't exist, or the feature is turned off and
-// has no off variation.
+// Returns defaultVal if there is an error, if the flag doesn't exist, or the
+// feature is turned off and has no off variation.
 //
-// If the flag variation has a numeric value that is not an integer, it is rounded toward zero (truncated).
+// If the flag variation has a numeric value that is not an integer, it is
+// rounded toward zero (truncated).
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluating#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/evaluating#go
 func (c *LDScopedClient) IntVariation(key string, defaultVal int) (int, error) {
 	return c.client.IntVariation(key, c.CurrentContext(), defaultVal)
 }
 
-// IntVariationCtx is the same as [LDScopedClient.IntVariation], but accepts a context.Context.
+// IntVariationCtx is the same as [LDScopedClient.IntVariation], but accepts a
+// context.Context.
 //
-// Cancelling the context.Context will not cause the evaluation to be cancelled. The context.Context is used
-// by hook implementations refer to [ldhooks.Hook].
+// Cancelling the context.Context will not cause the evaluation to be cancelled.
+// The context.Context is used by hook implementations refer to [ldhooks.Hook].
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluating#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/evaluating#go
 func (c *LDScopedClient) IntVariationCtx(
 	ctx gocontext.Context,
 	key string,
@@ -252,19 +262,22 @@ func (c *LDScopedClient) IntVariationCtx(
 	return c.client.IntVariationCtx(ctx, key, c.CurrentContext(), defaultVal)
 }
 
-// IntVariationDetail is the same as [LDScopedClient.IntVariation], but also returns further information about how
-// the value was calculated. The "reason" data will also be included in analytics events.
+// IntVariationDetail is the same as [LDScopedClient.IntVariation], but also
+// returns further information about how the value was calculated. The "reason"
+// data will also be included in analytics events.
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
 func (c *LDScopedClient) IntVariationDetail(key string, defaultVal int) (int, ldreason.EvaluationDetail, error) {
 	return c.client.IntVariationDetail(key, c.CurrentContext(), defaultVal)
 }
 
-// IntVariationDetailCtx is the same as [LDScopedClient.IntVariationCtx], but also returns further information about how
-// the value was calculated. The "reason" data will also be included in analytics events.
+// IntVariationDetailCtx is the same as [LDScopedClient.IntVariationCtx], but
+// also returns further information about how the value was calculated. The
+// "reason" data will also be included in analytics events.
 //
-// Cancelling the context.Context will not cause the evaluation to be cancelled. The context.Context is used
-// by hook implementations refer to [ldhooks.Hook].
+// Cancelling the context.Context will not cause the evaluation to be cancelled.
+// The context.Context is used by hook implementations refer to [ldhooks.Hook].
 //
 // For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
 func (c *LDScopedClient) IntVariationDetailCtx(
@@ -275,23 +288,26 @@ func (c *LDScopedClient) IntVariationDetailCtx(
 	return c.client.IntVariationDetailCtx(ctx, key, c.CurrentContext(), defaultVal)
 }
 
-// Float64Variation returns the value of a feature flag (whose variations are floats) for the current evaluation
-// context.
+// Float64Variation returns the value of a feature flag (whose variations are
+// floats) for the current evaluation context.
 //
-// Returns defaultVal if there is an error, if the flag doesn't exist, or the feature is turned off and
-// has no off variation.
+// Returns defaultVal if there is an error, if the flag doesn't exist, or the
+// feature is turned off and has no off variation.
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluating#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/evaluating#go
 func (c *LDScopedClient) Float64Variation(key string, defaultVal float64) (float64, error) {
 	return c.client.Float64Variation(key, c.CurrentContext(), defaultVal)
 }
 
-// Float64VariationCtx is the same as [LDScopedClient.Float64Variation], but accepts a context.Context.
+// Float64VariationCtx is the same as [LDScopedClient.Float64Variation], but
+// accepts a context.Context.
 //
-// Cancelling the context.Context will not cause the evaluation to be cancelled. The context.Context is used
-// by hook implementations refer to [ldhooks.Hook].
+// Cancelling the context.Context will not cause the evaluation to be cancelled.
+// The context.Context is used by hook implementations refer to [ldhooks.Hook].
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluating#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/evaluating#go
 func (c *LDScopedClient) Float64VariationCtx(
 	ctx gocontext.Context,
 	key string,
@@ -300,21 +316,25 @@ func (c *LDScopedClient) Float64VariationCtx(
 	return c.client.Float64VariationCtx(ctx, key, c.CurrentContext(), defaultVal)
 }
 
-// Float64VariationDetail is the same as [LDScopedClient.Float64Variation], but also returns further information about how
-// the value was calculated. The "reason" data will also be included in analytics events.
+// Float64VariationDetail is the same as [LDScopedClient.Float64Variation], but
+// also returns further information about how the value was calculated. The
+// "reason" data will also be included in analytics events.
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
 func (c *LDScopedClient) Float64VariationDetail(key string, defaultVal float64) (float64, ldreason.EvaluationDetail, error) {
 	return c.client.Float64VariationDetail(key, c.CurrentContext(), defaultVal)
 }
 
-// Float64VariationDetailCtx is the same as [LDScopedClient.Float64VariationCtx], but also returns further information about how
-// the value was calculated. The "reason" data will also be included in analytics events.
+// Float64VariationDetailCtx is the same as [LDScopedClient.Float64VariationCtx],
+// but also returns further information about how the value was calculated. The
+// "reason" data will also be included in analytics events.
 //
-// Cancelling the context.Context will not cause the evaluation to be cancelled. The context.Context is used
-// by hook implementations refer to [ldhooks.Hook].
+// Cancelling the context.Context will not cause the evaluation to be cancelled.
+// The context.Context is used by hook implementations refer to [ldhooks.Hook].
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
 func (c *LDScopedClient) Float64VariationDetailCtx(
 	ctx gocontext.Context,
 	key string,
@@ -323,23 +343,26 @@ func (c *LDScopedClient) Float64VariationDetailCtx(
 	return c.client.Float64VariationDetailCtx(ctx, key, c.CurrentContext(), defaultVal)
 }
 
-// StringVariation returns the value of a feature flag (whose variations are strings) for the current evaluation
-// context.
+// StringVariation returns the value of a feature flag (whose variations are
+// strings) for the current evaluation context.
 //
-// Returns defaultVal if there is an error, if the flag doesn't exist, or the feature is turned off and has
-// no off variation.
+// Returns defaultVal if there is an error, if the flag doesn't exist, or the
+// feature is turned off and has no off variation.
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluating#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/evaluating#go
 func (c *LDScopedClient) StringVariation(key string, defaultVal string) (string, error) {
 	return c.client.StringVariation(key, c.CurrentContext(), defaultVal)
 }
 
-// StringVariationCtx is the same as [LDScopedClient.StringVariation], but accepts a context.Context.
+// StringVariationCtx is the same as [LDScopedClient.StringVariation], but
+// accepts a context.Context.
 //
-// Cancelling the context.Context will not cause the evaluation to be cancelled. The context.Context is used
-// by hook implementations refer to [ldhooks.Hook].
+// Cancelling the context.Context will not cause the evaluation to be cancelled.
+// The context.Context is used by hook implementations refer to [ldhooks.Hook].
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluating#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/evaluating#go
 func (c *LDScopedClient) StringVariationCtx(
 	ctx gocontext.Context,
 	key string,
@@ -348,21 +371,25 @@ func (c *LDScopedClient) StringVariationCtx(
 	return c.client.StringVariationCtx(ctx, key, c.CurrentContext(), defaultVal)
 }
 
-// StringVariationDetail is the same as [LDScopedClient.StringVariation], but also returns further information about how
-// the value was calculated. The "reason" data will also be included in analytics events.
+// StringVariationDetail is the same as [LDScopedClient.StringVariation], but
+// also returns further information about how the value was calculated. The
+// "reason" data will also be included in analytics events.
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
 func (c *LDScopedClient) StringVariationDetail(key string, defaultVal string) (string, ldreason.EvaluationDetail, error) {
 	return c.client.StringVariationDetail(key, c.CurrentContext(), defaultVal)
 }
 
-// StringVariationDetailCtx is the same as [LDScopedClient.StringVariationCtx], but also returns further information about how
-// the value was calculated. The "reason" data will also be included in analytics events.
+// StringVariationDetailCtx is the same as [LDScopedClient.StringVariationCtx],
+// but also returns further information about how the value was calculated. The
+// "reason" data will also be included in analytics events.
 //
-// Cancelling the context.Context will not cause the evaluation to be cancelled. The context.Context is used
-// by hook implementations refer to [ldhooks.Hook].
+// Cancelling the context.Context will not cause the evaluation to be cancelled.
+// The context.Context is used by hook implementations refer to [ldhooks.Hook].
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
 func (c *LDScopedClient) StringVariationDetailCtx(
 	ctx gocontext.Context,
 	key string,
@@ -371,12 +398,13 @@ func (c *LDScopedClient) StringVariationDetailCtx(
 	return c.client.StringVariationDetailCtx(ctx, key, c.CurrentContext(), defaultVal)
 }
 
-// JSONVariation returns the value of a feature flag for the current evaluation context, allowing the value to
-// be of any JSON type.
+// JSONVariation returns the value of a feature flag for the current evaluation
+// context, allowing the value to be of any JSON type.
 //
-// The value is returned as an [ldvalue.Value], which can be inspected or converted to other types using
-// methods such as [ldvalue.Value.GetType] and [ldvalue.Value.BoolValue]. The defaultVal parameter also uses this
-// type. For instance, if the values for this flag are JSON arrays:
+// The value is returned as an [ldvalue.Value], which can be inspected or
+// converted to other types using methods such as [ldvalue.Value.GetType] and
+// [ldvalue.Value.BoolValue]. The defaultVal parameter also uses this type. For
+// instance, if the values for this flag are JSON arrays:
 //
 //	defaultValAsArray := ldvalue.BuildArray().
 //	    Add(ldvalue.String("defaultFirstItem")).
@@ -391,19 +419,23 @@ func (c *LDScopedClient) StringVariationDetailCtx(
 //	result, err := client.JSONVariation(flagKey, defaultValAsRawJSON)
 //	resultAsRawJSON := result.AsRaw()
 //
-// Returns defaultVal if there is an error, if the flag doesn't exist, or the feature is turned off.
+// Returns defaultVal if there is an error, if the flag doesn't exist, or the
+// feature is turned off.
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluating#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/evaluating#go
 func (c *LDScopedClient) JSONVariation(key string, defaultVal ldvalue.Value) (ldvalue.Value, error) {
 	return c.client.JSONVariation(key, c.CurrentContext(), defaultVal)
 }
 
-// JSONVariationCtx is the same as [LDScopedClient.JSONVariation], but accepts a context.Context.
+// JSONVariationCtx is the same as [LDScopedClient.JSONVariation], but accepts a
+// context.Context.
 //
-// Cancelling the context.Context will not cause the evaluation to be cancelled. The context.Context is used
-// by hook implementations refer to [ldhooks.Hook].
+// Cancelling the context.Context will not cause the evaluation to be cancelled.
+// The context.Context is used by hook implementations refer to [ldhooks.Hook].
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluating#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/evaluating#go
 func (c *LDScopedClient) JSONVariationCtx(
 	ctx gocontext.Context,
 	key string,
@@ -412,21 +444,25 @@ func (c *LDScopedClient) JSONVariationCtx(
 	return c.client.JSONVariationCtx(ctx, key, c.CurrentContext(), defaultVal)
 }
 
-// JSONVariationDetail is the same as [LDScopedClient.JSONVariation], but also returns further information about how
-// the value was calculated. The "reason" data will also be included in analytics events.
+// JSONVariationDetail is the same as [LDScopedClient.JSONVariation], but also
+// returns further information about how the value was calculated. The "reason"
+// data will also be included in analytics events.
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
 func (c *LDScopedClient) JSONVariationDetail(key string, defaultVal ldvalue.Value) (ldvalue.Value, ldreason.EvaluationDetail, error) {
 	return c.client.JSONVariationDetail(key, c.CurrentContext(), defaultVal)
 }
 
-// JSONVariationDetailCtx is the same as [LDScopedClient.JSONVariationCtx], but also returns further information about how
-// the value was calculated. The "reason" data will also be included in analytics events.
+// JSONVariationDetailCtx is the same as [LDScopedClient.JSONVariationCtx], but
+// also returns further information about how the value was calculated. The
+// "reason" data will also be included in analytics events.
 //
-// Cancelling the context.Context will not cause the evaluation to be cancelled. The context.Context is used
-// by hook implementations refer to [ldhooks.Hook].
+// Cancelling the context.Context will not cause the evaluation to be cancelled.
+// The context.Context is used by hook implementations refer to [ldhooks.Hook].
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
 func (c *LDScopedClient) JSONVariationDetailCtx(
 	ctx gocontext.Context,
 	key string,
@@ -435,7 +471,8 @@ func (c *LDScopedClient) JSONVariationDetailCtx(
 	return c.client.JSONVariationDetailCtx(ctx, key, c.CurrentContext(), defaultVal)
 }
 
-// MigrationVariation returns the migration stage of the migration feature flag for the current evaluation context.
+// MigrationVariation returns the migration stage of the migration feature flag
+// for the current evaluation context.
 //
 // Returns defaultStage if there is an error or if the flag doesn't exist.
 //
@@ -447,12 +484,14 @@ func (c *LDScopedClient) MigrationVariation(
 	return c.client.MigrationVariation(key, c.CurrentContext(), defaultStage)
 }
 
-// MigrationVariationCtx is the same as [LDScopedClient.MigrationVariation], but accepts a context.Context.
+// MigrationVariationCtx is the same as [LDScopedClient.MigrationVariation], but
+// accepts a context.Context.
 //
-// Cancelling the context.Context will not cause the evaluation to be cancelled. The context.Context is used
-// by hook implementations refer to [ldhooks.Hook].
+// Cancelling the context.Context will not cause the evaluation to be cancelled.
+// The context.Context is used by hook implementations refer to [ldhooks.Hook].
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluating#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/evaluating#go
 func (c *LDScopedClient) MigrationVariationCtx(
 	ctx gocontext.Context,
 	key string,
@@ -463,29 +502,33 @@ func (c *LDScopedClient) MigrationVariationCtx(
 
 // Identify sends an identify event for the current evaluation context.
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/identify#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/identify#go
 func (c *LDScopedClient) Identify() error {
 	return c.client.Identify(c.CurrentContext())
 }
 
 // TrackEvent sends a custom event for the current evaluation context.
 //
-// The eventName parameter is defined by the application and will be shown in analytics reports;
-// it normally corresponds to the event name of a metric that you have created through the
-// LaunchDarkly dashboard. If you want to associate additional data with this event, use [TrackData]
-// or [TrackMetric].
+// The eventName parameter is defined by the application and will be shown in
+// analytics reports; it normally corresponds to the event name of a metric that
+// you have created through the LaunchDarkly dashboard. If you want to associate
+// additional data with this event, use [TrackData] or [TrackMetric].
 //
 // For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/events#go
 func (c *LDScopedClient) TrackEvent(eventName string) error {
 	return c.client.TrackEvent(eventName, c.CurrentContext())
 }
 
-// TrackEventCtx is the same as [LDScopedClient.TrackEvent], but accepts a context.Context.
+// TrackEventCtx is the same as [LDScopedClient.TrackEvent], but accepts a
+// context.Context.
 //
-// Cancelling the context.Context will not cause the track operation to be cancelled. The context.Context is
-// used by hook implementations refer to [ldhooks.Hook].
+// Cancelling the context.Context will not cause the track operation to be
+// cancelled. The context.Context is used by hook implementations refer to
+// [ldhooks.Hook].
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/events#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/events#go
 func (c *LDScopedClient) TrackEventCtx(
 	ctx gocontext.Context,
 	eventName string,
@@ -493,27 +536,33 @@ func (c *LDScopedClient) TrackEventCtx(
 	return c.client.TrackEventCtx(ctx, eventName, c.CurrentContext())
 }
 
-// TrackData sends a custom event for the current evaluation context, with custom data.
+// TrackData sends a custom event for the current evaluation context, with custom
+// data.
 //
-// The eventName parameter is defined by the application and will be shown in analytics reports;
-// it normally corresponds to the event name of a metric that you have created through the
-// LaunchDarkly dashboard.
+// The eventName parameter is defined by the application and will be shown in
+// analytics reports; it normally corresponds to the event name of a metric that
+// you have created through the LaunchDarkly dashboard.
 //
-// The data parameter is a value of any JSON type, represented with the [ldvalue.Value] type, that
-// will be sent with the event. If no such value is needed, use [ldvalue.Null]() (or call [TrackEvent]
-// instead). To send a numeric value for experimentation, use [TrackMetric].
+// The data parameter is a value of any JSON type, represented with the
+// [ldvalue.Value] type, that will be sent with the event. If no such value is
+// needed, use [ldvalue.Null]() (or call [TrackEvent] instead). To send a numeric
+// value for experimentation, use [TrackMetric].
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/events#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/events#go
 func (c *LDScopedClient) TrackData(eventName string, data ldvalue.Value) error {
 	return c.client.TrackData(eventName, c.CurrentContext(), data)
 }
 
-// TrackDataCtx is the same as [LDScopedClient.TrackData], but accepts a context.Context.
+// TrackDataCtx is the same as [LDScopedClient.TrackData], but accepts a
+// context.Context.
 //
-// Cancelling the context.Context will not cause the track operation to be cancelled. The context.Context is
-// used by hook implementations refer to [ldhooks.Hook].
+// Cancelling the context.Context will not cause the track operation to be
+// cancelled. The context.Context is used by hook implementations refer to
+// [ldhooks.Hook].
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/events#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/events#go
 func (c *LDScopedClient) TrackDataCtx(
 	ctx gocontext.Context,
 	eventName string,
@@ -522,26 +571,32 @@ func (c *LDScopedClient) TrackDataCtx(
 	return c.client.TrackDataCtx(ctx, eventName, c.CurrentContext(), data)
 }
 
-// TrackMetric sends a custom event for the current evaluation context, with a numeric value.
+// TrackMetric sends a custom event for the current evaluation context, with a
+// numeric value.
 //
-// The eventName parameter is defined by the application and will be shown in analytics reports;
-// it normally corresponds to the event name of a metric that you have created through the
-// LaunchDarkly dashboard.
+// The eventName parameter is defined by the application and will be shown in
+// analytics reports; it normally corresponds to the event name of a metric that
+// you have created through the LaunchDarkly dashboard.
 //
-// The data parameter is a value of any JSON type, represented with the [ldvalue.Value] type, that
-// will be sent with the event. If no such value is needed, use [ldvalue.Null]().
+// The data parameter is a value of any JSON type, represented with the
+// [ldvalue.Value] type, that will be sent with the event. If no such value is
+// needed, use [ldvalue.Null]().
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/events#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/events#go
 func (c *LDScopedClient) TrackMetric(eventName string, metricValue float64, data ldvalue.Value) error {
 	return c.client.TrackMetric(eventName, c.CurrentContext(), metricValue, data)
 }
 
-// TrackMetricCtx is the same as [LDScopedClient.TrackMetric], but accepts a context.Context.
+// TrackMetricCtx is the same as [LDScopedClient.TrackMetric], but accepts a
+// context.Context.
 //
-// Cancelling the context.Context will not cause the track operation to be cancelled. The context.Context is
-// used by hook implementations refer to [ldhooks.Hook].
+// Cancelling the context.Context will not cause the track operation to be
+// cancelled. The context.Context is used by hook implementations refer to
+// [ldhooks.Hook].
 //
-// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/events#go
+// For more information, see the Reference Guide:
+// https://docs.launchdarkly.com/sdk/features/events#go
 func (c *LDScopedClient) TrackMetricCtx(
 	ctx gocontext.Context,
 	eventName string,

--- a/ldclient_scoped.go
+++ b/ldclient_scoped.go
@@ -12,11 +12,44 @@ import (
 	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
 )
 
-// TODO:
-// - add docstrings to everything
-// - e2e tests (ld_client_end_to_end_test.go?)
-// - unit tests for context collector piece
-
+// LDScopedClient is a wrapper around LDClient that lets you specify the context
+// to be used for all operations, rather than taking a context as a parameter
+// every time you call a method.
+//
+// A LDScopedClient is created by calling [LDClient.ForContext]. This sets the
+// initial context to be used for all operations:
+//
+//	userContext := ldcontext.New("user-key")
+//	scopedClient := client.ForContext(userContext)
+//	scopedClient.BoolVariation("flag-key", false)
+//
+// Scoped contexts are mutable, to facilitate incrementally building up a
+// multi-context representing the current scope. However, you should create a
+// new scoped client for each logical scope where the contexts are different. For
+// instance, if you are using a scoped client in an HTTP request handler, you
+// should create a new scoped client for each request. You should only use the
+// mutable features of LDScopedClient to add new contexts, not to change or
+// remove existing data. A scoped client is thread-safe, so you can safely use it
+// from multiple goroutines.
+//
+// You may add new contexts with [LDScopedClient.AddContext]. The scoped client's
+// contexts so far are combined into a multi-context whenever the scoped client
+// is used. This is useful when more contexts become available later in the
+// lifecycle of a request. For instance, you might have a `user` context that is
+// available early in the request, but you also want to evaluate flags with a
+// `company` context that is only available later:
+//
+//	company := fetchCompanyForUser(user)
+//	scopedClient.AddContext(ldcontext.NewWithKind("company", company.Id))
+//	scopedClient.BoolVariation("enterprise-features", false)
+//
+// You can also overwrite a context that was previously added, by calling
+// [LDScopedClient.OverwriteContextByKind]. This can be used when an existing
+// context needs to be updated with new data:
+//
+//	entitlements := fetchUserEntitlements(user)
+//	fullUserCtx := ldcontext.NewBuilder(user.Id).Set("entitlements", entitlements).Build()
+//	scopedClient.OverwriteContextByKind(fullUserCtx)
 type LDScopedClient struct {
 	sync.Mutex
 	client *LDClient
@@ -28,6 +61,21 @@ type LDScopedClient struct {
 	rebuild bool
 }
 
+// ForContext creates a new LDScopedClient with an initial context. This scoped
+// client wraps the original client, using the specified context for all
+// operations, like evaluating feature flags or sending events. The scoped client
+// supports most of the same methods as LDClient, like BoolVariation et al., but
+// without the context parameter.
+//
+// You may pass a multi-context, or multiple individual contexts, to ForContext.
+// All of the contexts passed in will be combined into a multi-context when the
+// scoped client is used.
+//
+// You should create a new scoped client for each logical scope where the
+// contexts are isolated from each other, like a web request.
+//
+// For more info on how to use the scoped client, see the documentation for
+// LDScopedClient.
 func (c *LDClient) ForContext(contexts ...ldcontext.Context) *LDScopedClient {
 	cc := &LDScopedClient{
 		client:   c,
@@ -46,6 +94,16 @@ func (c *LDScopedClient) addIndividualContext(context ldcontext.Context) {
 	c.contexts[context.Kind()] = context
 }
 
+// AddContext adds additional contexts to the scoped client, affecting all future
+// operations on it, like flag evaluations and event tracking.
+//
+// All of the contexts added must have kinds that are not already present. If you
+// try to add a context with a duplicate kind, the new context will not be added
+// and a warning will be logged. If you want to replace an existing context, use
+// [LDScopedClient.OverwriteContextByKind] instead.
+//
+// The scoped client's contexts so far are combined into a multi-context whenever the
+// scoped client is used.
 func (c *LDScopedClient) AddContext(contexts ...ldcontext.Context) {
 	c.Lock()
 	defer c.Unlock()
@@ -66,6 +124,20 @@ func (c *LDScopedClient) overwriteIndividualContextByKind(context ldcontext.Cont
 	c.contexts[context.Kind()] = context
 }
 
+// OverwriteContextByKind overwrites an existing context in the scoped client, affecting all future
+// operations on it, like flag evaluations and event tracking.
+//
+// You may pass a multi-context, or multiple individual contexts, to OverwriteContextByKind.
+// Any existing contexts with the same kind as any of the new contexts will be overwritten.
+//
+// If the scoped client had multiple contexts, only the context with the same kind as the new context
+// will be overwritten. Any other existing contexts will remain unchanged:
+//
+//	company := ldcontext.NewWithKind("company", "acme")
+//	scopedClient := client.ForContext(company)
+//	scopedClient.AddContext(ldcontext.New("user-key"))
+//	scopedClient.OverwriteContextByKind(ldcontext.NewWithKind("company", "monsoon"))
+//	scopedClient.CurrentContext() // returns a multi-context with "monsoon" and "user-key"
 func (c *LDScopedClient) OverwriteContextByKind(contexts ...ldcontext.Context) {
 	c.Lock()
 	defer c.Unlock()
@@ -82,6 +154,9 @@ func (c *LDScopedClient) OverwriteContextByKind(contexts ...ldcontext.Context) {
 	}
 }
 
+// CurrentContext returns the current context for the scoped client. This is the
+// combination of all the contexts that have been added so far, as a
+// multi-context.
 func (c *LDScopedClient) CurrentContext() ldcontext.Context {
 	c.Lock()
 	defer c.Unlock()
@@ -97,16 +172,29 @@ func (c *LDScopedClient) CurrentContext() ldcontext.Context {
 	return c.context
 }
 
+// Client returns the underlying LDClient that this scoped client wraps.
 func (c *LDScopedClient) Client() *LDClient {
 	return c.client
 }
 
 // Contextual methods: equivalent to calling the same method on the underlying client with the current context
 
+// BoolVariation returns the value of a boolean feature flag for the current evaluation context.
+//
+// Returns defaultVal if there is an error, if the flag doesn't exist, or the feature is turned off and
+// has no off variation.
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluating#go
 func (c *LDScopedClient) BoolVariation(key string, defaultVal bool) (bool, error) {
 	return c.client.BoolVariation(key, c.CurrentContext(), defaultVal)
 }
 
+// BoolVariationCtx is the same as [LDScopedClient.BoolVariation], but accepts a context.Context.
+//
+// Cancelling the context.Context will not cause the evaluation to be cancelled. The context.Context is used
+// by hook implementations refer to [ldhooks.Hook].
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluating#go
 func (c *LDScopedClient) BoolVariationCtx(
 	ctx gocontext.Context,
 	key string,
@@ -115,10 +203,21 @@ func (c *LDScopedClient) BoolVariationCtx(
 	return c.client.BoolVariationCtx(ctx, key, c.CurrentContext(), defaultVal)
 }
 
+// BoolVariationDetail is the same as [LDScopedClient.BoolVariation], but also returns further information about how
+// the value was calculated. The "reason" data will also be included in analytics events.
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
 func (c *LDScopedClient) BoolVariationDetail(key string, defaultVal bool) (bool, ldreason.EvaluationDetail, error) {
 	return c.client.BoolVariationDetail(key, c.CurrentContext(), defaultVal)
 }
 
+// BoolVariationDetailCtx is the same as [LDScopedClient.BoolVariationCtx], but also returns further information about how
+// the value was calculated. The "reason" data will also be included in analytics events.
+//
+// Cancelling the context.Context will not cause the evaluation to be cancelled. The context.Context is used
+// by hook implementations refer to [ldhooks.Hook].
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
 func (c *LDScopedClient) BoolVariationDetailCtx(
 	ctx gocontext.Context,
 	key string,
@@ -127,10 +226,24 @@ func (c *LDScopedClient) BoolVariationDetailCtx(
 	return c.client.BoolVariationDetailCtx(ctx, key, c.CurrentContext(), defaultVal)
 }
 
+// IntVariation returns the value of a feature flag (whose variations are integers) for the current evaluation context.
+//
+// Returns defaultVal if there is an error, if the flag doesn't exist, or the feature is turned off and
+// has no off variation.
+//
+// If the flag variation has a numeric value that is not an integer, it is rounded toward zero (truncated).
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluating#go
 func (c *LDScopedClient) IntVariation(key string, defaultVal int) (int, error) {
 	return c.client.IntVariation(key, c.CurrentContext(), defaultVal)
 }
 
+// IntVariationCtx is the same as [LDScopedClient.IntVariation], but accepts a context.Context.
+//
+// Cancelling the context.Context will not cause the evaluation to be cancelled. The context.Context is used
+// by hook implementations refer to [ldhooks.Hook].
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluating#go
 func (c *LDScopedClient) IntVariationCtx(
 	ctx gocontext.Context,
 	key string,
@@ -139,10 +252,21 @@ func (c *LDScopedClient) IntVariationCtx(
 	return c.client.IntVariationCtx(ctx, key, c.CurrentContext(), defaultVal)
 }
 
+// IntVariationDetail is the same as [LDScopedClient.IntVariation], but also returns further information about how
+// the value was calculated. The "reason" data will also be included in analytics events.
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
 func (c *LDScopedClient) IntVariationDetail(key string, defaultVal int) (int, ldreason.EvaluationDetail, error) {
 	return c.client.IntVariationDetail(key, c.CurrentContext(), defaultVal)
 }
 
+// IntVariationDetailCtx is the same as [LDScopedClient.IntVariationCtx], but also returns further information about how
+// the value was calculated. The "reason" data will also be included in analytics events.
+//
+// Cancelling the context.Context will not cause the evaluation to be cancelled. The context.Context is used
+// by hook implementations refer to [ldhooks.Hook].
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
 func (c *LDScopedClient) IntVariationDetailCtx(
 	ctx gocontext.Context,
 	key string,
@@ -151,10 +275,23 @@ func (c *LDScopedClient) IntVariationDetailCtx(
 	return c.client.IntVariationDetailCtx(ctx, key, c.CurrentContext(), defaultVal)
 }
 
+// Float64Variation returns the value of a feature flag (whose variations are floats) for the current evaluation
+// context.
+//
+// Returns defaultVal if there is an error, if the flag doesn't exist, or the feature is turned off and
+// has no off variation.
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluating#go
 func (c *LDScopedClient) Float64Variation(key string, defaultVal float64) (float64, error) {
 	return c.client.Float64Variation(key, c.CurrentContext(), defaultVal)
 }
 
+// Float64VariationCtx is the same as [LDScopedClient.Float64Variation], but accepts a context.Context.
+//
+// Cancelling the context.Context will not cause the evaluation to be cancelled. The context.Context is used
+// by hook implementations refer to [ldhooks.Hook].
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluating#go
 func (c *LDScopedClient) Float64VariationCtx(
 	ctx gocontext.Context,
 	key string,
@@ -163,10 +300,21 @@ func (c *LDScopedClient) Float64VariationCtx(
 	return c.client.Float64VariationCtx(ctx, key, c.CurrentContext(), defaultVal)
 }
 
+// Float64VariationDetail is the same as [LDScopedClient.Float64Variation], but also returns further information about how
+// the value was calculated. The "reason" data will also be included in analytics events.
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
 func (c *LDScopedClient) Float64VariationDetail(key string, defaultVal float64) (float64, ldreason.EvaluationDetail, error) {
 	return c.client.Float64VariationDetail(key, c.CurrentContext(), defaultVal)
 }
 
+// Float64VariationDetailCtx is the same as [LDScopedClient.Float64VariationCtx], but also returns further information about how
+// the value was calculated. The "reason" data will also be included in analytics events.
+//
+// Cancelling the context.Context will not cause the evaluation to be cancelled. The context.Context is used
+// by hook implementations refer to [ldhooks.Hook].
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
 func (c *LDScopedClient) Float64VariationDetailCtx(
 	ctx gocontext.Context,
 	key string,
@@ -175,10 +323,23 @@ func (c *LDScopedClient) Float64VariationDetailCtx(
 	return c.client.Float64VariationDetailCtx(ctx, key, c.CurrentContext(), defaultVal)
 }
 
+// StringVariation returns the value of a feature flag (whose variations are strings) for the current evaluation
+// context.
+//
+// Returns defaultVal if there is an error, if the flag doesn't exist, or the feature is turned off and has
+// no off variation.
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluating#go
 func (c *LDScopedClient) StringVariation(key string, defaultVal string) (string, error) {
 	return c.client.StringVariation(key, c.CurrentContext(), defaultVal)
 }
 
+// StringVariationCtx is the same as [LDScopedClient.StringVariation], but accepts a context.Context.
+//
+// Cancelling the context.Context will not cause the evaluation to be cancelled. The context.Context is used
+// by hook implementations refer to [ldhooks.Hook].
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluating#go
 func (c *LDScopedClient) StringVariationCtx(
 	ctx gocontext.Context,
 	key string,
@@ -187,10 +348,21 @@ func (c *LDScopedClient) StringVariationCtx(
 	return c.client.StringVariationCtx(ctx, key, c.CurrentContext(), defaultVal)
 }
 
+// StringVariationDetail is the same as [LDScopedClient.StringVariation], but also returns further information about how
+// the value was calculated. The "reason" data will also be included in analytics events.
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
 func (c *LDScopedClient) StringVariationDetail(key string, defaultVal string) (string, ldreason.EvaluationDetail, error) {
 	return c.client.StringVariationDetail(key, c.CurrentContext(), defaultVal)
 }
 
+// StringVariationDetailCtx is the same as [LDScopedClient.StringVariationCtx], but also returns further information about how
+// the value was calculated. The "reason" data will also be included in analytics events.
+//
+// Cancelling the context.Context will not cause the evaluation to be cancelled. The context.Context is used
+// by hook implementations refer to [ldhooks.Hook].
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
 func (c *LDScopedClient) StringVariationDetailCtx(
 	ctx gocontext.Context,
 	key string,
@@ -199,10 +371,39 @@ func (c *LDScopedClient) StringVariationDetailCtx(
 	return c.client.StringVariationDetailCtx(ctx, key, c.CurrentContext(), defaultVal)
 }
 
+// JSONVariation returns the value of a feature flag for the current evaluation context, allowing the value to
+// be of any JSON type.
+//
+// The value is returned as an [ldvalue.Value], which can be inspected or converted to other types using
+// methods such as [ldvalue.Value.GetType] and [ldvalue.Value.BoolValue]. The defaultVal parameter also uses this
+// type. For instance, if the values for this flag are JSON arrays:
+//
+//	defaultValAsArray := ldvalue.BuildArray().
+//	    Add(ldvalue.String("defaultFirstItem")).
+//	    Add(ldvalue.String("defaultSecondItem")).
+//	    Build()
+//	result, err := client.JSONVariation(flagKey, defaultValAsArray)
+//	firstItemAsString := result.GetByIndex(0).StringValue() // "defaultFirstItem", etc.
+//
+// You can also use unparsed json.RawMessage values:
+//
+//	defaultValAsRawJSON := ldvalue.Raw(json.RawMessage(`{"things":[1,2,3]}`))
+//	result, err := client.JSONVariation(flagKey, defaultValAsRawJSON)
+//	resultAsRawJSON := result.AsRaw()
+//
+// Returns defaultVal if there is an error, if the flag doesn't exist, or the feature is turned off.
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluating#go
 func (c *LDScopedClient) JSONVariation(key string, defaultVal ldvalue.Value) (ldvalue.Value, error) {
 	return c.client.JSONVariation(key, c.CurrentContext(), defaultVal)
 }
 
+// JSONVariationCtx is the same as [LDScopedClient.JSONVariation], but accepts a context.Context.
+//
+// Cancelling the context.Context will not cause the evaluation to be cancelled. The context.Context is used
+// by hook implementations refer to [ldhooks.Hook].
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluating#go
 func (c *LDScopedClient) JSONVariationCtx(
 	ctx gocontext.Context,
 	key string,
@@ -211,10 +412,21 @@ func (c *LDScopedClient) JSONVariationCtx(
 	return c.client.JSONVariationCtx(ctx, key, c.CurrentContext(), defaultVal)
 }
 
+// JSONVariationDetail is the same as [LDScopedClient.JSONVariation], but also returns further information about how
+// the value was calculated. The "reason" data will also be included in analytics events.
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
 func (c *LDScopedClient) JSONVariationDetail(key string, defaultVal ldvalue.Value) (ldvalue.Value, ldreason.EvaluationDetail, error) {
 	return c.client.JSONVariationDetail(key, c.CurrentContext(), defaultVal)
 }
 
+// JSONVariationDetailCtx is the same as [LDScopedClient.JSONVariationCtx], but also returns further information about how
+// the value was calculated. The "reason" data will also be included in analytics events.
+//
+// Cancelling the context.Context will not cause the evaluation to be cancelled. The context.Context is used
+// by hook implementations refer to [ldhooks.Hook].
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluation-reasons#go
 func (c *LDScopedClient) JSONVariationDetailCtx(
 	ctx gocontext.Context,
 	key string,
@@ -223,6 +435,11 @@ func (c *LDScopedClient) JSONVariationDetailCtx(
 	return c.client.JSONVariationDetailCtx(ctx, key, c.CurrentContext(), defaultVal)
 }
 
+// MigrationVariation returns the migration stage of the migration feature flag for the current evaluation context.
+//
+// Returns defaultStage if there is an error or if the flag doesn't exist.
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluating#go
 func (c *LDScopedClient) MigrationVariation(
 	key string,
 	defaultStage ldmigration.Stage,
@@ -230,6 +447,12 @@ func (c *LDScopedClient) MigrationVariation(
 	return c.client.MigrationVariation(key, c.CurrentContext(), defaultStage)
 }
 
+// MigrationVariationCtx is the same as [LDScopedClient.MigrationVariation], but accepts a context.Context.
+//
+// Cancelling the context.Context will not cause the evaluation to be cancelled. The context.Context is used
+// by hook implementations refer to [ldhooks.Hook].
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/evaluating#go
 func (c *LDScopedClient) MigrationVariationCtx(
 	ctx gocontext.Context,
 	key string,
@@ -238,14 +461,31 @@ func (c *LDScopedClient) MigrationVariationCtx(
 	return c.client.MigrationVariationCtx(ctx, key, c.CurrentContext(), defaultStage)
 }
 
+// Identify sends an identify event for the current evaluation context.
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/identify#go
 func (c *LDScopedClient) Identify() error {
 	return c.client.Identify(c.CurrentContext())
 }
 
+// TrackEvent sends a custom event for the current evaluation context.
+//
+// The eventName parameter is defined by the application and will be shown in analytics reports;
+// it normally corresponds to the event name of a metric that you have created through the
+// LaunchDarkly dashboard. If you want to associate additional data with this event, use [TrackData]
+// or [TrackMetric].
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/events#go
 func (c *LDScopedClient) TrackEvent(eventName string) error {
 	return c.client.TrackEvent(eventName, c.CurrentContext())
 }
 
+// TrackEventCtx is the same as [LDScopedClient.TrackEvent], but accepts a context.Context.
+//
+// Cancelling the context.Context will not cause the track operation to be cancelled. The context.Context is
+// used by hook implementations refer to [ldhooks.Hook].
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/events#go
 func (c *LDScopedClient) TrackEventCtx(
 	ctx gocontext.Context,
 	eventName string,
@@ -253,10 +493,27 @@ func (c *LDScopedClient) TrackEventCtx(
 	return c.client.TrackEventCtx(ctx, eventName, c.CurrentContext())
 }
 
+// TrackData sends a custom event for the current evaluation context, with custom data.
+//
+// The eventName parameter is defined by the application and will be shown in analytics reports;
+// it normally corresponds to the event name of a metric that you have created through the
+// LaunchDarkly dashboard.
+//
+// The data parameter is a value of any JSON type, represented with the [ldvalue.Value] type, that
+// will be sent with the event. If no such value is needed, use [ldvalue.Null]() (or call [TrackEvent]
+// instead). To send a numeric value for experimentation, use [TrackMetric].
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/events#go
 func (c *LDScopedClient) TrackData(eventName string, data ldvalue.Value) error {
 	return c.client.TrackData(eventName, c.CurrentContext(), data)
 }
 
+// TrackDataCtx is the same as [LDScopedClient.TrackData], but accepts a context.Context.
+//
+// Cancelling the context.Context will not cause the track operation to be cancelled. The context.Context is
+// used by hook implementations refer to [ldhooks.Hook].
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/events#go
 func (c *LDScopedClient) TrackDataCtx(
 	ctx gocontext.Context,
 	eventName string,
@@ -265,10 +522,26 @@ func (c *LDScopedClient) TrackDataCtx(
 	return c.client.TrackDataCtx(ctx, eventName, c.CurrentContext(), data)
 }
 
+// TrackMetric sends a custom event for the current evaluation context, with a numeric value.
+//
+// The eventName parameter is defined by the application and will be shown in analytics reports;
+// it normally corresponds to the event name of a metric that you have created through the
+// LaunchDarkly dashboard.
+//
+// The data parameter is a value of any JSON type, represented with the [ldvalue.Value] type, that
+// will be sent with the event. If no such value is needed, use [ldvalue.Null]().
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/events#go
 func (c *LDScopedClient) TrackMetric(eventName string, metricValue float64, data ldvalue.Value) error {
 	return c.client.TrackMetric(eventName, c.CurrentContext(), metricValue, data)
 }
 
+// TrackMetricCtx is the same as [LDScopedClient.TrackMetric], but accepts a context.Context.
+//
+// Cancelling the context.Context will not cause the track operation to be cancelled. The context.Context is
+// used by hook implementations refer to [ldhooks.Hook].
+//
+// For more information, see the Reference Guide: https://docs.launchdarkly.com/sdk/features/events#go
 func (c *LDScopedClient) TrackMetricCtx(
 	ctx gocontext.Context,
 	eventName string,
@@ -278,6 +551,7 @@ func (c *LDScopedClient) TrackMetricCtx(
 	return c.client.TrackMetricCtx(ctx, eventName, c.CurrentContext(), metricValue, data)
 }
 
+// TrackMigrationOp reports a migration operation event.
 func (c *LDScopedClient) TrackMigrationOp(event ldevents.MigrationOpEventData) error {
 	return c.client.TrackMigrationOp(event)
 }

--- a/ldclient_scoped.go
+++ b/ldclient_scoped.go
@@ -63,6 +63,10 @@ func (c *LDScopedClient) AddContext(contexts ...ldcontext.Context) {
 	}
 }
 
+func (c *LDScopedClient) overwriteIndividualContextByKind(context ldcontext.Context) {
+	c.contexts[context.Kind()] = context
+}
+
 func (c *LDScopedClient) OverwriteContextByKind(contexts ...ldcontext.Context) {
 	c.Lock()
 	defer c.Unlock()
@@ -70,10 +74,12 @@ func (c *LDScopedClient) OverwriteContextByKind(contexts ...ldcontext.Context) {
 
 	for _, ctx := range contexts {
 		if ctx.Multiple() {
-			c.OverwriteContextByKind(ctx.GetAllIndividualContexts(nil)...)
+			for _, individual := range ctx.GetAllIndividualContexts(nil) {
+				c.overwriteIndividualContextByKind(individual)
+			}
 			continue
 		}
-		c.contexts[ctx.Kind()] = ctx
+		c.overwriteIndividualContextByKind(ctx)
 	}
 }
 

--- a/ldclient_scoped.go
+++ b/ldclient_scoped.go
@@ -16,7 +16,7 @@ import (
 // evaluation context to be used for all operations, rather than taking the
 // evaluation context as a parameter every time you call a method.
 //
-// A LDScopedClient is created by calling [LDClient.ForContext]. This sets the
+// An LDScopedClient is created by calling [LDClient.ForContext]. This sets the
 // initial context to be used for all operations:
 //
 //	userContext := ldcontext.New("user-key")

--- a/ldclient_scoped.go
+++ b/ldclient_scoped.go
@@ -1,9 +1,16 @@
 package ldclient
 
 import (
+	gocontext "context"
 	"sync"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldmigration"
+	"github.com/launchdarkly/go-sdk-common/v3/ldreason"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	ldevents "github.com/launchdarkly/go-sdk-events/v3"
+	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
+	"github.com/launchdarkly/go-server-sdk/v7/interfaces/flagstate"
 )
 
 type LDScopedClient struct {
@@ -72,4 +79,195 @@ func (c *LDScopedClient) CurrentContext() ldcontext.Context {
 	}
 	c.context = b.Build()
 	return c.context
+}
+
+func (c *LDScopedClient) Client() *LDClient {
+	return c.client
+}
+
+// Contextual methods: equivalent to calling the same method on the underlying client with the current context
+
+func (c *LDScopedClient) BoolVariation(key string, defaultVal bool) (bool, error) {
+	return c.client.BoolVariation(key, c.CurrentContext(), defaultVal)
+}
+
+func (c *LDScopedClient) BoolVariationCtx(
+	ctx gocontext.Context,
+	key string,
+	defaultVal bool,
+) (bool, error) {
+	return c.client.BoolVariationCtx(ctx, key, c.CurrentContext(), defaultVal)
+}
+
+func (c *LDScopedClient) BoolVariationDetail(key string, defaultVal bool) (bool, ldreason.EvaluationDetail, error) {
+	return c.client.BoolVariationDetail(key, c.CurrentContext(), defaultVal)
+}
+
+func (c *LDScopedClient) BoolVariationDetailCtx(
+	ctx gocontext.Context,
+	key string,
+	defaultVal bool,
+) (bool, ldreason.EvaluationDetail, error) {
+	return c.client.BoolVariationDetailCtx(ctx, key, c.CurrentContext(), defaultVal)
+}
+
+func (c *LDScopedClient) IntVariation(key string, defaultVal int) (int, error) {
+	return c.client.IntVariation(key, c.CurrentContext(), defaultVal)
+}
+
+func (c *LDScopedClient) IntVariationCtx(
+	ctx gocontext.Context,
+	key string,
+	defaultVal int,
+) (int, error) {
+	return c.client.IntVariationCtx(ctx, key, c.CurrentContext(), defaultVal)
+}
+
+func (c *LDScopedClient) IntVariationDetail(key string, defaultVal int) (int, ldreason.EvaluationDetail, error) {
+	return c.client.IntVariationDetail(key, c.CurrentContext(), defaultVal)
+}
+
+func (c *LDScopedClient) IntVariationDetailCtx(
+	ctx gocontext.Context,
+	key string,
+	defaultVal int,
+) (int, ldreason.EvaluationDetail, error) {
+	return c.client.IntVariationDetailCtx(ctx, key, c.CurrentContext(), defaultVal)
+}
+
+func (c *LDScopedClient) Float64Variation(key string, defaultVal float64) (float64, error) {
+	return c.client.Float64Variation(key, c.CurrentContext(), defaultVal)
+}
+
+func (c *LDScopedClient) Float64VariationCtx(
+	ctx gocontext.Context,
+	key string,
+	defaultVal float64,
+) (float64, error) {
+	return c.client.Float64VariationCtx(ctx, key, c.CurrentContext(), defaultVal)
+}
+
+func (c *LDScopedClient) Float64VariationDetail(key string, defaultVal float64) (float64, ldreason.EvaluationDetail, error) {
+	return c.client.Float64VariationDetail(key, c.CurrentContext(), defaultVal)
+}
+
+func (c *LDScopedClient) Float64VariationDetailCtx(
+	ctx gocontext.Context,
+	key string,
+	defaultVal float64,
+) (float64, ldreason.EvaluationDetail, error) {
+	return c.client.Float64VariationDetailCtx(ctx, key, c.CurrentContext(), defaultVal)
+}
+
+func (c *LDScopedClient) StringVariation(key string, defaultVal string) (string, error) {
+	return c.client.StringVariation(key, c.CurrentContext(), defaultVal)
+}
+
+func (c *LDScopedClient) StringVariationCtx(
+	ctx gocontext.Context,
+	key string,
+	defaultVal string,
+) (string, error) {
+	return c.client.StringVariationCtx(ctx, key, c.CurrentContext(), defaultVal)
+}
+
+func (c *LDScopedClient) StringVariationDetail(key string, defaultVal string) (string, ldreason.EvaluationDetail, error) {
+	return c.client.StringVariationDetail(key, c.CurrentContext(), defaultVal)
+}
+
+func (c *LDScopedClient) StringVariationDetailCtx(
+	ctx gocontext.Context,
+	key string,
+	defaultVal string,
+) (string, ldreason.EvaluationDetail, error) {
+	return c.client.StringVariationDetailCtx(ctx, key, c.CurrentContext(), defaultVal)
+}
+
+func (c *LDScopedClient) JSONVariation(key string, defaultVal ldvalue.Value) (ldvalue.Value, error) {
+	return c.client.JSONVariation(key, c.CurrentContext(), defaultVal)
+}
+
+func (c *LDScopedClient) JSONVariationCtx(
+	ctx gocontext.Context,
+	key string,
+	defaultVal ldvalue.Value,
+) (ldvalue.Value, error) {
+	return c.client.JSONVariationCtx(ctx, key, c.CurrentContext(), defaultVal)
+}
+
+func (c *LDScopedClient) JSONVariationDetail(key string, defaultVal ldvalue.Value) (ldvalue.Value, ldreason.EvaluationDetail, error) {
+	return c.client.JSONVariationDetail(key, c.CurrentContext(), defaultVal)
+}
+
+func (c *LDScopedClient) JSONVariationDetailCtx(
+	ctx gocontext.Context,
+	key string,
+	defaultVal ldvalue.Value,
+) (ldvalue.Value, ldreason.EvaluationDetail, error) {
+	return c.client.JSONVariationDetailCtx(ctx, key, c.CurrentContext(), defaultVal)
+}
+
+func (c *LDScopedClient) MigrationVariation(
+	key string,
+	defaultStage ldmigration.Stage,
+) (ldmigration.Stage, interfaces.LDMigrationOpTracker, error) {
+	return c.client.MigrationVariation(key, c.CurrentContext(), defaultStage)
+}
+
+func (c *LDScopedClient) MigrationVariationCtx(
+	ctx gocontext.Context,
+	key string,
+	defaultStage ldmigration.Stage,
+) (ldmigration.Stage, interfaces.LDMigrationOpTracker, error) {
+	return c.client.MigrationVariationCtx(ctx, key, c.CurrentContext(), defaultStage)
+}
+
+func (c *LDScopedClient) AllFlagsState(
+	options ...flagstate.Option,
+) flagstate.AllFlags {
+	return c.client.AllFlagsState(c.CurrentContext(), options...)
+}
+
+func (c *LDScopedClient) Identify() error {
+	return c.client.Identify(c.CurrentContext())
+}
+
+func (c *LDScopedClient) TrackEvent(eventName string) error {
+	return c.client.TrackEvent(eventName, c.CurrentContext())
+}
+
+func (c *LDScopedClient) TrackEventCtx(
+	ctx gocontext.Context,
+	eventName string,
+) error {
+	return c.client.TrackEventCtx(ctx, eventName, c.CurrentContext())
+}
+
+func (c *LDScopedClient) TrackData(eventName string, data ldvalue.Value) error {
+	return c.client.TrackData(eventName, c.CurrentContext(), data)
+}
+
+func (c *LDScopedClient) TrackDataCtx(
+	ctx gocontext.Context,
+	eventName string,
+	data ldvalue.Value,
+) error {
+	return c.client.TrackDataCtx(ctx, eventName, c.CurrentContext(), data)
+}
+
+func (c *LDScopedClient) TrackMetric(eventName string, metricValue float64, data ldvalue.Value) error {
+	return c.client.TrackMetric(eventName, c.CurrentContext(), metricValue, data)
+}
+
+func (c *LDScopedClient) TrackMetricCtx(
+	ctx gocontext.Context,
+	eventName string,
+	metricValue float64,
+	data ldvalue.Value,
+) error {
+	return c.client.TrackMetricCtx(ctx, eventName, c.CurrentContext(), metricValue, data)
+}
+
+func (c *LDScopedClient) TrackMigrationOp(event ldevents.MigrationOpEventData) error {
+	return c.client.TrackMigrationOp(event)
 }

--- a/ldclient_scoped.go
+++ b/ldclient_scoped.go
@@ -14,7 +14,9 @@ import (
 
 // LDScopedClient is a wrapper around LDClient that lets you specify the
 // evaluation context to be used for all operations, rather than taking the
-// evaluation context as a parameter every time you call a method.
+// evaluation context as a parameter every time you call a method. You should
+// create a new scoped client for each logical scope where the evaluation context
+// should be isolated from other scopes, like a web request.
 //
 // An LDScopedClient is created by calling [LDClient.ForContext]. This sets the
 // initial context to be used for all operations:
@@ -23,33 +25,37 @@ import (
 //	scopedClient := client.ForContext(userContext)
 //	scopedClient.BoolVariation("flag-key", false)
 //
-// Scoped contexts are mutable, to facilitate incrementally building up a
-// multi-context representing the current scope. You should create a new scoped
-// client for each logical scope where the contexts are different. For instance,
-// if you are using a scoped client in an HTTP request handler, you should create
-// a new scoped client for each request. You should only use the mutable features
-// of LDScopedClient to add new contexts, not to change or remove existing data.
-// A scoped client is thread-safe, so you can safely use it from multiple
-// goroutines.
+// A scoped client contains one or more contexts, each with a unique kind. You
+// can add additional contexts with [LDScopedClient.AddContext], as long as the
+// new contexts' kinds are not already present. The "current context" is the
+// combination of all contexts added so far, as a multi-context.
 //
-// You may add new contexts with [LDScopedClient.AddContext]. The scoped client's
-// contexts so far are combined into a multi-context whenever the scoped client
-// is used. This is useful when more contexts become available later in the
+//	scopedClient := client.ForContext(userContext)
+//	scopedClient.CurrentContext() // returns the single "user" context
+//	scopedClient.AddContext(ldcontext.NewWithKind("company", "acme"))
+//	scopedClient.CurrentContext() // returns a multi-context with a "user" and "company" context
+//
+// Adding contexts is useful when more contexts become available later in the
 // lifecycle of a request. For instance, you might have a `user` context that is
 // available early in the request, but you also want to evaluate flags with a
 // `company` context that is only available later:
 //
+//	scopedClient := client.ForContext(ldcontext.New("user-key"))
 //	company := fetchCompanyForUser(user)
 //	scopedClient.AddContext(ldcontext.NewWithKind("company", company.Id))
 //	scopedClient.BoolVariation("enterprise-features", false)
 //
-// You can also overwrite a context that was previously added, by calling
-// [LDScopedClient.OverwriteContextByKind]. This can be used when an existing
-// context needs to be updated with new data:
+// You can also overwrite a context that you previously added, by calling
+// [LDScopedClient.OverwriteContextByKind]. Use this when you need to update an
+// existing context with new data:
 //
 //	entitlements := fetchUserEntitlements(user)
-//	fullUserCtx := ldcontext.NewBuilder(user.Id).Set("entitlements", entitlements).Build()
+//	userCtx := scopedClient.CurrentContext().IndividualContextByKind("user")
+//	fullUserCtx := ldcontext.NewBuilderFromContext(userCtx).Set("entitlements", entitlements).Build()
 //	scopedClient.OverwriteContextByKind(fullUserCtx)
+//
+// A scoped client is thread-safe, so you can safely use it from multiple
+// goroutines.
 type LDScopedClient struct {
 	sync.Mutex
 	client *LDClient

--- a/ldclient_scoped_test.go
+++ b/ldclient_scoped_test.go
@@ -1,6 +1,7 @@
 package ldclient
 
 import (
+	gocontext "context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,6 +9,10 @@ import (
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
 	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
 	"github.com/launchdarkly/go-sdk-common/v3/ldlogtest"
+	"github.com/launchdarkly/go-sdk-common/v3/ldmigration"
+	"github.com/launchdarkly/go-sdk-common/v3/ldreason"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
 	"github.com/launchdarkly/go-server-sdk/v7/ldcomponents"
 )
 
@@ -63,4 +68,318 @@ func TestScopedClientCollectsContexts(t *testing.T) {
 
 		assert.Equal(t, ldcontext.NewMulti(ldctx2, ldctx3, ldctx4, dupeCtx), c.CurrentContext())
 	})
+}
+
+// Testing the scoped versions of all the evaluation methods
+// Almost the same as the tests in ldclient_evaluation_test.go, but with the scoped client instead
+
+func TestScopedBoolVariation(t *testing.T) {
+	expected, defaultVal := true, false
+
+	t.Run("simple", func(t *testing.T) {
+		withClientEvalTestParams(func(p clientEvalTestParams) {
+			p.setupSingleValueFlag(evalFlagKey, ldvalue.Bool(true))
+
+			actual, err := p.client.ForContext(evalTestUser).BoolVariation(evalFlagKey, defaultVal)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual)
+
+			p.expectSingleEvaluationEvent(t, evalFlagKey, ldvalue.Bool(expected), ldvalue.Bool(defaultVal), noReason)
+		})
+	})
+	t.Run("simpleCtx", func(t *testing.T) {
+		withClientEvalTestParams(func(p clientEvalTestParams) {
+			p.setupSingleValueFlag(evalFlagKey, ldvalue.Bool(true))
+
+			actual, err := p.client.ForContext(evalTestUser).BoolVariationCtx(gocontext.TODO(), evalFlagKey, defaultVal)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual)
+
+			p.expectSingleEvaluationEvent(t, evalFlagKey, ldvalue.Bool(expected), ldvalue.Bool(defaultVal), noReason)
+		})
+	})
+	t.Run("detail", func(t *testing.T) {
+		withClientEvalTestParams(func(p clientEvalTestParams) {
+			p.setupSingleValueFlag(evalFlagKey, ldvalue.Bool(true))
+
+			actual, detail, err := p.client.ForContext(evalTestUser).BoolVariationDetail(evalFlagKey, defaultVal)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual)
+			assert.Equal(t, ldreason.NewEvaluationDetail(ldvalue.Bool(expected), expectedVariationForSingleValueFlag,
+				expectedReasonForSingleValueFlag), detail)
+
+			p.expectSingleEvaluationEvent(t, evalFlagKey, ldvalue.Bool(expected), ldvalue.Bool(defaultVal), detail.Reason)
+		})
+	})
+	t.Run("detailCtx", func(t *testing.T) {
+		withClientEvalTestParams(func(p clientEvalTestParams) {
+			p.setupSingleValueFlag(evalFlagKey, ldvalue.Bool(true))
+
+			actual, detail, err := p.client.ForContext(evalTestUser).BoolVariationDetailCtx(gocontext.TODO(), evalFlagKey, defaultVal)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual)
+			assert.Equal(t, ldreason.NewEvaluationDetail(ldvalue.Bool(expected), expectedVariationForSingleValueFlag,
+				expectedReasonForSingleValueFlag), detail)
+
+			p.expectSingleEvaluationEvent(t, evalFlagKey, ldvalue.Bool(expected), ldvalue.Bool(defaultVal), detail.Reason)
+		})
+	})
+}
+
+func TestScopedIntVariation(t *testing.T) {
+	expected, defaultVal := 100, 10000
+
+	t.Run("simple", func(t *testing.T) {
+		withClientEvalTestParams(func(p clientEvalTestParams) {
+			p.setupSingleValueFlag(evalFlagKey, ldvalue.Int(expected))
+
+			actual, err := p.client.ForContext(evalTestUser).IntVariation(evalFlagKey, defaultVal)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual)
+
+			p.expectSingleEvaluationEvent(t, evalFlagKey, ldvalue.Int(expected), ldvalue.Int(defaultVal), noReason)
+		})
+	})
+	t.Run("simpleCtx", func(t *testing.T) {
+		withClientEvalTestParams(func(p clientEvalTestParams) {
+			p.setupSingleValueFlag(evalFlagKey, ldvalue.Int(expected))
+
+			actual, err := p.client.ForContext(evalTestUser).IntVariationCtx(gocontext.TODO(), evalFlagKey, defaultVal)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual)
+
+			p.expectSingleEvaluationEvent(t, evalFlagKey, ldvalue.Int(expected), ldvalue.Int(defaultVal), noReason)
+		})
+	})
+	t.Run("detail", func(t *testing.T) {
+		withClientEvalTestParams(func(p clientEvalTestParams) {
+			p.setupSingleValueFlag(evalFlagKey, ldvalue.Int(expected))
+
+			actual, detail, err := p.client.ForContext(evalTestUser).IntVariationDetail(evalFlagKey, defaultVal)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual)
+			assert.Equal(t, ldreason.NewEvaluationDetail(ldvalue.Int(expected), expectedVariationForSingleValueFlag,
+				expectedReasonForSingleValueFlag), detail)
+
+			p.expectSingleEvaluationEvent(t, evalFlagKey, ldvalue.Int(expected), ldvalue.Int(defaultVal), detail.Reason)
+		})
+	})
+	t.Run("detailCtx", func(t *testing.T) {
+		withClientEvalTestParams(func(p clientEvalTestParams) {
+			p.setupSingleValueFlag(evalFlagKey, ldvalue.Int(expected))
+
+			actual, detail, err := p.client.ForContext(evalTestUser).IntVariationDetailCtx(gocontext.TODO(), evalFlagKey, defaultVal)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual)
+			assert.Equal(t, ldreason.NewEvaluationDetail(ldvalue.Int(expected), expectedVariationForSingleValueFlag,
+				expectedReasonForSingleValueFlag), detail)
+
+			p.expectSingleEvaluationEvent(t, evalFlagKey, ldvalue.Int(expected), ldvalue.Int(defaultVal), detail.Reason)
+		})
+	})
+}
+
+func TestScopedFloat64Variation(t *testing.T) {
+	expected, defaultVal := 100.01, 0.0
+
+	t.Run("simple", func(t *testing.T) {
+		withClientEvalTestParams(func(p clientEvalTestParams) {
+			p.setupSingleValueFlag(evalFlagKey, ldvalue.Float64(expected))
+
+			actual, err := p.client.ForContext(evalTestUser).Float64Variation(evalFlagKey, defaultVal)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual)
+
+			p.expectSingleEvaluationEvent(t, evalFlagKey, ldvalue.Float64(expected), ldvalue.Float64(defaultVal), noReason)
+		})
+	})
+	t.Run("simpleCtx", func(t *testing.T) {
+		withClientEvalTestParams(func(p clientEvalTestParams) {
+			p.setupSingleValueFlag(evalFlagKey, ldvalue.Float64(expected))
+
+			actual, err := p.client.ForContext(evalTestUser).Float64VariationCtx(gocontext.TODO(), evalFlagKey, defaultVal)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual)
+
+			p.expectSingleEvaluationEvent(t, evalFlagKey, ldvalue.Float64(expected), ldvalue.Float64(defaultVal), noReason)
+		})
+	})
+	t.Run("detail", func(t *testing.T) {
+		withClientEvalTestParams(func(p clientEvalTestParams) {
+			p.setupSingleValueFlag(evalFlagKey, ldvalue.Float64(expected))
+
+			actual, detail, err := p.client.ForContext(evalTestUser).Float64VariationDetail(evalFlagKey, defaultVal)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual)
+			assert.Equal(t, ldreason.NewEvaluationDetail(ldvalue.Float64(expected), expectedVariationForSingleValueFlag,
+				expectedReasonForSingleValueFlag), detail)
+
+			p.expectSingleEvaluationEvent(t, evalFlagKey, ldvalue.Float64(expected), ldvalue.Float64(defaultVal), detail.Reason)
+		})
+	})
+	t.Run("detailCtx", func(t *testing.T) {
+		withClientEvalTestParams(func(p clientEvalTestParams) {
+			p.setupSingleValueFlag(evalFlagKey, ldvalue.Float64(expected))
+
+			actual, detail, err := p.client.ForContext(evalTestUser).Float64VariationDetailCtx(gocontext.TODO(), evalFlagKey, defaultVal)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual)
+			assert.Equal(t, ldreason.NewEvaluationDetail(ldvalue.Float64(expected), expectedVariationForSingleValueFlag,
+				expectedReasonForSingleValueFlag), detail)
+
+			p.expectSingleEvaluationEvent(t, evalFlagKey, ldvalue.Float64(expected), ldvalue.Float64(defaultVal), detail.Reason)
+		})
+	})
+}
+
+func TestScopedStringVariation(t *testing.T) {
+	expected, defaultVal := "b", "a"
+
+	t.Run("simple", func(t *testing.T) {
+		withClientEvalTestParams(func(p clientEvalTestParams) {
+			p.setupSingleValueFlag(evalFlagKey, ldvalue.String(expected))
+
+			actual, err := p.client.ForContext(evalTestUser).StringVariation(evalFlagKey, defaultVal)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual)
+
+			p.expectSingleEvaluationEvent(t, evalFlagKey, ldvalue.String(expected), ldvalue.String(defaultVal), noReason)
+		})
+	})
+	t.Run("simpleCtx", func(t *testing.T) {
+		withClientEvalTestParams(func(p clientEvalTestParams) {
+			p.setupSingleValueFlag(evalFlagKey, ldvalue.String(expected))
+
+			actual, err := p.client.ForContext(evalTestUser).StringVariationCtx(gocontext.TODO(), evalFlagKey, defaultVal)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual)
+
+			p.expectSingleEvaluationEvent(t, evalFlagKey, ldvalue.String(expected), ldvalue.String(defaultVal), noReason)
+		})
+	})
+	t.Run("detail", func(t *testing.T) {
+		withClientEvalTestParams(func(p clientEvalTestParams) {
+			p.setupSingleValueFlag(evalFlagKey, ldvalue.String(expected))
+
+			actual, detail, err := p.client.ForContext(evalTestUser).StringVariationDetail(evalFlagKey, defaultVal)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual)
+			assert.Equal(t, ldreason.NewEvaluationDetail(ldvalue.String(expected), expectedVariationForSingleValueFlag,
+				expectedReasonForSingleValueFlag), detail)
+
+			p.expectSingleEvaluationEvent(t, evalFlagKey, ldvalue.String(expected), ldvalue.String(defaultVal), detail.Reason)
+		})
+	})
+	t.Run("detailCtx", func(t *testing.T) {
+		withClientEvalTestParams(func(p clientEvalTestParams) {
+			p.setupSingleValueFlag(evalFlagKey, ldvalue.String(expected))
+
+			actual, detail, err := p.client.ForContext(evalTestUser).StringVariationDetailCtx(gocontext.TODO(), evalFlagKey, defaultVal)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual)
+			assert.Equal(t, ldreason.NewEvaluationDetail(ldvalue.String(expected), expectedVariationForSingleValueFlag,
+				expectedReasonForSingleValueFlag), detail)
+
+			p.expectSingleEvaluationEvent(t, evalFlagKey, ldvalue.String(expected), ldvalue.String(defaultVal), detail.Reason)
+		})
+	})
+}
+
+func TestScopedJSONVariation(t *testing.T) {
+	expected := ldvalue.CopyArbitraryValue(map[string]interface{}{"field2": "value2"})
+	defaultVal := ldvalue.String("no")
+
+	t.Run("simple", func(t *testing.T) {
+		withClientEvalTestParams(func(p clientEvalTestParams) {
+			p.setupSingleValueFlag(evalFlagKey, expected)
+
+			actual, err := p.client.ForContext(evalTestUser).JSONVariation(evalFlagKey, defaultVal)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual)
+
+			p.expectSingleEvaluationEvent(t, evalFlagKey, expected, defaultVal, noReason)
+		})
+	})
+	t.Run("simpleCtx", func(t *testing.T) {
+		withClientEvalTestParams(func(p clientEvalTestParams) {
+			p.setupSingleValueFlag(evalFlagKey, expected)
+
+			actual, err := p.client.ForContext(evalTestUser).JSONVariationCtx(gocontext.TODO(), evalFlagKey, defaultVal)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual)
+
+			p.expectSingleEvaluationEvent(t, evalFlagKey, expected, defaultVal, noReason)
+		})
+	})
+	t.Run("detail", func(t *testing.T) {
+		withClientEvalTestParams(func(p clientEvalTestParams) {
+			p.setupSingleValueFlag(evalFlagKey, expected)
+
+			actual, detail, err := p.client.ForContext(evalTestUser).JSONVariationDetail(evalFlagKey, defaultVal)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual)
+			assert.Equal(t, ldreason.NewEvaluationDetail(expected, expectedVariationForSingleValueFlag,
+				expectedReasonForSingleValueFlag), detail)
+
+			p.expectSingleEvaluationEvent(t, evalFlagKey, expected, defaultVal, detail.Reason)
+		})
+	})
+	t.Run("detailCtx", func(t *testing.T) {
+		withClientEvalTestParams(func(p clientEvalTestParams) {
+			p.setupSingleValueFlag(evalFlagKey, expected)
+
+			actual, detail, err := p.client.ForContext(evalTestUser).JSONVariationDetailCtx(gocontext.TODO(), evalFlagKey, defaultVal)
+
+			assert.NoError(t, err)
+			assert.Equal(t, expected, actual)
+			assert.Equal(t, ldreason.NewEvaluationDetail(expected, expectedVariationForSingleValueFlag,
+				expectedReasonForSingleValueFlag), detail)
+
+			p.expectSingleEvaluationEvent(t, evalFlagKey, expected, defaultVal, detail.Reason)
+		})
+	})
+}
+
+// Scoped version of ldclient_migration_test.go
+
+func TestScopedMigrationVariation(t *testing.T) {
+	t.Run("with MigrationVariation", func(t *testing.T) {
+		runMigrationTests(t, func(client *LDClient,
+			key string,
+			context ldcontext.Context,
+			stage ldmigration.Stage,
+		) (ldmigration.Stage, interfaces.LDMigrationOpTracker, error) {
+			return client.ForContext(context).MigrationVariation(key, stage)
+		})
+	})
+
+	t.Run("with MigrationVariationCtx", func(t *testing.T) {
+		runMigrationTests(t, func(client *LDClient,
+			key string,
+			context ldcontext.Context,
+			stage ldmigration.Stage,
+		) (ldmigration.Stage, interfaces.LDMigrationOpTracker, error) {
+			return client.ForContext(context).MigrationVariationCtx(gocontext.TODO(), key, stage)
+		})
+	})
+
 }

--- a/ldclient_scoped_test.go
+++ b/ldclient_scoped_test.go
@@ -1,0 +1,65 @@
+package ldclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
+	"github.com/launchdarkly/go-sdk-common/v3/ldlogtest"
+	"github.com/launchdarkly/go-server-sdk/v7/ldcomponents"
+)
+
+func TestScopedClientCurrentContext(t *testing.T) {
+	ldctx := ldcontext.New("user1")
+	c := makeTestClient().ForContext(ldctx)
+
+	assert.Equal(t, ldctx, c.CurrentContext())
+}
+
+func TestScopedClientCollectsContexts(t *testing.T) {
+	ldctx1 := ldcontext.NewWithKind("foo", "foo1")
+	ldctx2 := ldcontext.NewMulti(
+		ldcontext.NewWithKind("bar", "bar1"),
+		ldcontext.NewWithKind("baz", "baz1"),
+	)
+	ldctx3 := ldcontext.NewWithKind("qux", "qux1")
+	ldctx4 := ldcontext.NewMulti(
+		ldcontext.NewWithKind("quux", "quux1"),
+		ldcontext.NewWithKind("quuz", "quuz1"),
+	)
+	dupeCtx := ldcontext.NewWithKind("foo", "foo2")
+
+	t.Run("adding contexts happy path", func(t *testing.T) {
+		logCapture := ldlogtest.NewMockLog()
+		c := makeTestClientWithConfig(func(config *Config) {
+			config.Logging = ldcomponents.Logging().Loggers(logCapture.Loggers)
+		}).ForContext(ldctx1, ldctx2)
+
+		c.AddContext(ldctx3, ldctx4)
+
+		assert.Equal(t, ldcontext.NewMulti(ldctx1, ldctx2, ldctx3, ldctx4), c.CurrentContext())
+		assert.Empty(t, logCapture.GetOutput(ldlog.Warn))
+	})
+
+	t.Run("adding duplicate context kinds", func(t *testing.T) {
+		logCapture := ldlogtest.NewMockLog()
+		c := makeTestClientWithConfig(func(config *Config) {
+			config.Logging = ldcomponents.Logging().Loggers(logCapture.Loggers)
+		}).ForContext(ldctx1)
+
+		c.AddContext(dupeCtx)
+
+		assert.Equal(t, ldcontext.NewMulti(ldctx1), c.CurrentContext())
+		logCapture.AssertMessageMatch(t, true, ldlog.Warn, "Tried to add a duplicate foo context to LDScopedClient")
+	})
+
+	t.Run("overwriting contexts", func(t *testing.T) {
+		c := makeTestClient().ForContext(ldctx1, ldctx2, ldctx3, ldctx4)
+
+		c.OverwriteContextByKind(dupeCtx)
+
+		assert.Equal(t, ldcontext.NewMulti(ldctx2, ldctx3, ldctx4, dupeCtx), c.CurrentContext())
+	})
+}

--- a/ldclient_scoped_test.go
+++ b/ldclient_scoped_test.go
@@ -59,6 +59,7 @@ func TestScopedClientCollectsContexts(t *testing.T) {
 		c := makeTestClient().ForContext(ldctx1, ldctx2, ldctx3, ldctx4)
 
 		c.OverwriteContextByKind(dupeCtx)
+		c.OverwriteContextByKind(ldctx2, ldctx3)
 
 		assert.Equal(t, ldcontext.NewMulti(ldctx2, ldctx3, ldctx4, dupeCtx), c.CurrentContext())
 	})

--- a/ldclient_scoped_test.go
+++ b/ldclient_scoped_test.go
@@ -33,9 +33,10 @@ func TestScopedClientCollectsContexts(t *testing.T) {
 
 	t.Run("adding contexts happy path", func(t *testing.T) {
 		logCapture := ldlogtest.NewMockLog()
-		c := makeTestClientWithConfig(func(config *Config) {
+		client := makeTestClientWithConfig(func(config *Config) {
 			config.Logging = ldcomponents.Logging().Loggers(logCapture.Loggers)
-		}).ForContext(ldctx1, ldctx2)
+		})
+		c := NewScopedClient(client, ldctx1, ldctx2)
 
 		c.AddContext(ldctx3, ldctx4)
 
@@ -45,9 +46,10 @@ func TestScopedClientCollectsContexts(t *testing.T) {
 
 	t.Run("adding duplicate context kinds", func(t *testing.T) {
 		logCapture := ldlogtest.NewMockLog()
-		c := makeTestClientWithConfig(func(config *Config) {
+		client := makeTestClientWithConfig(func(config *Config) {
 			config.Logging = ldcomponents.Logging().Loggers(logCapture.Loggers)
-		}).ForContext(ldctx1)
+		})
+		c := NewScopedClient(client, ldctx1)
 
 		c.AddContext(dupeCtx)
 
@@ -56,7 +58,8 @@ func TestScopedClientCollectsContexts(t *testing.T) {
 	})
 
 	t.Run("overwriting contexts", func(t *testing.T) {
-		c := makeTestClient().ForContext(ldctx1, ldctx2, ldctx3, ldctx4)
+		client := makeTestClient()
+		c := NewScopedClient(client, ldctx1, ldctx2, ldctx3, ldctx4)
 
 		c.OverwriteContextByKind(dupeCtx)
 		c.OverwriteContextByKind(ldctx2, ldctx3)
@@ -75,7 +78,8 @@ func TestScopedBoolVariation(t *testing.T) {
 		withClientEvalTestParams(func(p clientEvalTestParams) {
 			p.setupSingleValueFlag(evalFlagKey, ldvalue.Bool(true))
 
-			actual, err := p.client.ForContext(evalTestUser).BoolVariation(evalFlagKey, defaultVal)
+			scopedClient := NewScopedClient(p.client, evalTestUser)
+			actual, err := scopedClient.BoolVariation(evalFlagKey, defaultVal)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
@@ -87,7 +91,8 @@ func TestScopedBoolVariation(t *testing.T) {
 		withClientEvalTestParams(func(p clientEvalTestParams) {
 			p.setupSingleValueFlag(evalFlagKey, ldvalue.Bool(true))
 
-			actual, err := p.client.ForContext(evalTestUser).BoolVariationCtx(gocontext.TODO(), evalFlagKey, defaultVal)
+			scopedClient := NewScopedClient(p.client, evalTestUser)
+			actual, err := scopedClient.BoolVariationCtx(gocontext.TODO(), evalFlagKey, defaultVal)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
@@ -99,7 +104,8 @@ func TestScopedBoolVariation(t *testing.T) {
 		withClientEvalTestParams(func(p clientEvalTestParams) {
 			p.setupSingleValueFlag(evalFlagKey, ldvalue.Bool(true))
 
-			actual, detail, err := p.client.ForContext(evalTestUser).BoolVariationDetail(evalFlagKey, defaultVal)
+			scopedClient := NewScopedClient(p.client, evalTestUser)
+			actual, detail, err := scopedClient.BoolVariationDetail(evalFlagKey, defaultVal)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
@@ -113,7 +119,8 @@ func TestScopedBoolVariation(t *testing.T) {
 		withClientEvalTestParams(func(p clientEvalTestParams) {
 			p.setupSingleValueFlag(evalFlagKey, ldvalue.Bool(true))
 
-			actual, detail, err := p.client.ForContext(evalTestUser).BoolVariationDetailCtx(gocontext.TODO(), evalFlagKey, defaultVal)
+			scopedClient := NewScopedClient(p.client, evalTestUser)
+			actual, detail, err := scopedClient.BoolVariationDetailCtx(gocontext.TODO(), evalFlagKey, defaultVal)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
@@ -132,7 +139,8 @@ func TestScopedIntVariation(t *testing.T) {
 		withClientEvalTestParams(func(p clientEvalTestParams) {
 			p.setupSingleValueFlag(evalFlagKey, ldvalue.Int(expected))
 
-			actual, err := p.client.ForContext(evalTestUser).IntVariation(evalFlagKey, defaultVal)
+			scopedClient := NewScopedClient(p.client, evalTestUser)
+			actual, err := scopedClient.IntVariation(evalFlagKey, defaultVal)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
@@ -144,7 +152,8 @@ func TestScopedIntVariation(t *testing.T) {
 		withClientEvalTestParams(func(p clientEvalTestParams) {
 			p.setupSingleValueFlag(evalFlagKey, ldvalue.Int(expected))
 
-			actual, err := p.client.ForContext(evalTestUser).IntVariationCtx(gocontext.TODO(), evalFlagKey, defaultVal)
+			scopedClient := NewScopedClient(p.client, evalTestUser)
+			actual, err := scopedClient.IntVariationCtx(gocontext.TODO(), evalFlagKey, defaultVal)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
@@ -156,7 +165,8 @@ func TestScopedIntVariation(t *testing.T) {
 		withClientEvalTestParams(func(p clientEvalTestParams) {
 			p.setupSingleValueFlag(evalFlagKey, ldvalue.Int(expected))
 
-			actual, detail, err := p.client.ForContext(evalTestUser).IntVariationDetail(evalFlagKey, defaultVal)
+			scopedClient := NewScopedClient(p.client, evalTestUser)
+			actual, detail, err := scopedClient.IntVariationDetail(evalFlagKey, defaultVal)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
@@ -170,7 +180,8 @@ func TestScopedIntVariation(t *testing.T) {
 		withClientEvalTestParams(func(p clientEvalTestParams) {
 			p.setupSingleValueFlag(evalFlagKey, ldvalue.Int(expected))
 
-			actual, detail, err := p.client.ForContext(evalTestUser).IntVariationDetailCtx(gocontext.TODO(), evalFlagKey, defaultVal)
+			scopedClient := NewScopedClient(p.client, evalTestUser)
+			actual, detail, err := scopedClient.IntVariationDetailCtx(gocontext.TODO(), evalFlagKey, defaultVal)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
@@ -189,7 +200,8 @@ func TestScopedFloat64Variation(t *testing.T) {
 		withClientEvalTestParams(func(p clientEvalTestParams) {
 			p.setupSingleValueFlag(evalFlagKey, ldvalue.Float64(expected))
 
-			actual, err := p.client.ForContext(evalTestUser).Float64Variation(evalFlagKey, defaultVal)
+			scopedClient := NewScopedClient(p.client, evalTestUser)
+			actual, err := scopedClient.Float64Variation(evalFlagKey, defaultVal)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
@@ -201,7 +213,8 @@ func TestScopedFloat64Variation(t *testing.T) {
 		withClientEvalTestParams(func(p clientEvalTestParams) {
 			p.setupSingleValueFlag(evalFlagKey, ldvalue.Float64(expected))
 
-			actual, err := p.client.ForContext(evalTestUser).Float64VariationCtx(gocontext.TODO(), evalFlagKey, defaultVal)
+			scopedClient := NewScopedClient(p.client, evalTestUser)
+			actual, err := scopedClient.Float64VariationCtx(gocontext.TODO(), evalFlagKey, defaultVal)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
@@ -213,7 +226,8 @@ func TestScopedFloat64Variation(t *testing.T) {
 		withClientEvalTestParams(func(p clientEvalTestParams) {
 			p.setupSingleValueFlag(evalFlagKey, ldvalue.Float64(expected))
 
-			actual, detail, err := p.client.ForContext(evalTestUser).Float64VariationDetail(evalFlagKey, defaultVal)
+			scopedClient := NewScopedClient(p.client, evalTestUser)
+			actual, detail, err := scopedClient.Float64VariationDetail(evalFlagKey, defaultVal)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
@@ -227,7 +241,8 @@ func TestScopedFloat64Variation(t *testing.T) {
 		withClientEvalTestParams(func(p clientEvalTestParams) {
 			p.setupSingleValueFlag(evalFlagKey, ldvalue.Float64(expected))
 
-			actual, detail, err := p.client.ForContext(evalTestUser).Float64VariationDetailCtx(gocontext.TODO(), evalFlagKey, defaultVal)
+			scopedClient := NewScopedClient(p.client, evalTestUser)
+			actual, detail, err := scopedClient.Float64VariationDetailCtx(gocontext.TODO(), evalFlagKey, defaultVal)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
@@ -246,7 +261,8 @@ func TestScopedStringVariation(t *testing.T) {
 		withClientEvalTestParams(func(p clientEvalTestParams) {
 			p.setupSingleValueFlag(evalFlagKey, ldvalue.String(expected))
 
-			actual, err := p.client.ForContext(evalTestUser).StringVariation(evalFlagKey, defaultVal)
+			scopedClient := NewScopedClient(p.client, evalTestUser)
+			actual, err := scopedClient.StringVariation(evalFlagKey, defaultVal)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
@@ -258,7 +274,8 @@ func TestScopedStringVariation(t *testing.T) {
 		withClientEvalTestParams(func(p clientEvalTestParams) {
 			p.setupSingleValueFlag(evalFlagKey, ldvalue.String(expected))
 
-			actual, err := p.client.ForContext(evalTestUser).StringVariationCtx(gocontext.TODO(), evalFlagKey, defaultVal)
+			scopedClient := NewScopedClient(p.client, evalTestUser)
+			actual, err := scopedClient.StringVariationCtx(gocontext.TODO(), evalFlagKey, defaultVal)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
@@ -270,7 +287,8 @@ func TestScopedStringVariation(t *testing.T) {
 		withClientEvalTestParams(func(p clientEvalTestParams) {
 			p.setupSingleValueFlag(evalFlagKey, ldvalue.String(expected))
 
-			actual, detail, err := p.client.ForContext(evalTestUser).StringVariationDetail(evalFlagKey, defaultVal)
+			scopedClient := NewScopedClient(p.client, evalTestUser)
+			actual, detail, err := scopedClient.StringVariationDetail(evalFlagKey, defaultVal)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
@@ -284,7 +302,8 @@ func TestScopedStringVariation(t *testing.T) {
 		withClientEvalTestParams(func(p clientEvalTestParams) {
 			p.setupSingleValueFlag(evalFlagKey, ldvalue.String(expected))
 
-			actual, detail, err := p.client.ForContext(evalTestUser).StringVariationDetailCtx(gocontext.TODO(), evalFlagKey, defaultVal)
+			scopedClient := NewScopedClient(p.client, evalTestUser)
+			actual, detail, err := scopedClient.StringVariationDetailCtx(gocontext.TODO(), evalFlagKey, defaultVal)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
@@ -304,7 +323,8 @@ func TestScopedJSONVariation(t *testing.T) {
 		withClientEvalTestParams(func(p clientEvalTestParams) {
 			p.setupSingleValueFlag(evalFlagKey, expected)
 
-			actual, err := p.client.ForContext(evalTestUser).JSONVariation(evalFlagKey, defaultVal)
+			scopedClient := NewScopedClient(p.client, evalTestUser)
+			actual, err := scopedClient.JSONVariation(evalFlagKey, defaultVal)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
@@ -316,7 +336,8 @@ func TestScopedJSONVariation(t *testing.T) {
 		withClientEvalTestParams(func(p clientEvalTestParams) {
 			p.setupSingleValueFlag(evalFlagKey, expected)
 
-			actual, err := p.client.ForContext(evalTestUser).JSONVariationCtx(gocontext.TODO(), evalFlagKey, defaultVal)
+			scopedClient := NewScopedClient(p.client, evalTestUser)
+			actual, err := scopedClient.JSONVariationCtx(gocontext.TODO(), evalFlagKey, defaultVal)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
@@ -328,7 +349,8 @@ func TestScopedJSONVariation(t *testing.T) {
 		withClientEvalTestParams(func(p clientEvalTestParams) {
 			p.setupSingleValueFlag(evalFlagKey, expected)
 
-			actual, detail, err := p.client.ForContext(evalTestUser).JSONVariationDetail(evalFlagKey, defaultVal)
+			scopedClient := NewScopedClient(p.client, evalTestUser)
+			actual, detail, err := scopedClient.JSONVariationDetail(evalFlagKey, defaultVal)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
@@ -342,7 +364,8 @@ func TestScopedJSONVariation(t *testing.T) {
 		withClientEvalTestParams(func(p clientEvalTestParams) {
 			p.setupSingleValueFlag(evalFlagKey, expected)
 
-			actual, detail, err := p.client.ForContext(evalTestUser).JSONVariationDetailCtx(gocontext.TODO(), evalFlagKey, defaultVal)
+			scopedClient := NewScopedClient(p.client, evalTestUser)
+			actual, detail, err := scopedClient.JSONVariationDetailCtx(gocontext.TODO(), evalFlagKey, defaultVal)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
@@ -363,7 +386,8 @@ func TestScopedMigrationVariation(t *testing.T) {
 			context ldcontext.Context,
 			stage ldmigration.Stage,
 		) (ldmigration.Stage, interfaces.LDMigrationOpTracker, error) {
-			return client.ForContext(context).MigrationVariation(key, stage)
+			scopedClient := NewScopedClient(client, context)
+			return scopedClient.MigrationVariation(key, stage)
 		})
 	})
 
@@ -373,7 +397,8 @@ func TestScopedMigrationVariation(t *testing.T) {
 			context ldcontext.Context,
 			stage ldmigration.Stage,
 		) (ldmigration.Stage, interfaces.LDMigrationOpTracker, error) {
-			return client.ForContext(context).MigrationVariationCtx(gocontext.TODO(), key, stage)
+			scopedClient := NewScopedClient(client, context)
+			return scopedClient.MigrationVariationCtx(gocontext.TODO(), key, stage)
 		})
 	})
 
@@ -387,7 +412,8 @@ func TestScopedTrackCalls(t *testing.T) {
 		defer client.Close()
 
 		key := "eventKey"
-		err := client.ForContext(evalTestUser).TrackEvent(key)
+		scopedClient := NewScopedClient(client, evalTestUser)
+		err := scopedClient.TrackEvent(key)
 		assert.NoError(t, err)
 
 		events := client.eventProcessor.(*mocks.CapturingEventProcessor).Events
@@ -401,7 +427,8 @@ func TestScopedTrackCalls(t *testing.T) {
 		defer client.Close()
 
 		key := "eventKey"
-		err := client.ForContext(evalTestUser).TrackEventCtx(gocontext.TODO(), key)
+		scopedClient := NewScopedClient(client, evalTestUser)
+		err := scopedClient.TrackEventCtx(gocontext.TODO(), key)
 		assert.NoError(t, err)
 
 		events := client.eventProcessor.(*mocks.CapturingEventProcessor).Events
@@ -416,7 +443,8 @@ func TestScopedTrackCalls(t *testing.T) {
 
 		key := "eventKey"
 		data := ldvalue.String("data")
-		err := client.ForContext(evalTestUser).TrackData(key, data)
+		scopedClient := NewScopedClient(client, evalTestUser)
+		err := scopedClient.TrackData(key, data)
 		assert.NoError(t, err)
 
 		events := client.eventProcessor.(*mocks.CapturingEventProcessor).Events
@@ -432,7 +460,8 @@ func TestScopedTrackCalls(t *testing.T) {
 
 		key := "eventKey"
 		data := ldvalue.String("data")
-		err := client.ForContext(evalTestUser).TrackDataCtx(gocontext.TODO(), key, data)
+		scopedClient := NewScopedClient(client, evalTestUser)
+		err := scopedClient.TrackDataCtx(gocontext.TODO(), key, data)
 		assert.NoError(t, err)
 
 		events := client.eventProcessor.(*mocks.CapturingEventProcessor).Events
@@ -449,7 +478,8 @@ func TestScopedTrackCalls(t *testing.T) {
 		key := "eventKey"
 		data := ldvalue.String("data")
 		metric := float64(1.5)
-		err := client.ForContext(evalTestUser).TrackMetric(key, metric, data)
+		scopedClient := NewScopedClient(client, evalTestUser)
+		err := scopedClient.TrackMetric(key, metric, data)
 		assert.NoError(t, err)
 
 		events := client.eventProcessor.(*mocks.CapturingEventProcessor).Events
@@ -467,7 +497,8 @@ func TestScopedTrackCalls(t *testing.T) {
 		key := "eventKey"
 		data := ldvalue.String("data")
 		metric := float64(1.5)
-		err := client.ForContext(evalTestUser).TrackMetricCtx(gocontext.TODO(), key, metric, data)
+		scopedClient := NewScopedClient(client, evalTestUser)
+		err := scopedClient.TrackMetricCtx(gocontext.TODO(), key, metric, data)
 		assert.NoError(t, err)
 
 		events := client.eventProcessor.(*mocks.CapturingEventProcessor).Events

--- a/ldclient_scoped_test.go
+++ b/ldclient_scoped_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/launchdarkly/go-sdk-common/v3/ldmigration"
 	"github.com/launchdarkly/go-sdk-common/v3/ldreason"
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	ldevents "github.com/launchdarkly/go-sdk-events/v3"
 	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
+	"github.com/launchdarkly/go-server-sdk/v7/internal/sharedtest/mocks"
 	"github.com/launchdarkly/go-server-sdk/v7/ldcomponents"
 )
 
@@ -382,4 +384,105 @@ func TestScopedMigrationVariation(t *testing.T) {
 		})
 	})
 
+}
+
+// Scoped event tests
+
+func TestScopedTrackCalls(t *testing.T) {
+	t.Run("TrackEvent", func(t *testing.T) {
+		client := makeTestClient()
+		defer client.Close()
+
+		key := "eventKey"
+		err := client.ForContext(evalTestUser).TrackEvent(key)
+		assert.NoError(t, err)
+
+		events := client.eventProcessor.(*mocks.CapturingEventProcessor).Events
+		assert.Equal(t, 1, len(events))
+		e := events[0].(ldevents.CustomEventData)
+		assert.Equal(t, ldevents.Context(evalTestUser), e.Context)
+		assert.Equal(t, key, e.Key)
+	})
+	t.Run("TrackEventCtx", func(t *testing.T) {
+		client := makeTestClient()
+		defer client.Close()
+
+		key := "eventKey"
+		err := client.ForContext(evalTestUser).TrackEventCtx(gocontext.TODO(), key)
+		assert.NoError(t, err)
+
+		events := client.eventProcessor.(*mocks.CapturingEventProcessor).Events
+		assert.Equal(t, 1, len(events))
+		e := events[0].(ldevents.CustomEventData)
+		assert.Equal(t, ldevents.Context(evalTestUser), e.Context)
+		assert.Equal(t, key, e.Key)
+	})
+	t.Run("TrackData", func(t *testing.T) {
+		client := makeTestClient()
+		defer client.Close()
+
+		key := "eventKey"
+		data := ldvalue.String("data")
+		err := client.ForContext(evalTestUser).TrackData(key, data)
+		assert.NoError(t, err)
+
+		events := client.eventProcessor.(*mocks.CapturingEventProcessor).Events
+		assert.Equal(t, 1, len(events))
+		e := events[0].(ldevents.CustomEventData)
+		assert.Equal(t, ldevents.Context(evalTestUser), e.Context)
+		assert.Equal(t, key, e.Key)
+		assert.Equal(t, data, e.Data)
+	})
+	t.Run("TrackDataCtx", func(t *testing.T) {
+		client := makeTestClient()
+		defer client.Close()
+
+		key := "eventKey"
+		data := ldvalue.String("data")
+		err := client.ForContext(evalTestUser).TrackDataCtx(gocontext.TODO(), key, data)
+		assert.NoError(t, err)
+
+		events := client.eventProcessor.(*mocks.CapturingEventProcessor).Events
+		assert.Equal(t, 1, len(events))
+		e := events[0].(ldevents.CustomEventData)
+		assert.Equal(t, ldevents.Context(evalTestUser), e.Context)
+		assert.Equal(t, key, e.Key)
+		assert.Equal(t, data, e.Data)
+	})
+	t.Run("TrackMetric", func(t *testing.T) {
+		client := makeTestClient()
+		defer client.Close()
+
+		key := "eventKey"
+		data := ldvalue.String("data")
+		metric := float64(1.5)
+		err := client.ForContext(evalTestUser).TrackMetric(key, metric, data)
+		assert.NoError(t, err)
+
+		events := client.eventProcessor.(*mocks.CapturingEventProcessor).Events
+		assert.Equal(t, 1, len(events))
+		e := events[0].(ldevents.CustomEventData)
+		assert.Equal(t, ldevents.Context(evalTestUser), e.Context)
+		assert.Equal(t, key, e.Key)
+		assert.Equal(t, data, e.Data)
+		assert.Equal(t, metric, e.MetricValue)
+	})
+	t.Run("TrackMetricCtx", func(t *testing.T) {
+		client := makeTestClient()
+		defer client.Close()
+
+		key := "eventKey"
+		data := ldvalue.String("data")
+		metric := float64(1.5)
+		err := client.ForContext(evalTestUser).TrackMetricCtx(gocontext.TODO(), key, metric, data)
+		assert.NoError(t, err)
+
+		events := client.eventProcessor.(*mocks.CapturingEventProcessor).Events
+		assert.Equal(t, 1, len(events))
+		e := events[0].(ldevents.CustomEventData)
+		assert.Equal(t, ldevents.Context(evalTestUser), e.Context)
+		assert.Equal(t, key, e.Key)
+		assert.Equal(t, data, e.Data)
+		assert.Equal(t, metric, e.MetricValue)
+	})
 }

--- a/ldclient_scoped_test.go
+++ b/ldclient_scoped_test.go
@@ -18,13 +18,6 @@ import (
 	"github.com/launchdarkly/go-server-sdk/v7/ldcomponents"
 )
 
-func TestScopedClientCurrentContext(t *testing.T) {
-	ldctx := ldcontext.New("user1")
-	c := makeTestClient().ForContext(ldctx)
-
-	assert.Equal(t, ldctx, c.CurrentContext())
-}
-
 func TestScopedClientCollectsContexts(t *testing.T) {
 	ldctx1 := ldcontext.NewWithKind("foo", "foo1")
 	ldctx2 := ldcontext.NewMulti(


### PR DESCRIPTION
You can now create a "scoped client", a wrapper of the client that will use the specified context for all operations, including feature flag evaluations and event tracking. This facilitates propagating a context down to all logic that is related to a scoped piece of logic, like a web request.

An `LDScopedClient` implements most of the same methods as `LDClient`, but without the `context` argument.

A scoped client is mutable, to facilitate incrementally building up a multi-context representing the current scope. You can add new contexts (as long as they aren't replacing an existing kind) with `LDScopedClient.AddContext`, and all contexts added so far will be combined into a multi-context whenever the scoped client is used. `LDScopedClient.OverwriteContextByKind` is offered as an escape hatch if you need to update existing data.