### PR TITLE
fix: improves fallback behavior when using custom data system configuration

### DIFF
--- a/internal/datasystem/fdv2_datasystem.go
+++ b/internal/datasystem/fdv2_datasystem.go
@@ -152,14 +152,10 @@ func NewFDv2(disabled bool, cfgBuilder subsystems.ComponentConfigurer[subsystems
 		return interruptedAtRuntime || cannotInitialize
 	}
 	fdv2.recoveryCond = func(status interfaces.DataSourceStatus) bool {
-		interruptedAtRuntime := status.State == interfaces.DataSourceStateInterrupted &&
-			time.Since(status.StateSince) > 1*time.Minute
 		healthyForTooLong := status.State == interfaces.DataSourceStateValid &&
 			time.Since(status.StateSince) > 5*time.Minute
-		cannotInitialize := status.State == interfaces.DataSourceStateInitializing &&
-			time.Since(status.StateSince) > 10*time.Second
 
-		return interruptedAtRuntime || healthyForTooLong || cannotInitialize
+		return healthyForTooLong
 	}
 
 	fdv2.configuredWithDataSources = len(fdv2.initializers) > 0 || len(fdv2.synchronizerBuilders) > 0


### PR DESCRIPTION
Removes recovery conditions that could interfere with data system configurations with more than two synchronizers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to fallback/recovery condition evaluation; main risk is altered runtime failover behavior in edge cases where previously recovery could trigger while interrupted/initializing.
> 
> **Overview**
> FDv2’s `recoveryCond` logic is simplified to **only** trigger recovery (jump back to the first synchronizer) when the data source has remained `Valid` for more than 5 minutes.
> 
> This removes recovery triggers based on prolonged `Interrupted` or `Initializing` states, preventing recovery decisions that could interfere with custom configurations that use more than two synchronizers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb33ba86057c2902bf0c3a9e7e684fabbca75bef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->