### PR TITLE
fix: Remove disable streaming warning

### DIFF
--- a/ldclient_end_to_end_fdv2_test.go
+++ b/ldclient_end_to_end_fdv2_test.go
@@ -200,7 +200,7 @@ func TestFDV2ShutdownDownIfBothSynchronizersFail(t *testing.T) {
 		expectedStreamError := "Error in stream connection (giving up permanently): HTTP error 401 (invalid SDK key)"
 		expectedPollError := "Error on polling request (giving up permanently): HTTP error 401 (invalid SDK key)"
 		assert.Equal(t, []string{expectedStreamError, expectedPollError}, logCapture.GetOutput(ldlog.Error))
-		assert.Equal(t, []string{pollingModeWarningMessage, initializationFailedErrorMessage}, logCapture.GetOutput(ldlog.Warn))
+		assert.Equal(t, []string{initializationFailedErrorMessage}, logCapture.GetOutput(ldlog.Warn))
 	})
 }
 
@@ -280,7 +280,7 @@ func TestFDV2PollingSynchronizerFailsToStartWith401Error(t *testing.T) {
 
 		expectedError := "Error on polling request (giving up permanently): HTTP error 401 (invalid SDK key)"
 		assert.Equal(t, []string{expectedError}, logCapture.GetOutput(ldlog.Error))
-		assert.Equal(t, []string{pollingModeWarningMessage, initializationFailedErrorMessage}, logCapture.GetOutput(ldlog.Warn))
+		assert.Equal(t, []string{initializationFailedErrorMessage}, logCapture.GetOutput(ldlog.Warn))
 	})
 }
 
@@ -372,7 +372,6 @@ func TestFDV2FileInitializerWillDeferToFirstSynchronizer(t *testing.T) {
 	handler, requestsCh := httphelpers.RecordingHandler(streamHandler)
 
 	testHelpers.WithTempFileData([]byte(`{"flags": {"`+alwaysFalseFlag.Key+`": {"on": false}}, "segments": {}}`), func(filename string) {
-
 		httphelpers.WithServer(handler, func(server *httptest.Server) {
 			logCapture := ldlogtest.NewMockLog()
 

--- a/ldcomponents/polling_data_source_builder_v2.go
+++ b/ldcomponents/polling_data_source_builder_v2.go
@@ -84,8 +84,6 @@ func (b *PollingDataSourceBuilderV2) PayloadFilter(filterKey string) *PollingDat
 
 // Build is called internally by the SDK.
 func (b *PollingDataSourceBuilderV2) Build(context subsystems.ClientContext) (subsystems.DataSynchronizer, error) {
-	context.GetLogging().Loggers.Warn(
-		"You should only disable the streaming API if instructed to do so by LaunchDarkly support")
 	filterKey, wasSet := b.filterKey.Get()
 	if wasSet && filterKey == "" {
 		return nil, errors.New("payload filter key cannot be an empty string")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the legacy "disable streaming" warning and aligns tests with the new logging behavior.
> 
> - Delete warning log from `PollingDataSourceBuilderV2.Build` that discouraged disabling streaming
> - Update FDv2 end-to-end tests to stop asserting `pollingModeWarningMessage` warnings; keep other error/warn assertions intact
> - Minor test cleanup (whitespace/handler setup)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34fa4d005c91069d20cfaf506d57385dcfabb315. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->