### PR TITLE
fix: Add `ChangeSet.Collections` to help reduce relay memory usage

### DIFF
--- a/internal/datasourcev2/streaming_data_source_test.go
+++ b/internal/datasourcev2/streaming_data_source_test.go
@@ -563,7 +563,7 @@ func TestStreamingDataSourceHandlesUpToDateAndSubsequentChanges(t *testing.T) {
 			status = <-resultChan
 			assert.Equal(t, interfaces.DataSourceStateValid, status.State)
 			assert.NotNil(t, status.ChangeSet)
-			dd.SetBasis(status.ChangeSet.Changes(), status.ChangeSet.Selector(), true)
+			dd.Apply(*status.ChangeSet, true)
 
 			flag, err = dd.DataStore.Get(datakinds.Features, "test-flag")
 			assert.NoError(t, err)
@@ -646,7 +646,7 @@ func TestStreamingDataSourceHandlesResettingFromError(t *testing.T) {
 			status = <-resultChan
 			assert.Equal(t, interfaces.DataSourceStateValid, status.State)
 			assert.NotNil(t, status.ChangeSet)
-			dd.SetBasis(status.ChangeSet.Changes(), status.ChangeSet.Selector(), true)
+			dd.Apply(*status.ChangeSet, true)
 
 			flag, err = dd.DataStore.Get(datakinds.Features, "test-flag")
 			assert.NoError(t, err)
@@ -734,7 +734,7 @@ func TestStreamingDataSourceIgnoresGoodbye(t *testing.T) {
 			status = <-resultChan
 			assert.Equal(t, interfaces.DataSourceStateValid, status.State)
 			assert.NotNil(t, status.ChangeSet)
-			dd.SetBasis(status.ChangeSet.Changes(), status.ChangeSet.Selector(), true)
+			dd.Apply(*status.ChangeSet, true)
 
 			flag, err = dd.DataStore.Get(datakinds.Features, "test-flag")
 			assert.NoError(t, err)

--- a/internal/datasystem/store.go
+++ b/internal/datasystem/store.go
@@ -173,7 +173,7 @@ func (s *Store) Close() error {
 // Apply applies a changeset to the store. The changeset must be a valid set of changes that can be applied
 // to the store. If the changeset is not valid, an error will be logged and the changeset will not be applied.
 func (s *Store) Apply(changeSet subsystems.ChangeSet, persist bool) {
-	collections, err := subsystems.ToStorableItems(changeSet.Changes())
+	collections, err := changeSet.Collections()
 	if err != nil {
 		s.loggers.Errorf("store: couldn't set basis due to malformed data: %v", err)
 		return
@@ -244,7 +244,7 @@ func (s *Store) shouldPersist() bool {
 	return s.persist && s.persistentStore.writable()
 }
 
-// applyDelta applies a delta update to the store. applyDelta should not be called until SetBasis has been called.
+// applyDelta applies a delta update to the store. applyDelta should not be called until setBasis has been called.
 // To request data persistence, set persist to true.
 func (s *Store) applyDelta(collections []ldstoretypes.Collection, selector subsystems.Selector, persist bool) {
 	s.memoryStore.ApplyDelta(collections)
@@ -298,7 +298,7 @@ func (s *Store) GetDataStoreStatusProvider() interfaces.DataStoreStatusProvider 
 }
 
 // Commit persists the data in the memory store to the persistent store, if configured. The persistent store
-// must also be in write mode, and the last call to SetBasis or ApplyDelta must have had persist set to true.
+// must also be in write mode, and the last call to setBasis or applyDelta must have had persist set to true.
 func (s *Store) Commit() error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/sharedtest/mocks/mock_data_destination.go
+++ b/internal/sharedtest/mocks/mock_data_destination.go
@@ -50,14 +50,20 @@ func (d *MockDataDestination) Selector() subsystems.Selector {
 	return d.lastKnownSelector
 }
 
-// SetBasis in this test implementation, delegates to d.DataStore.CapturedUpdates.
-func (d *MockDataDestination) SetBasis(events []subsystems.Change, selector subsystems.Selector, _ bool) {
-	// For now, the selector is ignored. When the data sources start making use of it, it should be
-	// stored so that assertions can be made.
+func (d *MockDataDestination) Apply(changeSet subsystems.ChangeSet, persist bool) {
+	switch changeSet.IntentCode() {
+	case subsystems.IntentTransferFull:
+		d.setBasis(changeSet, persist)
+	case subsystems.IntentTransferChanges:
+		d.applyDelta(changeSet, persist)
+	}
+}
 
-	collections, err := subsystems.ToStorableItems(events)
+// setBasis in this test implementation, delegates to d.DataStore.CapturedUpdates.
+func (d *MockDataDestination) setBasis(changeSet subsystems.ChangeSet, _ bool) {
+	collections, err := changeSet.Collections()
 	if err != nil {
-		panic("MockDataDestination.SetBasis received malformed data: " + err.Error())
+		panic("MockDataDestination.setBasis received malformed data: " + err.Error())
 	}
 
 	for _, coll := range collections {
@@ -66,19 +72,16 @@ func (d *MockDataDestination) SetBasis(events []subsystems.Change, selector subs
 
 	if err := d.DataStore.Init(toposort.Sort(collections)); err == nil {
 		d.lock.Lock()
-		d.lastKnownSelector = selector
+		d.lastKnownSelector = changeSet.Selector()
 		d.lock.Unlock()
 	}
 }
 
-// ApplyDelta in this test implementation, delegates to d.DataStore.CapturedUpdates.
-func (d *MockDataDestination) ApplyDelta(events []subsystems.Change, selector subsystems.Selector, _ bool) {
-	// For now, the selector is ignored. When the data sources start making use of it, it should be
-	// stored so that assertions can be made.
-
-	collections, err := subsystems.ToStorableItems(events)
+// applyDelta in this test implementation, delegates to d.DataStore.CapturedUpdates.
+func (d *MockDataDestination) applyDelta(changeSet subsystems.ChangeSet, _ bool) {
+	collections, err := changeSet.Collections()
 	if err != nil {
-		panic("MockDataDestination.ApplyDelta received malformed data: " + err.Error())
+		panic("MockDataDestination.applyDelta received malformed data: " + err.Error())
 	}
 
 	for _, coll := range collections {
@@ -94,7 +97,7 @@ func (d *MockDataDestination) ApplyDelta(events []subsystems.Change, selector su
 	}
 
 	d.lock.Lock()
-	d.lastKnownSelector = selector
+	d.lastKnownSelector = changeSet.Selector()
 	d.lock.Unlock()
 }
 

--- a/internal/sharedtest/mocks/mock_data_destination.go
+++ b/internal/sharedtest/mocks/mock_data_destination.go
@@ -50,6 +50,7 @@ func (d *MockDataDestination) Selector() subsystems.Selector {
 	return d.lastKnownSelector
 }
 
+// Apply persists the given ChangeSet to the DataStore.
 func (d *MockDataDestination) Apply(changeSet subsystems.ChangeSet, persist bool) {
 	switch changeSet.IntentCode() {
 	case subsystems.IntentTransferFull:

--- a/ldfiledatav2/file_data_source_impl.go
+++ b/ldfiledatav2/file_data_source_impl.go
@@ -137,9 +137,11 @@ func (fs *fileDataSource) Fetch(ds subsystems.DataSelector, ctx context.Context)
 	changeSetChan := fs.changeSetBroadcaster.AddListener()
 	statusChan := fs.statusBroadcaster.AddListener()
 
+	changeset := subsystems.NewChangeSetBuilder().NoChanges()
+
 	var err error
 	basis := &subsystems.Basis{
-		ChangeSet: subsystems.ChangeSet{},
+		ChangeSet: *changeset,
 		Persist:   false,
 	}
 

--- a/subsystems/changeset.go
+++ b/subsystems/changeset.go
@@ -3,6 +3,10 @@ package subsystems
 import (
 	"encoding/json"
 	"errors"
+	"sync"
+
+	"github.com/launchdarkly/go-jsonstream/v3/jreader"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
 )
 
 // ChangeType specifies if an object is being upserted or deleted.
@@ -48,6 +52,9 @@ type ChangeSet struct {
 	intentCode IntentCode
 	changes    []Change
 	selector   Selector
+
+	mu         *sync.Mutex
+	collection []ldstoretypes.Collection
 }
 
 // IntentCode represents the intent of the changeset.
@@ -64,6 +71,63 @@ func (c *ChangeSet) Changes() []Change {
 // Selector identifies the version of the changes.
 func (c *ChangeSet) Selector() Selector {
 	return c.selector
+}
+
+func (c *ChangeSet) Collections() ([]ldstoretypes.Collection, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.collection != nil {
+		return c.collection, nil
+	}
+
+	collection, err := toStorableItems(c.changes)
+	if err != nil {
+		return nil, err
+	}
+
+	c.collection = collection
+	return c.collection, nil
+}
+
+// toStorableItems converts a list of FDv2 events to a list of collections suitable for insertion
+// into a data store.
+func toStorableItems(deltas []Change) ([]ldstoretypes.Collection, error) {
+	collections := make(kindMap)
+	for _, event := range deltas {
+		kind, ok := event.Kind.ToFDV1()
+		if !ok {
+			// If we don't recognize this kind, it's not an error and should be ignored for forwards
+			// compatibility.
+			continue
+		}
+
+		switch event.Action {
+		case ChangeTypePut:
+			// A put requires deserializing the item. We delegate to the optimized streaming JSON
+			// parser.
+			reader := jreader.NewReader(event.Object)
+			item, err := kind.DeserializeFromJSONReader(&reader)
+			if err != nil {
+				return nil, err
+			}
+			collections[kind] = append(collections[kind], ldstoretypes.KeyedItemDescriptor{
+				Key:  event.Key,
+				Item: item,
+			})
+		case ChangeTypeDelete:
+			// A deletion is represented by a tombstone, which is an ItemDescriptor with a version and nil item.
+			collections[kind] = append(collections[kind], ldstoretypes.KeyedItemDescriptor{
+				Key:  event.Key,
+				Item: ldstoretypes.ItemDescriptor{Version: event.Version, Item: nil},
+			})
+		default:
+			// An unknown action isn't an error, and should be ignored for forwards compatibility.
+			continue
+		}
+	}
+
+	return collections.flatten(), nil
 }
 
 // ChangeSetBuilder is a helper for constructing a ChangeSet.
@@ -96,6 +160,7 @@ func (c *ChangeSetBuilder) NoChanges() *ChangeSet {
 		intentCode: IntentNone,
 		selector:   NoSelector(),
 		changes:    nil,
+		mu:         &sync.Mutex{},
 	}
 }
 
@@ -106,6 +171,7 @@ func (c *ChangeSetBuilder) Empty(selector Selector) *ChangeSet {
 		intentCode: IntentTransferFull,
 		selector:   selector,
 		changes:    nil,
+		mu:         &sync.Mutex{},
 	}
 }
 
@@ -152,6 +218,7 @@ func (c *ChangeSetBuilder) Finish(selector Selector) (*ChangeSet, error) {
 		intentCode: c.intent.Payload.Code,
 		selector:   selector,
 		changes:    c.changes,
+		mu:         &sync.Mutex{},
 	}
 	c.changes = nil
 

--- a/subsystems/changeset.go
+++ b/subsystems/changeset.go
@@ -81,6 +81,11 @@ func (c *ChangeSet) Collections() ([]ldstoretypes.Collection, error) {
 		return c.collection, nil
 	}
 
+	if c.changes == nil {
+		c.collection = []ldstoretypes.Collection{}
+		return c.collection, nil
+	}
+
 	collection, err := toStorableItems(c.changes)
 	if err != nil {
 		return nil, err

--- a/subsystems/changeset.go
+++ b/subsystems/changeset.go
@@ -73,6 +73,8 @@ func (c *ChangeSet) Selector() Selector {
 	return c.selector
 }
 
+// Collections converts the changeset into a list of collections suitable for
+// insertion into a data store, relaying to FDv1 clients, etc.
 func (c *ChangeSet) Collections() ([]ldstoretypes.Collection, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/subsystems/changeset_test.go
+++ b/subsystems/changeset_test.go
@@ -3,6 +3,7 @@ package subsystems
 import (
 	"testing"
 
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -79,4 +80,217 @@ func TestChangeSetBuilder_NoChanges(t *testing.T) {
 
 	assert.False(t, changeSet.Selector().IsDefined())
 	assert.Equal(t, NoSelector(), changeSet.Selector())
+}
+
+func TestChangeSet_Collections_EmptyChanges(t *testing.T) {
+	builder := NewChangeSetBuilder()
+	builder.Start(ServerIntent{Payload: Payload{Code: IntentTransferFull}})
+	changeSet, err := builder.Finish(NewSelector("test", 1))
+	assert.NoError(t, err)
+
+	collections, err := changeSet.Collections()
+	assert.NoError(t, err)
+	assert.NotNil(t, collections)
+	assert.Equal(t, 0, len(collections))
+}
+
+func TestChangeSet_Collections_PutChanges(t *testing.T) {
+	builder := NewChangeSetBuilder()
+	builder.Start(ServerIntent{Payload: Payload{Code: IntentTransferFull}})
+
+	flagJSON := []byte(`{"key":"flag1","version":1}`)
+	segmentJSON := []byte(`{"key":"seg1","version":2}`)
+
+	builder.AddPut(FlagKind, "flag1", 1, flagJSON)
+	builder.AddPut(SegmentKind, "seg1", 2, segmentJSON)
+
+	changeSet, err := builder.Finish(NewSelector("test", 1))
+	assert.NoError(t, err)
+
+	collections, err := changeSet.Collections()
+	assert.NoError(t, err)
+	assert.NotNil(t, collections)
+	assert.Equal(t, 2, len(collections))
+
+	// Verify we have both flags and segments collections
+	var foundFlags, foundSegments bool
+	for _, collection := range collections {
+		if len(collection.Items) > 0 {
+			if collection.Items[0].Key == "flag1" {
+				foundFlags = true
+				assert.Equal(t, 1, collection.Items[0].Item.Version)
+				assert.NotNil(t, collection.Items[0].Item.Item)
+			}
+			if collection.Items[0].Key == "seg1" {
+				foundSegments = true
+				assert.Equal(t, 2, collection.Items[0].Item.Version)
+				assert.NotNil(t, collection.Items[0].Item.Item)
+			}
+		}
+	}
+	assert.True(t, foundFlags, "Expected to find flags collection")
+	assert.True(t, foundSegments, "Expected to find segments collection")
+}
+
+func TestChangeSet_Collections_DeleteChanges(t *testing.T) {
+	builder := NewChangeSetBuilder()
+	builder.Start(ServerIntent{Payload: Payload{Code: IntentTransferChanges}})
+
+	builder.AddDelete(FlagKind, "flag1", 5)
+	builder.AddDelete(SegmentKind, "seg1", 10)
+
+	changeSet, err := builder.Finish(NewSelector("test", 1))
+	assert.NoError(t, err)
+
+	collections, err := changeSet.Collections()
+	assert.NoError(t, err)
+	assert.NotNil(t, collections)
+	assert.Equal(t, 2, len(collections))
+
+	// Verify tombstones (nil items with versions)
+	for _, collection := range collections {
+		if len(collection.Items) > 0 {
+			item := collection.Items[0]
+			assert.Nil(t, item.Item.Item, "Deleted items should have nil Item")
+			if item.Key == "flag1" {
+				assert.Equal(t, 5, item.Item.Version)
+			} else if item.Key == "seg1" {
+				assert.Equal(t, 10, item.Item.Version)
+			}
+		}
+	}
+}
+
+func TestChangeSet_Collections_MixedChanges(t *testing.T) {
+	builder := NewChangeSetBuilder()
+	builder.Start(ServerIntent{Payload: Payload{Code: IntentTransferChanges}})
+
+	flagJSON := []byte(`{"key":"flag1","version":1}`)
+
+	builder.AddPut(FlagKind, "flag1", 1, flagJSON)
+	builder.AddDelete(FlagKind, "flag2", 2)
+	builder.AddPut(SegmentKind, "seg1", 3, []byte(`{"key":"seg1","version":3}`))
+
+	changeSet, err := builder.Finish(NewSelector("test", 1))
+	assert.NoError(t, err)
+
+	collections, err := changeSet.Collections()
+	assert.NoError(t, err)
+	assert.NotNil(t, collections)
+
+	// Find the flags collection
+	var flagsCollection *ldstoretypes.Collection
+	for i := range collections {
+		for _, item := range collections[i].Items {
+			if item.Key == "flag1" || item.Key == "flag2" {
+				flagsCollection = &collections[i]
+				break
+			}
+		}
+	}
+
+	assert.NotNil(t, flagsCollection, "Expected to find flags collection")
+	assert.Equal(t, 2, len(flagsCollection.Items), "Expected 2 flag items")
+
+	// Verify the put and delete
+	for _, item := range flagsCollection.Items {
+		if item.Key == "flag1" {
+			assert.NotNil(t, item.Item.Item, "Put item should have non-nil Item")
+			assert.Equal(t, 1, item.Item.Version)
+		} else if item.Key == "flag2" {
+			assert.Nil(t, item.Item.Item, "Deleted item should have nil Item")
+			assert.Equal(t, 2, item.Item.Version)
+		}
+	}
+}
+
+func TestChangeSet_Collections_Caching(t *testing.T) {
+	builder := NewChangeSetBuilder()
+	builder.Start(ServerIntent{Payload: Payload{Code: IntentTransferFull}})
+
+	flagJSON := []byte(`{"key":"flag1","version":1}`)
+	builder.AddPut(FlagKind, "flag1", 1, flagJSON)
+
+	changeSet, err := builder.Finish(NewSelector("test", 1))
+	assert.NoError(t, err)
+
+	// First call
+	collections1, err := changeSet.Collections()
+	assert.NoError(t, err)
+	assert.NotNil(t, collections1)
+
+	// Second call should return the cached result (same pointer)
+	collections2, err := changeSet.Collections()
+	assert.NoError(t, err)
+	assert.NotNil(t, collections2)
+
+	// Verify they are the same slice (cached)
+	assert.Equal(t, &collections1[0], &collections2[0], "Expected cached collections to be the same slice")
+}
+
+func TestChangeSet_Collections_UnknownKind(t *testing.T) {
+	builder := NewChangeSetBuilder()
+	builder.Start(ServerIntent{Payload: Payload{Code: IntentTransferChanges}})
+
+	// Add an unknown kind that won't convert to FDV1
+	builder.AddPut(ObjectKind("unknown"), "item1", 1, []byte(`{"key":"item1"}`))
+	// Also add a valid flag
+	builder.AddPut(FlagKind, "flag1", 2, []byte(`{"key":"flag1","version":2}`))
+
+	changeSet, err := builder.Finish(NewSelector("test", 1))
+	assert.NoError(t, err)
+
+	collections, err := changeSet.Collections()
+	assert.NoError(t, err)
+	assert.NotNil(t, collections)
+
+	// Should only have 1 collection (the flag), unknown kind should be ignored
+	assert.Equal(t, 1, len(collections))
+	assert.Equal(t, 1, len(collections[0].Items))
+	assert.Equal(t, "flag1", collections[0].Items[0].Key)
+}
+
+func TestChangeSet_Collections_InvalidJSON(t *testing.T) {
+	builder := NewChangeSetBuilder()
+	builder.Start(ServerIntent{Payload: Payload{Code: IntentTransferChanges}})
+
+	// Add invalid JSON for a put
+	builder.AddPut(FlagKind, "flag1", 1, []byte(`{invalid json`))
+
+	changeSet, err := builder.Finish(NewSelector("test", 1))
+	assert.NoError(t, err)
+
+	collections, err := changeSet.Collections()
+	assert.Error(t, err, "Expected error for invalid JSON")
+	assert.Nil(t, collections)
+}
+
+func TestChangeSet_Collections_MultipleItemsSameKind(t *testing.T) {
+	builder := NewChangeSetBuilder()
+	builder.Start(ServerIntent{Payload: Payload{Code: IntentTransferFull}})
+
+	// Add multiple flags
+	builder.AddPut(FlagKind, "flag1", 1, []byte(`{"key":"flag1","version":1}`))
+	builder.AddPut(FlagKind, "flag2", 2, []byte(`{"key":"flag2","version":2}`))
+	builder.AddPut(FlagKind, "flag3", 3, []byte(`{"key":"flag3","version":3}`))
+
+	changeSet, err := builder.Finish(NewSelector("test", 1))
+	assert.NoError(t, err)
+
+	collections, err := changeSet.Collections()
+	assert.NoError(t, err)
+	assert.NotNil(t, collections)
+
+	// Should have 1 collection with 3 items
+	assert.Equal(t, 1, len(collections))
+	assert.Equal(t, 3, len(collections[0].Items))
+
+	// Verify all flags are present
+	keys := make(map[string]bool)
+	for _, item := range collections[0].Items {
+		keys[item.Key] = true
+	}
+	assert.True(t, keys["flag1"])
+	assert.True(t, keys["flag2"])
+	assert.True(t, keys["flag3"])
 }

--- a/subsystems/deltas_to_storable_items.go
+++ b/subsystems/deltas_to_storable_items.go
@@ -1,56 +1,9 @@
 package subsystems
 
 import (
-	"github.com/launchdarkly/go-jsonstream/v3/jreader"
 	"github.com/launchdarkly/go-server-sdk/v7/internal/datakinds"
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
 )
-
-// ToStorableItems converts a list of FDv2 events to a list of collections suitable for insertion
-// into a data store.
-//
-// This function is not stable, and not subject to any backwards
-// compatibility guarantees or semantic versioning. It is not suitable for production usage.
-//
-// Do not use it.
-// You have been warned.
-func ToStorableItems(deltas []Change) ([]ldstoretypes.Collection, error) {
-	collections := make(kindMap)
-	for _, event := range deltas {
-		kind, ok := event.Kind.ToFDV1()
-		if !ok {
-			// If we don't recognize this kind, it's not an error and should be ignored for forwards
-			// compatibility.
-			continue
-		}
-
-		switch event.Action {
-		case ChangeTypePut:
-			// A put requires deserializing the item. We delegate to the optimized streaming JSON
-			// parser.
-			reader := jreader.NewReader(event.Object)
-			item, err := kind.DeserializeFromJSONReader(&reader)
-			if err != nil {
-				return nil, err
-			}
-			collections[kind] = append(collections[kind], ldstoretypes.KeyedItemDescriptor{
-				Key:  event.Key,
-				Item: item,
-			})
-		case ChangeTypeDelete:
-			// A deletion is represented by a tombstone, which is an ItemDescriptor with a version and nil item.
-			collections[kind] = append(collections[kind], ldstoretypes.KeyedItemDescriptor{
-				Key:  event.Key,
-				Item: ldstoretypes.ItemDescriptor{Version: event.Version, Item: nil},
-			})
-		default:
-			// An unknown action isn't an error, and should be ignored for forwards compatibility.
-			continue
-		}
-	}
-
-	return collections.flatten(), nil
-}
 
 type kindMap map[datakinds.DataKindInternal][]ldstoretypes.KeyedItemDescriptor
 


### PR DESCRIPTION
The SDK changes to convert changesets into `[]ldstoretypes.Collection`
for a lot of it's internal workings. Coincidentally, the relay proxy
also needs to do this same conversion when supporting FDv1 formats.

To help with this, we add a `.Collections` method which memoizes the
result for later use, reducing our memory allocation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce memoized ChangeSet.Collections and update store, mocks, and tests to consume it, simplifying conversions and reducing allocations.
> 
> - **Subsystems**:
>   - **ChangeSet**: add `Collections()` with caching and synchronization; embed conversion logic (`toStorableItems`) and backing cache; extend builder-created sets to include mutex.
>   - **Tests**: add comprehensive `ChangeSet.Collections` tests (empty, put/delete, mixed, caching, unknown kind, invalid JSON, multiple items).
>   - **Cleanup**: remove `ToStorableItems`; retain `kindMap.flatten()` helper.
> - **Datasystem**:
>   - **Store.Apply**: switch to `changeSet.Collections()`; minor comment/casing fixes.
> - **Mocks/Tests**:
>   - **MockDataDestination**: replace `SetBasis/ApplyDelta` entrypoints with `Apply(ChangeSet)` delegating to internal `setBasis/applyDelta` using `Collections()`; update selector handling.
>   - **Streaming tests**: replace `dd.SetBasis/ApplyDelta` with `dd.Apply(*status.ChangeSet, true)`.
> - **File data source**:
>   - **Fetch**: initialize `Basis.ChangeSet` with `NewChangeSetBuilder().NoChanges()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db21f162f895f176d35445912800107d82e44814. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->