### PR TITLE
fix: add usage tracking to config method

### DIFF
--- a/ldai/client.go
+++ b/ldai/client.go
@@ -70,6 +70,8 @@ func (c *Client) Config(
 	defaultValue Config,
 	variables map[string]interface{},
 ) (Config, *Tracker) {
+	c.sdk.TrackMetric("$ld:ai:config:function:single", context, 1, ldvalue.String(key))
+
 	result, _ := c.sdk.JSONVariation(key, context, defaultValue.AsLdValue())
 
 	// The spec requires the config to at least be an object (although all properties are optional, so it may be an

--- a/ldai/client.go
+++ b/ldai/client.go
@@ -70,7 +70,7 @@ func (c *Client) Config(
 	defaultValue Config,
 	variables map[string]interface{},
 ) (Config, *Tracker) {
-	c.sdk.TrackMetric("$ld:ai:config:function:single", context, 1, ldvalue.String(key))
+	_ = c.sdk.TrackMetric("$ld:ai:config:function:single", context, 1, ldvalue.String(key))
 
 	result, _ := c.sdk.JSONVariation(key, context, defaultValue.AsLdValue())
 

--- a/ldai/client_test.go
+++ b/ldai/client_test.go
@@ -17,13 +17,21 @@ import (
 )
 
 type mockServerSDK struct {
-	log  *ldlogtest.MockLog
-	json []byte
-	err  error
+	log    *ldlogtest.MockLog
+	json   []byte
+	err    error
+	events []mockEvent
+}
+
+type mockEvent struct {
+	eventName   string
+	context     ldcontext.Context
+	metricValue float64
+	data        ldvalue.Value
 }
 
 func newMockSDK(json []byte, err error) *mockServerSDK {
-	return &mockServerSDK{json: json, err: err, log: ldlogtest.NewMockLog()}
+	return &mockServerSDK{json: json, err: err, log: ldlogtest.NewMockLog(), events: []mockEvent{}}
 }
 
 func (m *mockServerSDK) JSONVariation(
@@ -44,6 +52,12 @@ func (m *mockServerSDK) Loggers() interfaces.LDLoggers {
 }
 
 func (m *mockServerSDK) TrackMetric(eventName string, context ldcontext.Context, metricValue float64, data ldvalue.Value) error {
+	m.events = append(m.events, mockEvent{
+		eventName:   eventName,
+		context:     context,
+		metricValue: metricValue,
+		data:        data,
+	})
 	return nil
 }
 
@@ -286,6 +300,33 @@ func TestCanSetDefaultConfigFields(t *testing.T) {
 	assert.Equal(t, datamodel.User, msg[0].Role)
 	assert.Equal(t, "world", msg[1].Content)
 	assert.Equal(t, datamodel.System, msg[1].Role)
+}
+
+func TestConfigMethodTracking(t *testing.T) {
+	mockSDK := newMockSDK(nil, nil)
+	client, err := NewClient(mockSDK)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	defaultConfig := NewConfig().WithEnabled(false).Build()
+	context := ldcontext.New("user-key")
+	configKey := "test-config-key"
+
+	config, tracker := client.Config(configKey, context, defaultConfig, nil)
+
+	require.NotNil(t, config)
+	require.NotNil(t, tracker)
+
+	expectedEvents := []mockEvent{
+		{
+			eventName:   "$ld:ai:config:function:single",
+			context:     context,
+			metricValue: 1,
+			data:        ldvalue.String(configKey),
+		},
+	}
+
+	assert.ElementsMatch(t, expectedEvents, mockSDK.events)
 }
 
 func TestCanSetModelParameters(t *testing.T) {


### PR DESCRIPTION
Tracking internally in SDK-1414.

## Add usage tracking to config method

This PR implements SDK spec requirement 1.2.3.5 by adding usage tracking to the `config` method across all AI SDK repositories, following the pattern established in [JS Core PR #904](https://github.com/launchdarkly/js-core/pull/904).

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions ⚠️ *See testing notes below*

**Related issues**

- Implements [SDK spec requirement 1.2.3.5](https://github.com/launchdarkly/sdk-specs/tree/main/specs/AITRACK-ai-tracking-%26-performance#requirement-1235)
- Follows pattern from [JS Core PR #904](https://github.com/launchdarkly/js-core/pull/904)

**Describe the solution you've provided**

Added a single tracking call `track('$ld:ai:config:function:single', context, key, 1)` at the beginning of each `config` method across all 4 AI SDK repositories:

- **Ruby**: `@ld_client.track('$ld:ai:config:function:single', context, config_key, 1)`
- **Python**: `self._client.track('$ld:ai:config:function:single', context, key, 1)`
- **Go**: `c.sdk.TrackMetric("$ld:ai:config:function:single", context, 1, ldvalue.String(key))`
- **.NET**: `_client.Track("$ld:ai:config:function:single", context, LdValue.Of(key), 1)`

Each implementation includes a corresponding unit test to verify the tracking call is made with the correct parameters.

**Critical Review Points**

⚠️ **Testing Limitations**: Due to local environment setup constraints, I was unable to run the full test suites locally. The tests were written based on existing patterns but should be verified to pass in the proper CI environment.

🔍 **Key Items to Review**:
1. **Tracking method signatures**: Each SDK uses different tracking APIs - verify parameter order and types are correct
2. **Event consistency**: Confirm the event name `$ld:ai:config:function:single` is exactly as specified
3. **Method placement**: Tracking call is added at the beginning of each config method - verify this is the intended location  
4. **Test validity**: Run tests to ensure they pass and properly verify the tracking functionality

**Describe alternatives you've considered**

- Considered placing tracking calls after input validation, but chose to place them at method entry to ensure all invocations are tracked
- Each SDK's tracking implementation follows its existing patterns rather than trying to standardize the approach

**Additional context**

- Work requested by @jsonbailey in Slack #team-sdks
- Link to Devin session: https://app.devin.ai/sessions/3340d364f83144e0aa1afb9a43870b09
- This change maintains backward compatibility - only adds tracking, no functional changes to config method behavior
- All 4 PRs use identical branch names and commit messages for consistency across repositories

**Cross-SDK Implementation Details**

| SDK | Tracking Method | Parameter Order |
|-----|----------------|----------------|
| Ruby | `track(event, context, key, value)` | Standard LaunchDarkly pattern |
| Python | `track(event, context, key, value)` | Standard LaunchDarkly pattern |
| Go | `TrackMetric(event, context, value, data)` | Go-specific metric tracking |
| .NET | `Track(event, context, data, value)` | .NET-specific parameter order |