### PR TITLE
fix(experimental): NewScopedClient can now only take one context argument

### DIFF
--- a/ldclient_scoped.go
+++ b/ldclient_scoped.go
@@ -77,10 +77,9 @@ type LDScopedClient struct {
 // methods as LDClient, like BoolVariation et al., but without the
 // ldcontext.Context parameter.
 //
-// You may pass one or more contexts to NewScopedClient. All contexts will be
-// combined into a multi-context when the scoped client is used. Providing a
+// You may pass a single-kind or multi-kind context to NewScopedClient. Providing a
 // multi-context to NewScopedClient is equivalent to providing all of its
-// individual contexts separately.
+// individual contexts separately via [LDScopedClient.AddContext].
 //
 // For more information on how to use the scoped client, read the documentation
 // for LDScopedClient.
@@ -88,13 +87,13 @@ type LDScopedClient struct {
 // This function is not stable, and not subject to any backwards compatibility
 // guarantees or semantic versioning. It is not suitable for production usage. Do
 // not use it. You have been warned.
-func NewScopedClient(client *LDClient, contexts ...ldcontext.Context) *LDScopedClient {
+func NewScopedClient(client *LDClient, context ldcontext.Context) *LDScopedClient {
 	cc := &LDScopedClient{
 		client:   client,
 		contexts: make(map[ldcontext.Kind]ldcontext.Context),
 		rebuild:  true,
 	}
-	cc.AddContext(contexts...)
+	cc.AddContext(context)
 	return cc
 }
 

--- a/ldclient_scoped_test.go
+++ b/ldclient_scoped_test.go
@@ -36,9 +36,8 @@ func TestScopedClientCollectsContexts(t *testing.T) {
 		client := makeTestClientWithConfig(func(config *Config) {
 			config.Logging = ldcomponents.Logging().Loggers(logCapture.Loggers)
 		})
-		c := NewScopedClient(client, ldctx1, ldctx2)
-
-		c.AddContext(ldctx3, ldctx4)
+		c := NewScopedClient(client, ldctx2)
+		c.AddContext(ldctx1, ldctx3, ldctx4)
 
 		assert.Equal(t, ldcontext.NewMulti(ldctx1, ldctx2, ldctx3, ldctx4), c.CurrentContext())
 		assert.Empty(t, logCapture.GetOutput(ldlog.Warn))
@@ -59,7 +58,7 @@ func TestScopedClientCollectsContexts(t *testing.T) {
 
 	t.Run("overwriting contexts", func(t *testing.T) {
 		client := makeTestClient()
-		c := NewScopedClient(client, ldctx1, ldctx2, ldctx3, ldctx4)
+		c := NewScopedClient(client, ldcontext.NewMulti(ldctx1, ldctx2, ldctx3, ldctx4))
 
 		c.OverwriteContextByKind(dupeCtx)
 		c.OverwriteContextByKind(ldctx2, ldctx3)


### PR DESCRIPTION
Currently, NewScopedClient takes a variadic (zero or more) list of contexts to initially seed the scoped client. However, this means it's possible to pass in _zero_ contexts, resulting in an invalid state: a scoped client with zero contexts.

To avoid this scenario, I propose changing `NewScopedClient` to only take in one context, which could be a multi-context. This is the simplest implementation choice and it doesn't block any of the common use cases I anticipate: adding 1 or N contexts will still be possible with this syntax.