### PR TITLE
fix: Bump minimum go to 1.24

### DIFF
--- a/.github/variables/go-versions.env
+++ b/.github/variables/go-versions.env
@@ -1,3 +1,3 @@
 latest=1.25
 penultimate=1.24
-min=1.23
+min=1.24

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/launchdarkly/go-server-sdk/v7
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/fsnotify/fsnotify v1.4.7

--- a/ldmiddleware/go.mod
+++ b/ldmiddleware/go.mod
@@ -1,6 +1,6 @@
 module github.com/launchdarkly/go-server-sdk/ldmiddleware
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/felixge/httpsnoop v1.0.4

--- a/ldotel/go.mod
+++ b/ldotel/go.mod
@@ -1,6 +1,6 @@
 module github.com/launchdarkly/go-server-sdk/ldotel
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/launchdarkly/go-sdk-common/v3 v3.3.0

--- a/testservice/go.mod
+++ b/testservice/go.mod
@@ -1,6 +1,6 @@
 module github.com/launchdarkly/go-server-sdk/v7/testservice
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.17.5


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Raises the minimum supported Go version to 1.24 across the repo (env and all go.mod files).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56cdd8a1d56bbe81f0e0188054066dc6cf01ea18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->