### PR TITLE
chore: Remove SDK release-as

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,6 @@
   "packages" : {
     "." : {
       "release-type" : "go",
-      "release-as": "7.14.0",
       "bump-minor-pre-major" : true,
       "versioning" : "default",
       "include-component-in-tag" : false,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Remove the release-as override for the root Go package in release-please-config.json.
> 
> - **Release configuration**:
>   - Remove `release-as` from the root package `.` in `release-please-config.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26e77df118dd75cf7c03e680cef20cb9d6d9a395. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->