### PR TITLE
fix(experimental): Functions for putting/getting an LDScopedClient from context.Context

### DIFF
--- a/ldclient_gocontext.go
+++ b/ldclient_gocontext.go
@@ -4,15 +4,42 @@ import "context"
 
 type scopedClientKey struct{}
 
+// GoContextWithScopedClient adds a scoped client to the Go context. This can be
+// used to pass a scoped client to a function or goroutine that might not
+// otherwise have access to it:
+//
+//	scopedClient := ld.NewScopedClient(client, ldUserContext)
+//	ctx := ld.GoContextWithScopedClient(context.Background(), scopedClient)
+//	otherFunction(ctx)
 func GoContextWithScopedClient(ctx context.Context, client *LDScopedClient) context.Context {
 	return context.WithValue(ctx, scopedClientKey{}, client)
 }
 
+// GetScopedClient retrieves a scoped client from the Go context that was set
+// with GoContextWithScopedClient, if present. If not present, returns nil and
+// false.
+//
+//	func logicWithFeatureFlag(ctx context.Context) {
+//		scopedClient, ok := ld.GetScopedClient(ctx)
+//		isFeatureEnabled := false // default value if scoped client is not available
+//		if ok {
+//			isFeatureEnabled, err = scopedClient.BoolVariation("my-flag", false)
+//			// handle err as appropriate...
+//		}
+//	}
 func GetScopedClient(ctx context.Context) (*LDScopedClient, bool) {
 	client, ok := ctx.Value(scopedClientKey{}).(*LDScopedClient)
 	return client, ok
 }
 
+// MustGetScopedClient retrieves a scoped client from the Go context that was set
+// with GoContextWithScopedClient, or panics if not present.
+//
+//	func logicWithFeatureFlag(ctx context.Context) {
+//		scopedClient := ld.MustGetScopedClient(ctx)
+//		isFeatureEnabled, err := scopedClient.BoolVariation("my-flag", false)
+//		// handle err as appropriate...
+//	}
 func MustGetScopedClient(ctx context.Context) *LDScopedClient {
 	client, ok := GetScopedClient(ctx)
 	if !ok {

--- a/ldclient_gocontext.go
+++ b/ldclient_gocontext.go
@@ -11,6 +11,10 @@ type scopedClientKey struct{}
 //	scopedClient := ld.NewScopedClient(client, ldUserContext)
 //	ctx := ld.GoContextWithScopedClient(context.Background(), scopedClient)
 //	otherFunction(ctx)
+//
+// This function is not stable, and not subject to any backwards compatibility
+// guarantees or semantic versioning. It is not suitable for production usage. Do
+// not use it. You have been warned.
 func GoContextWithScopedClient(ctx context.Context, client *LDScopedClient) context.Context {
 	return context.WithValue(ctx, scopedClientKey{}, client)
 }
@@ -27,6 +31,10 @@ func GoContextWithScopedClient(ctx context.Context, client *LDScopedClient) cont
 //			// handle err as appropriate...
 //		}
 //	}
+//
+// This function is not stable, and not subject to any backwards compatibility
+// guarantees or semantic versioning. It is not suitable for production usage. Do
+// not use it. You have been warned.
 func GetScopedClient(ctx context.Context) (*LDScopedClient, bool) {
 	client, ok := ctx.Value(scopedClientKey{}).(*LDScopedClient)
 	return client, ok
@@ -40,6 +48,10 @@ func GetScopedClient(ctx context.Context) (*LDScopedClient, bool) {
 //		isFeatureEnabled, err := scopedClient.BoolVariation("my-flag", false)
 //		// handle err as appropriate...
 //	}
+//
+// This function is not stable, and not subject to any backwards compatibility
+// guarantees or semantic versioning. It is not suitable for production usage. Do
+// not use it. You have been warned.
 func MustGetScopedClient(ctx context.Context) *LDScopedClient {
 	client, ok := GetScopedClient(ctx)
 	if !ok {

--- a/ldclient_gocontext.go
+++ b/ldclient_gocontext.go
@@ -1,0 +1,22 @@
+package ldclient
+
+import "context"
+
+type scopedClientKey struct{}
+
+func GoContextWithScopedClient(ctx context.Context, client *LDScopedClient) context.Context {
+	return context.WithValue(ctx, scopedClientKey{}, client)
+}
+
+func GetScopedClient(ctx context.Context) (*LDScopedClient, bool) {
+	client, ok := ctx.Value(scopedClientKey{}).(*LDScopedClient)
+	return client, ok
+}
+
+func MustGetScopedClient(ctx context.Context) *LDScopedClient {
+	client, ok := GetScopedClient(ctx)
+	if !ok {
+		panic("No scoped client found in context")
+	}
+	return client
+}

--- a/ldclient_gocontext_test.go
+++ b/ldclient_gocontext_test.go
@@ -1,0 +1,40 @@
+package ldclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetScopedClient(t *testing.T) {
+	t.Run("returns client from context", func(t *testing.T) {
+		origCtx := context.Background()
+		sc := &LDScopedClient{}
+
+		newCtx := GoContextWithScopedClient(origCtx, sc)
+		retrieved, ok := GetScopedClient(newCtx)
+
+		assert.True(t, ok, "expected to find scoped client in context")
+		assert.Equal(t, sc, retrieved, "retrieved client should match original")
+	})
+
+	t.Run("returns nil when not present", func(t *testing.T) {
+		retrieved, ok := GetScopedClient(context.Background())
+		assert.False(t, ok, "should not find scoped client in empty context")
+		assert.Nil(t, retrieved, "retrieved client should be nil when not present")
+	})
+}
+
+func TestMustGetScopedClient(t *testing.T) {
+	sc := &LDScopedClient{}
+	ctxWith := GoContextWithScopedClient(context.Background(), sc)
+
+	// Should return the client without panicking when present
+	assert.Equal(t, sc, MustGetScopedClient(ctxWith))
+
+	// Should panic when the client is not present
+	assert.Panics(t, func() {
+		MustGetScopedClient(context.Background())
+	})
+}


### PR DESCRIPTION
This PR introduces a few more functions to the main `ld` package. This will allow Go developers to easily pass around a scoped client to any logic that already takes a `context.Context`.

In particular, this will make writing HTTP middleware that establishes an LD context pretty easy. The middleware just needs to create a scoped client with the LD context it wants, then pass that scoped client into the `http.Request`'s built-in Go context.

```go
func LDScopedClientMiddleware(client *LDClient) func(http.Handler) http.Handler {
	return func(next http.Handler) http.Handler {
		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
			scopedClient := NewScopedClient(client, ldcontext.New("user-key"))
			ctx := GoContextWithScopedClient(r.Context(), scopedClient)
			next.ServeHTTP(w, r.WithContext(ctx))
		})
	}
}

func requestLogic(r *http.Request) {
	featureFlagEnabled := MustGetScopedClient(r.Context()).BoolVariation("my-flag", false)
	// use featureFlagEnabled...
}
```