### PR TITLE
chore: Use gh-actions/actions/persistent-stores

### DIFF
--- a/.github/workflows/common_ci.yml
+++ b/.github/workflows/common_ci.yml
@@ -33,21 +33,13 @@ jobs:
     env:
       TEST_SERVICE_PORT: 10000
 
-    services:
-      redis:
-        image: redis
-        ports:
-            - 6379:6379
-      dynamodb:
-        image: amazon/dynamodb-local
-        ports:
-            - 8000:8000
-      consul:
-        image: hashicorp/consul
-        ports:
-            - 8500:8500
     steps:
       - uses: actions/checkout@v4
+      - uses: launchdarkly/gh-actions/actions/persistent-stores@persistent-stores-v0
+        with:
+          redis: 'true'
+          consul: 'true'
+          dynamodb: 'true'
       - name: Setup Go ${{ inputs.go-version }}
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
The latest consul image incorrectly handles a '$' in the key name. This
is causing failing tests since we use an '$inited' key. Until the consul
change is remedied, we need to pin to a working version of consul.

This is already done in our shared GH action for persistent stores, so I
am updating this SDK to finally use that.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace inline Redis/Consul/DynamoDB services with the persistent-stores GitHub Action in the contract-tests workflow.
> 
> - **CI Workflow (`.github/workflows/common_ci.yml`)**:
>   - **Contract Tests**:
>     - Replace inline `services` for `redis`, `consul`, and `dynamodb` with `launchdarkly/gh-actions/actions/persistent-stores@persistent-stores-v0` (enabled `redis`, `consul`, `dynamodb`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3be543d908064f50da595ee4f430dba38e7af0e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->