### PR TITLE
fix: fdv2 datasystem leaves sychronizer open after client is closed

### DIFF
--- a/internal/datasystem/fdv2_datasystem.go
+++ b/internal/datasystem/fdv2_datasystem.go
@@ -288,10 +288,12 @@ func (f *FDv2) runSynchronizers(ctx context.Context, closeWhenReady chan struct{
 			f.loggers.Debugf("Primary synchronizer %s is starting", primarySync.Name())
 			resultChan := primarySync.Sync(f.store)
 			removeSync, fallbackv1, err := f.consumeSynchronizerResults(ctx, resultChan, f.fallbackCond, closeWhenReady)
+
+			if err := primarySync.Close(); err != nil {
+				f.loggers.Errorf("Primary synchronizer %s failed to gracefully close: %v", primarySync.Name(), err)
+			}
 			if errors.Is(err, context.Canceled) {
 				return
-			} else if err := primarySync.Close(); err != nil {
-				f.loggers.Errorf("Primary synchronizer %s failed to gracefully close: %v", primarySync.Name(), err)
 			}
 
 			if removeSync {
@@ -327,10 +329,12 @@ func (f *FDv2) runSynchronizers(ctx context.Context, closeWhenReady chan struct{
 
 			resultChan = secondarySync.Sync(f.store)
 			removeSync, fallbackv1, err = f.consumeSynchronizerResults(ctx, resultChan, f.recoveryCond, closeWhenReady)
+
+			if err := secondarySync.Close(); err != nil {
+				f.loggers.Errorf("Secondary synchronizer %s failed to gracefully close: %v", secondarySync.Name(), err)
+			}
 			if errors.Is(err, context.Canceled) {
 				return
-			} else if err := secondarySync.Close(); err != nil {
-				f.loggers.Errorf("Secondary synchronizer %s failed to gracefully close: %v", secondarySync.Name(), err)
 			}
 
 			if removeSync {


### PR DESCRIPTION

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/v5/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

This update modifies the runSynchronizers method to ensure that both primary and secondary synchronizers are closed before returning due to a client shutdown.

**Describe alternatives you've considered**

Alternatively, we could handle the context cancelling in the synchronizer implementation, but this is a less disruptive change.

**Additional context**

Take a look at jira issue for a more detailed investigation of the problem

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Always close primary and secondary synchronizers after processing results, even when context is canceled, to avoid leaving them open after client shutdown.
> 
> - **FDv2 DataSystem (`internal/datasystem/fdv2_datasystem.go`)**:
>   - Ensure `primarySync.Close()` and `secondarySync.Close()` are invoked immediately after `consumeSynchronizerResults`, before checking for `context.Canceled`.
>   - Prevents leaving synchronizers running by closing them unconditionally after each sync cycle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a76595dbf9f943f5ca1d257e74ed06c313cbca7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->