### PR TITLE
feat: Add new transport configuration options

### DIFF
--- a/ldcomponents/http_configuration_builder.go
+++ b/ldcomponents/http_configuration_builder.go
@@ -88,6 +88,20 @@ func (b *HTTPConfigurationBuilder) CACertFile(filePath string) *HTTPConfiguratio
 	return b
 }
 
+// HTTPOptions allows specifying additional HTTP transport options that will be applied to the
+// underlying HTTP transport used by the SDK.
+//
+// These options are applied in addition to any other HTTP configuration settings you may have
+// specified with other methods on this builder. The options are processed in the order they
+// are provided.
+func (b *HTTPConfigurationBuilder) HTTPOptions(opts []ldhttp.TransportOption) *HTTPConfigurationBuilder {
+	if b.checkValid() {
+		b.httpOptions = append(b.httpOptions, opts...)
+	}
+
+	return b
+}
+
 // ConnectTimeout sets the connection timeout.
 //
 // This is the maximum amount of time to wait for each individual connection attempt to a remote service

--- a/ldcomponents/http_configuration_builder_test.go
+++ b/ldcomponents/http_configuration_builder_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
 	"github.com/launchdarkly/go-server-sdk/v7/internal"
+	"github.com/launchdarkly/go-server-sdk/v7/ldhttp"
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
 
 	helpers "github.com/launchdarkly/go-test-helpers/v3"
@@ -252,6 +253,119 @@ func TestHTTPConfigurationBuilder(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, "application-id/appid application-version/appver", c.DefaultHeaders.Get("X-LaunchDarkly-Tags"))
 		})
+	})
+
+	t.Run("HTTPOptions with IdleConnTimeout", func(t *testing.T) {
+		customTimeout := 45 * time.Second
+		c, err := HTTPConfiguration().
+			HTTPOptions([]ldhttp.TransportOption{ldhttp.IdleConnTimeoutOption(customTimeout)}).
+			Build(basicConfig)
+		require.NoError(t, err)
+
+		client := c.CreateHTTPClient()
+		require.NotNil(t, client.Transport)
+		transport := client.Transport.(*http.Transport)
+		assert.Equal(t, customTimeout, transport.IdleConnTimeout)
+	})
+
+	t.Run("HTTPOptions with MaxIdleConns", func(t *testing.T) {
+		customMax := 50
+		c, err := HTTPConfiguration().
+			HTTPOptions([]ldhttp.TransportOption{ldhttp.MaxIdleConnsOption(customMax)}).
+			Build(basicConfig)
+		require.NoError(t, err)
+
+		client := c.CreateHTTPClient()
+		require.NotNil(t, client.Transport)
+		transport := client.Transport.(*http.Transport)
+		assert.Equal(t, customMax, transport.MaxIdleConns)
+	})
+
+	t.Run("HTTPOptions with MaxIdleConnsPerHost", func(t *testing.T) {
+		customMax := 15
+		c, err := HTTPConfiguration().
+			HTTPOptions([]ldhttp.TransportOption{ldhttp.MaxIdleConnsPerHostOption(customMax)}).
+			Build(basicConfig)
+		require.NoError(t, err)
+
+		client := c.CreateHTTPClient()
+		require.NotNil(t, client.Transport)
+		transport := client.Transport.(*http.Transport)
+		assert.Equal(t, customMax, transport.MaxIdleConnsPerHost)
+	})
+
+	t.Run("HTTPOptions with DisableKeepAlives", func(t *testing.T) {
+		c, err := HTTPConfiguration().
+			HTTPOptions([]ldhttp.TransportOption{ldhttp.DisableKeepAlivesOption(true)}).
+			Build(basicConfig)
+		require.NoError(t, err)
+
+		client := c.CreateHTTPClient()
+		require.NotNil(t, client.Transport)
+		transport := client.Transport.(*http.Transport)
+		assert.True(t, transport.DisableKeepAlives)
+	})
+
+	t.Run("HTTPOptions with multiple transport options", func(t *testing.T) {
+		customIdleTimeout := 30 * time.Second
+		customMaxIdle := 75
+		customMaxIdlePerHost := 20
+
+		c, err := HTTPConfiguration().
+			HTTPOptions([]ldhttp.TransportOption{
+				ldhttp.IdleConnTimeoutOption(customIdleTimeout),
+				ldhttp.MaxIdleConnsOption(customMaxIdle),
+				ldhttp.MaxIdleConnsPerHostOption(customMaxIdlePerHost),
+				ldhttp.DisableKeepAlivesOption(true),
+			}).
+			Build(basicConfig)
+		require.NoError(t, err)
+
+		client := c.CreateHTTPClient()
+		require.NotNil(t, client.Transport)
+		transport := client.Transport.(*http.Transport)
+		assert.Equal(t, customIdleTimeout, transport.IdleConnTimeout)
+		assert.Equal(t, customMaxIdle, transport.MaxIdleConns)
+		assert.Equal(t, customMaxIdlePerHost, transport.MaxIdleConnsPerHost)
+		assert.True(t, transport.DisableKeepAlives)
+	})
+
+	t.Run("HTTPOptions combined with other builder methods", func(t *testing.T) {
+		customIdleTimeout := 60 * time.Second
+		customConnectTimeout := 5 * time.Second
+
+		c, err := HTTPConfiguration().
+			ConnectTimeout(customConnectTimeout).
+			HTTPOptions([]ldhttp.TransportOption{ldhttp.IdleConnTimeoutOption(customIdleTimeout)}).
+			Header("Custom-Header", "test-value").
+			Build(basicConfig)
+		require.NoError(t, err)
+
+		client := c.CreateHTTPClient()
+		assert.Equal(t, customConnectTimeout, client.Timeout)
+
+		require.NotNil(t, client.Transport)
+		transport := client.Transport.(*http.Transport)
+		assert.Equal(t, customIdleTimeout, transport.IdleConnTimeout)
+
+		assert.Equal(t, "test-value", c.DefaultHeaders.Get("Custom-Header"))
+	})
+
+	t.Run("HTTPOptions called multiple times accumulates options", func(t *testing.T) {
+		customIdleTimeout := 25 * time.Second
+		customMaxIdle := 80
+
+		c, err := HTTPConfiguration().
+			HTTPOptions([]ldhttp.TransportOption{ldhttp.IdleConnTimeoutOption(customIdleTimeout)}).
+			HTTPOptions([]ldhttp.TransportOption{ldhttp.MaxIdleConnsOption(customMaxIdle)}).
+			Build(basicConfig)
+		require.NoError(t, err)
+
+		client := c.CreateHTTPClient()
+		require.NotNil(t, client.Transport)
+		transport := client.Transport.(*http.Transport)
+		assert.Equal(t, customIdleTimeout, transport.IdleConnTimeout)
+		assert.Equal(t, customMaxIdle, transport.MaxIdleConns)
 	})
 
 	t.Run("nil safety", func(t *testing.T) {

--- a/ldhttp/http_transport.go
+++ b/ldhttp/http_transport.go
@@ -22,6 +22,14 @@ type transportExtraOptions struct {
 	caCerts        *x509.CertPool
 	connectTimeout time.Duration
 	proxyURL       *url.URL
+
+	// idleConnTimeout and maxIdleConns have to be pointers to support backwards
+	// compatibility as we provide defaults for these.
+	idleConnTimeout *time.Duration
+	maxIdleConns    *int
+
+	maxIdleConnsPerHost int
+	disableKeepAlives   bool
 }
 
 // TransportOption is the interface for optional configuration parameters that can be passed to NewHTTPTransport.
@@ -101,6 +109,65 @@ func (o proxyOption) apply(opts *transportExtraOptions) error {
 	return nil
 }
 
+type idleConnTimeoutOption struct {
+	timeout time.Duration
+}
+
+func (o idleConnTimeoutOption) apply(opts *transportExtraOptions) error {
+	opts.idleConnTimeout = &o.timeout
+	return nil
+}
+
+// IdleConnTimeoutOption specifies the maximum amount of time an idle (keep-alive) connection will remain
+// idle before closing itself, when used with NewHTTPTransport.
+func IdleConnTimeoutOption(timeout time.Duration) TransportOption {
+	return idleConnTimeoutOption{timeout: timeout}
+}
+
+type maxIdleConnsOption struct {
+	count int
+}
+
+func (o maxIdleConnsOption) apply(opts *transportExtraOptions) error {
+	opts.maxIdleConns = &o.count
+	return nil
+}
+
+// MaxIdleConnsOption specifies the maximum number of idle (keep-alive) connections across all hosts,
+// when used with NewHTTPTransport.
+func MaxIdleConnsOption(count int) TransportOption {
+	return maxIdleConnsOption{count: count}
+}
+
+type maxIdleConnsPerHostOption struct {
+	count int
+}
+
+func (o maxIdleConnsPerHostOption) apply(opts *transportExtraOptions) error {
+	opts.maxIdleConnsPerHost = o.count
+	return nil
+}
+
+// MaxIdleConnsPerHostOption specifies the maximum number of idle (keep-alive) connections per host,
+// when used with NewHTTPTransport.
+func MaxIdleConnsPerHostOption(count int) TransportOption {
+	return maxIdleConnsPerHostOption{count: count}
+}
+
+type disableKeepAlivesOption struct {
+	disable bool
+}
+
+func (o disableKeepAlivesOption) apply(opts *transportExtraOptions) error {
+	opts.disableKeepAlives = o.disable
+	return nil
+}
+
+// DisableKeepAlivesOption disables HTTP keep-alives when set to true, when used with NewHTTPTransport.
+func DisableKeepAlivesOption(disable bool) TransportOption {
+	return disableKeepAlivesOption{disable: disable}
+}
+
 // NewHTTPTransport creates a customized http.Transport struct using the specified options. It returns both
 // the Transport and an associated net.Dialer.
 //
@@ -127,6 +194,18 @@ func NewHTTPTransport(options ...TransportOption) (*http.Transport, *net.Dialer,
 	}
 	if extraOptions.proxyURL != nil {
 		transport.Proxy = http.ProxyURL(extraOptions.proxyURL)
+	}
+	if extraOptions.idleConnTimeout != nil {
+		transport.IdleConnTimeout = *extraOptions.idleConnTimeout
+	}
+	if extraOptions.maxIdleConns != nil {
+		transport.MaxIdleConns = *extraOptions.maxIdleConns
+	}
+	if extraOptions.maxIdleConnsPerHost != 0 {
+		transport.MaxIdleConnsPerHost = extraOptions.maxIdleConnsPerHost
+	}
+	if extraOptions.disableKeepAlives {
+		transport.DisableKeepAlives = true
 	}
 	return transport, dialer, nil
 }

--- a/ldhttp/http_transport_test.go
+++ b/ldhttp/http_transport_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -86,4 +87,76 @@ func TestCanSetProxyURL(t *testing.T) {
 	urlOut, err := transport.Proxy(&http.Request{})
 	require.NoError(t, err)
 	assert.Equal(t, url, urlOut)
+}
+
+func TestCanSetIdleConnTimeout(t *testing.T) {
+	customTimeout := 30 * time.Second
+	transport, _, err := NewHTTPTransport(IdleConnTimeoutOption(customTimeout))
+	require.NoError(t, err)
+	assert.Equal(t, customTimeout, transport.IdleConnTimeout)
+}
+
+func TestDefaultIdleConnTimeoutIsUsedWhenNotSet(t *testing.T) {
+	transport, _, err := NewHTTPTransport()
+	require.NoError(t, err)
+	// Should use the default from newDefaultTransport
+	assert.Equal(t, 90*time.Second, transport.IdleConnTimeout)
+}
+
+func TestCanSetMaxIdleConns(t *testing.T) {
+	customMax := 50
+	transport, _, err := NewHTTPTransport(MaxIdleConnsOption(customMax))
+	require.NoError(t, err)
+	assert.Equal(t, customMax, transport.MaxIdleConns)
+}
+
+func TestDefaultMaxIdleConnsIsUsedWhenNotSet(t *testing.T) {
+	transport, _, err := NewHTTPTransport()
+	require.NoError(t, err)
+	// Should use the default from newDefaultTransport
+	assert.Equal(t, 100, transport.MaxIdleConns)
+}
+
+func TestCanSetMaxIdleConnsPerHost(t *testing.T) {
+	customMax := 10
+	transport, _, err := NewHTTPTransport(MaxIdleConnsPerHostOption(customMax))
+	require.NoError(t, err)
+	assert.Equal(t, customMax, transport.MaxIdleConnsPerHost)
+}
+
+func TestDefaultMaxIdleConnsPerHostIsUsedWhenNotSet(t *testing.T) {
+	transport, _, err := NewHTTPTransport()
+	require.NoError(t, err)
+	// Should be 0 (no limit) when not set
+	assert.Equal(t, 0, transport.MaxIdleConnsPerHost)
+}
+
+func TestCanDisableKeepAlives(t *testing.T) {
+	transport, _, err := NewHTTPTransport(DisableKeepAlivesOption(true))
+	require.NoError(t, err)
+	assert.True(t, transport.DisableKeepAlives)
+}
+
+func TestKeepAlivesEnabledByDefault(t *testing.T) {
+	transport, _, err := NewHTTPTransport()
+	require.NoError(t, err)
+	assert.False(t, transport.DisableKeepAlives)
+}
+
+func TestCanSetMultipleConnectionOptions(t *testing.T) {
+	customIdleTimeout := 45 * time.Second
+	customMaxIdle := 75
+	customMaxIdlePerHost := 15
+
+	transport, _, err := NewHTTPTransport(
+		IdleConnTimeoutOption(customIdleTimeout),
+		MaxIdleConnsOption(customMaxIdle),
+		MaxIdleConnsPerHostOption(customMaxIdlePerHost),
+		DisableKeepAlivesOption(true),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, customIdleTimeout, transport.IdleConnTimeout)
+	assert.Equal(t, customMaxIdle, transport.MaxIdleConns)
+	assert.Equal(t, customMaxIdlePerHost, transport.MaxIdleConnsPerHost)
+	assert.True(t, transport.DisableKeepAlives)
 }


### PR DESCRIPTION
Supports:

  - idleConnTimeout
  - maxIdleConns
  - maxIdleConnsPerHost
  - disableKeepAlives

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new ldhttp transport options (idle timeout, max idle conns, per-host, disable keep-alives) and exposes them via HTTPConfiguration.HTTPOptions with comprehensive tests.
> 
> - **Networking/HTTP**:
>   - **`ldhttp` transport options**: add `IdleConnTimeoutOption`, `MaxIdleConnsOption`, `MaxIdleConnsPerHostOption`, `DisableKeepAlivesOption`; wired into `NewHTTPTransport` to set corresponding `http.Transport` fields.
>   - **Builder passthrough**: add `HTTPOptions([]ldhttp.TransportOption)` to `ldcomponents.HTTPConfigurationBuilder`; options accumulate and work alongside `ConnectTimeout`, proxy, and headers.
> - **Tests**:
>   - Add unit tests in `ldhttp/http_transport_test.go` and `ldcomponents/http_configuration_builder_test.go` covering defaults, each option, combinations, and interaction with existing builder settings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43752e37168d19c9616ea63f6f9954c83d0eb56a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->