### PR TITLE
chore: Support flag change listeners in contract tests

### DIFF
--- a/testservice/flag_change_listener.go
+++ b/testservice/flag_change_listener.go
@@ -18,27 +18,36 @@ type listenerEntry struct {
 // listenerRegistry manages all active flag change listener registrations for a single
 // SDK client entity. It is safe to use from multiple goroutines.
 type listenerRegistry struct {
-	mu      sync.Mutex
-	entries map[string]*listenerEntry // keyed by listenerId
-	tracker interfaces.FlagTracker
+	mu        sync.Mutex
+	listeners map[string]*listenerEntry // keyed by listenerId
+	tracker   interfaces.FlagTracker
 }
 
 func newListenerRegistry(tracker interfaces.FlagTracker) *listenerRegistry {
 	return &listenerRegistry{
-		entries: make(map[string]*listenerEntry),
-		tracker: tracker,
+		listeners: make(map[string]*listenerEntry),
+		tracker:   tracker,
 	}
 }
 
-// registerFlagChangeListener subscribes to general flag configuration changes. If flagKey
-// is non-empty, only events for that specific flag are forwarded to the callback URI.
-func (r *listenerRegistry) registerFlagChangeListener(listenerID, flagKey, callbackURI string) {
-	ch := r.tracker.AddFlagChangeListener()
+// storeListener registers a new listener entry under listenerID, cancelling any
+// previously registered listener with the same ID. Returns the new entry's context.
+func (r *listenerRegistry) storeListener(listenerID string) context.Context {
 	ctx, cancel := context.WithCancel(context.Background())
-
 	r.mu.Lock()
-	r.entries[listenerID] = &listenerEntry{cancel: cancel}
+	if old, exists := r.listeners[listenerID]; exists {
+		old.cancel()
+	}
+	r.listeners[listenerID] = &listenerEntry{cancel: cancel}
 	r.mu.Unlock()
+	return ctx
+}
+
+// registerFlagChangeListener subscribes to general flag configuration changes.
+// All flag change events are forwarded to the callback URI.
+func (r *listenerRegistry) registerFlagChangeListener(listenerID, callbackURI string) {
+	ch := r.tracker.AddFlagChangeListener()
+	ctx := r.storeListener(listenerID)
 
 	svc := callbackService{baseURL: callbackURI}
 	go func() {
@@ -50,9 +59,6 @@ func (r *listenerRegistry) registerFlagChangeListener(listenerID, flagKey, callb
 			case event, ok := <-ch:
 				if !ok {
 					return
-				}
-				if flagKey != "" && event.Key != flagKey {
-					continue
 				}
 				_ = svc.post("", servicedef.ListenerNotification{
 					ListenerID: listenerID,
@@ -73,11 +79,7 @@ func (r *listenerRegistry) registerFlagValueChangeListener(
 	callbackURI string,
 ) {
 	ch := r.tracker.AddFlagValueChangeListener(flagKey, evalCtx, defaultValue)
-	ctx, cancel := context.WithCancel(context.Background())
-
-	r.mu.Lock()
-	r.entries[listenerID] = &listenerEntry{cancel: cancel}
-	r.mu.Unlock()
+	ctx := r.storeListener(listenerID)
 
 	svc := callbackService{baseURL: callbackURI}
 	go func() {
@@ -107,9 +109,9 @@ func (r *listenerRegistry) registerFlagValueChangeListener(
 // registry. Returns false if no listener with that ID was found.
 func (r *listenerRegistry) unregister(listenerID string) bool {
 	r.mu.Lock()
-	entry, ok := r.entries[listenerID]
+	entry, ok := r.listeners[listenerID]
 	if ok {
-		delete(r.entries, listenerID)
+		delete(r.listeners, listenerID)
 	}
 	r.mu.Unlock()
 
@@ -122,11 +124,11 @@ func (r *listenerRegistry) unregister(listenerID string) bool {
 // closeAll stops all active listener goroutines. Called when the SDK client entity closes.
 func (r *listenerRegistry) closeAll() {
 	r.mu.Lock()
-	entries := r.entries
-	r.entries = make(map[string]*listenerEntry)
+	listeners := r.listeners
+	r.listeners = make(map[string]*listenerEntry)
 	r.mu.Unlock()
 
-	for _, entry := range entries {
+	for _, entry := range listeners {
 		entry.cancel()
 	}
 }

--- a/testservice/flag_change_listener.go
+++ b/testservice/flag_change_listener.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"context"
+	"sync"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/go-server-sdk/v7/interfaces"
+	"github.com/launchdarkly/go-server-sdk/v7/testservice/servicedef"
+)
+
+// listenerEntry holds the cancellation handle for one registered listener goroutine.
+type listenerEntry struct {
+	cancel context.CancelFunc
+}
+
+// listenerRegistry manages all active flag change listener registrations for a single
+// SDK client entity. It is safe to use from multiple goroutines.
+type listenerRegistry struct {
+	mu      sync.Mutex
+	entries map[string]*listenerEntry // keyed by listenerId
+	tracker interfaces.FlagTracker
+}
+
+func newListenerRegistry(tracker interfaces.FlagTracker) *listenerRegistry {
+	return &listenerRegistry{
+		entries: make(map[string]*listenerEntry),
+		tracker: tracker,
+	}
+}
+
+// registerFlagChangeListener subscribes to general flag configuration changes. If flagKey
+// is non-empty, only events for that specific flag are forwarded to the callback URI.
+func (r *listenerRegistry) registerFlagChangeListener(listenerID, flagKey, callbackURI string) {
+	ch := r.tracker.AddFlagChangeListener()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	r.mu.Lock()
+	r.entries[listenerID] = &listenerEntry{cancel: cancel}
+	r.mu.Unlock()
+
+	svc := callbackService{baseURL: callbackURI}
+	go func() {
+		defer r.tracker.RemoveFlagChangeListener(ch)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event, ok := <-ch:
+				if !ok {
+					return
+				}
+				if flagKey != "" && event.Key != flagKey {
+					continue
+				}
+				_ = svc.post("", servicedef.ListenerNotification{
+					ListenerID: listenerID,
+					FlagKey:    event.Key,
+				}, nil)
+			}
+		}
+	}()
+}
+
+// registerFlagValueChangeListener subscribes to value changes for a specific flag and
+// evaluation context. The callback is invoked only when the evaluated value actually
+// changes; configuration changes that leave the value unchanged are suppressed by the SDK.
+func (r *listenerRegistry) registerFlagValueChangeListener(
+	listenerID, flagKey string,
+	evalCtx ldcontext.Context,
+	defaultValue ldvalue.Value,
+	callbackURI string,
+) {
+	ch := r.tracker.AddFlagValueChangeListener(flagKey, evalCtx, defaultValue)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	r.mu.Lock()
+	r.entries[listenerID] = &listenerEntry{cancel: cancel}
+	r.mu.Unlock()
+
+	svc := callbackService{baseURL: callbackURI}
+	go func() {
+		defer r.tracker.RemoveFlagValueChangeListener(ch)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event, ok := <-ch:
+				if !ok {
+					return
+				}
+				oldVal := event.OldValue
+				newVal := event.NewValue
+				_ = svc.post("", servicedef.ListenerNotification{
+					ListenerID: listenerID,
+					FlagKey:    event.Key,
+					OldValue:   &oldVal,
+					NewValue:   &newVal,
+				}, nil)
+			}
+		}
+	}()
+}
+
+// unregister stops the listener goroutine for the given ID and removes it from the
+// registry. Returns false if no listener with that ID was found.
+func (r *listenerRegistry) unregister(listenerID string) bool {
+	r.mu.Lock()
+	entry, ok := r.entries[listenerID]
+	if ok {
+		delete(r.entries, listenerID)
+	}
+	r.mu.Unlock()
+
+	if ok {
+		entry.cancel()
+	}
+	return ok
+}
+
+// closeAll stops all active listener goroutines. Called when the SDK client entity closes.
+func (r *listenerRegistry) closeAll() {
+	r.mu.Lock()
+	entries := r.entries
+	r.entries = make(map[string]*listenerEntry)
+	r.mu.Unlock()
+
+	for _, entry := range entries {
+		entry.cancel()
+	}
+}

--- a/testservice/sdk_client_entity.go
+++ b/testservice/sdk_client_entity.go
@@ -39,8 +39,9 @@ import (
 const defaultStartWaitTime = 5 * time.Second
 
 type SDKClientEntity struct {
-	sdk    *ld.LDClient
-	logger *log.Logger
+	sdk       *ld.LDClient
+	logger    *log.Logger
+	listeners *listenerRegistry
 }
 
 func NewSDKClientEntity(params servicedef.CreateInstanceParams) (*SDKClientEntity, error) {
@@ -71,11 +72,13 @@ func NewSDKClientEntity(params servicedef.CreateInstanceParams) (*SDKClientEntit
 		return nil, err
 	}
 	c.sdk = sdk
+	c.listeners = newListenerRegistry(sdk.GetFlagTracker())
 
 	return c, nil
 }
 
 func (c *SDKClientEntity) Close() {
+	c.listeners.closeAll()
 	_ = c.sdk.Close()
 	c.logger.Println("Test ended")
 	c.logger.SetOutput(io.Discard)
@@ -130,6 +133,20 @@ func (c *SDKClientEntity) DoCommand(params servicedef.CommandParams) (interface{
 		return servicedef.MigrationVariationResponse{Result: string(stage)}, nil
 	case servicedef.CommandMigrationOperation:
 		return c.migrationOperation(*params.MigrationOperation)
+	case servicedef.CommandRegisterFlagChangeListener:
+		p := params.RegisterFlagChangeListener
+		c.listeners.registerFlagChangeListener(p.ListenerID, p.FlagKey, p.CallbackURI)
+		return nil, nil
+	case servicedef.CommandRegisterFlagValueChangeListener:
+		p := params.RegisterFlagValueChangeListener
+		c.listeners.registerFlagValueChangeListener(p.ListenerID, p.FlagKey, p.Context, p.DefaultValue, p.CallbackURI)
+		return nil, nil
+	case servicedef.CommandUnregisterListener:
+		p := params.UnregisterListener
+		if !c.listeners.unregister(p.ListenerID) {
+			return nil, BadRequestError{Message: fmt.Sprintf("no listener with id %q", p.ListenerID)}
+		}
+		return nil, nil
 	default:
 		return nil, BadRequestError{Message: fmt.Sprintf("unknown command %q", params.Command)}
 	}

--- a/testservice/sdk_client_entity.go
+++ b/testservice/sdk_client_entity.go
@@ -135,7 +135,7 @@ func (c *SDKClientEntity) DoCommand(params servicedef.CommandParams) (interface{
 		return c.migrationOperation(*params.MigrationOperation)
 	case servicedef.CommandRegisterFlagChangeListener:
 		p := params.RegisterFlagChangeListener
-		c.listeners.registerFlagChangeListener(p.ListenerID, p.FlagKey, p.CallbackURI)
+		c.listeners.registerFlagChangeListener(p.ListenerID, p.CallbackURI)
 		return nil, nil
 	case servicedef.CommandRegisterFlagValueChangeListener:
 		p := params.RegisterFlagValueChangeListener

--- a/testservice/service.go
+++ b/testservice/service.go
@@ -49,6 +49,7 @@ var capabilities = []string{
 	servicedef.CapabilityPersistentDataStoreConsul,
 	servicedef.CapabilityPersistentDataStoreDynamoDB,
 	servicedef.CapabilityFlagChangeListeners,
+	servicedef.CapabilityFlagValueChangeListeners,
 }
 
 // gets the specified environment variable, or the default if not set

--- a/testservice/service.go
+++ b/testservice/service.go
@@ -48,6 +48,7 @@ var capabilities = []string{
 	servicedef.CapabilityPersistentDataStoreRedis,
 	servicedef.CapabilityPersistentDataStoreConsul,
 	servicedef.CapabilityPersistentDataStoreDynamoDB,
+	servicedef.CapabilityFlagChangeListeners,
 }
 
 // gets the specified environment variable, or the default if not set

--- a/testservice/servicedef/command_params.go
+++ b/testservice/servicedef/command_params.go
@@ -8,18 +8,21 @@ import (
 )
 
 const (
-	CommandEvaluateFlag             = "evaluate"
-	CommandEvaluateAllFlags         = "evaluateAll"
-	CommandIdentifyEvent            = "identifyEvent"
-	CommandCustomEvent              = "customEvent"
-	CommandAliasEvent               = "aliasEvent"
-	CommandFlushEvents              = "flushEvents"
-	CommandGetBigSegmentStoreStatus = "getBigSegmentStoreStatus"
-	CommandContextBuild             = "contextBuild"
-	CommandContextConvert           = "contextConvert"
-	CommandSecureModeHash           = "secureModeHash"
-	CommandMigrationVariation       = "migrationVariation"
-	CommandMigrationOperation       = "migrationOperation"
+	CommandEvaluateFlag                    = "evaluate"
+	CommandEvaluateAllFlags                = "evaluateAll"
+	CommandIdentifyEvent                   = "identifyEvent"
+	CommandCustomEvent                     = "customEvent"
+	CommandAliasEvent                      = "aliasEvent"
+	CommandFlushEvents                     = "flushEvents"
+	CommandGetBigSegmentStoreStatus        = "getBigSegmentStoreStatus"
+	CommandContextBuild                    = "contextBuild"
+	CommandContextConvert                  = "contextConvert"
+	CommandSecureModeHash                  = "secureModeHash"
+	CommandMigrationVariation              = "migrationVariation"
+	CommandMigrationOperation              = "migrationOperation"
+	CommandRegisterFlagChangeListener      = "registerFlagChangeListener"
+	CommandRegisterFlagValueChangeListener = "registerFlagValueChangeListener"
+	CommandUnregisterListener              = "unregisterListener"
 )
 
 type ValueType string
@@ -33,16 +36,19 @@ const (
 )
 
 type CommandParams struct {
-	Command            string                    `json:"command"`
-	Evaluate           *EvaluateFlagParams       `json:"evaluate,omitempty"`
-	EvaluateAll        *EvaluateAllFlagsParams   `json:"evaluateAll,omitempty"`
-	CustomEvent        *CustomEventParams        `json:"customEvent,omitempty"`
-	IdentifyEvent      *IdentifyEventParams      `json:"identifyEvent,omitempty"`
-	ContextBuild       *ContextBuildParams       `json:"contextBuild,omitempty"`
-	ContextConvert     *ContextConvertParams     `json:"contextConvert,omitempty"`
-	SecureModeHash     *SecureModeHashParams     `json:"secureModeHash,omitempty"`
-	MigrationVariation *MigrationVariationParams `json:"migrationVariation,omitempty"`
-	MigrationOperation *MigrationOperationParams `json:"migrationOperation,omitempty"`
+	Command                         string                                  `json:"command"`
+	Evaluate                        *EvaluateFlagParams                     `json:"evaluate,omitempty"`
+	EvaluateAll                     *EvaluateAllFlagsParams                 `json:"evaluateAll,omitempty"`
+	CustomEvent                     *CustomEventParams                      `json:"customEvent,omitempty"`
+	IdentifyEvent                   *IdentifyEventParams                    `json:"identifyEvent,omitempty"`
+	ContextBuild                    *ContextBuildParams                     `json:"contextBuild,omitempty"`
+	ContextConvert                  *ContextConvertParams                   `json:"contextConvert,omitempty"`
+	SecureModeHash                  *SecureModeHashParams                   `json:"secureModeHash,omitempty"`
+	MigrationVariation              *MigrationVariationParams               `json:"migrationVariation,omitempty"`
+	MigrationOperation              *MigrationOperationParams               `json:"migrationOperation,omitempty"`
+	RegisterFlagChangeListener      *RegisterFlagChangeListenerParams       `json:"registerFlagChangeListener,omitempty"`      //nolint:lll
+	RegisterFlagValueChangeListener *RegisterFlagValueChangeListenerParams  `json:"registerFlagValueChangeListener,omitempty"` //nolint:lll
+	UnregisterListener              *UnregisterListenerParams               `json:"unregisterListener,omitempty"`
 }
 
 type EvaluateFlagParams struct {
@@ -180,5 +186,40 @@ type HookExecutionEvaluationPayload struct {
 
 type HookExecutionTrackPayload struct {
 	TrackSeriesContext TrackSeriesContext `json:"trackSeriesContext,omitempty"`
-	Stage              HookStage          `json:"stage,omitempty"`
+	Stage              HookStage         `json:"stage,omitempty"`
+}
+
+// RegisterFlagChangeListenerParams defines parameters for registering a general flag change listener.
+// FlagKey may be empty to listen for changes to any flag, or non-empty to filter to a specific flag.
+type RegisterFlagChangeListenerParams struct {
+	ListenerID  string `json:"listenerId"`
+	FlagKey     string `json:"flagKey"`
+	CallbackURI string `json:"callbackUri"`
+}
+
+// RegisterFlagValueChangeListenerParams defines parameters for registering a flag value change listener.
+// The listener fires when the evaluated value of FlagKey changes for the given Context.
+type RegisterFlagValueChangeListenerParams struct {
+	ListenerID   string            `json:"listenerId"`
+	FlagKey      string            `json:"flagKey"`
+	Context      ldcontext.Context `json:"context"`
+	DefaultValue ldvalue.Value     `json:"defaultValue"`
+	CallbackURI  string            `json:"callbackUri"`
+}
+
+// UnregisterListenerParams defines parameters for unregistering a previously registered listener.
+// Works for both flag change and flag value change listeners.
+type UnregisterListenerParams struct {
+	ListenerID string `json:"listenerId"`
+}
+
+// ListenerNotification is the JSON payload POSTed by the test service to a callback URI when a
+// listener fires. OldValue and NewValue are only present for value-change notifications
+// (registerFlagValueChangeListener); they are nil for general flag-change notifications
+// (registerFlagChangeListener).
+type ListenerNotification struct {
+	ListenerID string         `json:"listenerId"`
+	FlagKey    string         `json:"flagKey"`
+	OldValue   *ldvalue.Value `json:"oldValue,omitempty"`
+	NewValue   *ldvalue.Value `json:"newValue,omitempty"`
 }

--- a/testservice/servicedef/command_params.go
+++ b/testservice/servicedef/command_params.go
@@ -190,10 +190,9 @@ type HookExecutionTrackPayload struct {
 }
 
 // RegisterFlagChangeListenerParams defines parameters for registering a general flag change listener.
-// FlagKey may be empty to listen for changes to any flag, or non-empty to filter to a specific flag.
+// The listener will be notified whenever any flag's configuration changes.
 type RegisterFlagChangeListenerParams struct {
 	ListenerID  string `json:"listenerId"`
-	FlagKey     string `json:"flagKey"`
 	CallbackURI string `json:"callbackUri"`
 }
 

--- a/testservice/servicedef/service_params.go
+++ b/testservice/servicedef/service_params.go
@@ -29,6 +29,7 @@ const (
 	CapabilityPersistentDataStoreRedis    = "persistent-data-store-redis"
 	CapabilityPersistentDataStoreConsul   = "persistent-data-store-consul"
 	CapabilityPersistentDataStoreDynamoDB = "persistent-data-store-dynamodb"
+	CapabilityFlagChangeListeners         = "flag-change-listeners"
 )
 
 type StatusRep struct {

--- a/testservice/servicedef/service_params.go
+++ b/testservice/servicedef/service_params.go
@@ -30,6 +30,7 @@ const (
 	CapabilityPersistentDataStoreConsul   = "persistent-data-store-consul"
 	CapabilityPersistentDataStoreDynamoDB = "persistent-data-store-dynamodb"
 	CapabilityFlagChangeListeners         = "flag-change-listeners"
+	CapabilityFlagValueChangeListeners    = "flag-value-change-listeners"
 )
 
 type StatusRep struct {


### PR DESCRIPTION
This pull request is part of a larger set of PRs that implement Flag Change Listener tests for server SDKs. Here's the list of pull requests that I currently have open:
* [[sdk-test-harness] feat: Add test harness support for flag change listeners in Server SDKs](https://github.com/launchdarkly/sdk-test-harness/pull/317)
* **[go-server-sdk] feat(contract-tests): Implement flag change listener tests in the Go server SDK <-- This PR**
* [[js-core] feat(contract-tests): Implement flag change listener tests in the Node server SDK](https://github.com/launchdarkly/js-core/pull/1120)

---

## Summary

Implements test service support for the new **flag change listener** contract tests defined in [sdk-test-harness#317](https://github.com/launchdarkly/sdk-test-harness/pull/317). No changes to the SDK itself — only the test service (`testservice/`) is modified.

For context on how the test harness drives these tests and what the full test matrix covers, see the [sdk-test-harness PR description](https://github.com/launchdarkly/sdk-test-harness/pull/317).

### What this PR does

**Adds type definitions** (`testservice/servicedef/`) for the three new commands and the `ListenerNotification` callback payload, plus the `flag-change-listeners` capability constant.

**Implements a `listenerRegistry`** (`testservice/flag_change_listener.go`) that manages all active listener subscriptions for an SDK client entity. Each registration spawns a goroutine that consumes events from the Go SDK's `FlagTracker` channel and POSTs a `ListenerNotification` JSON payload to the callback URI provided by the test harness. The registry handles:

- **General flag change listeners** — subscribes via `FlagTracker.AddFlagChangeListener()`, with optional key filtering when the test registers for a specific flag
- **Flag value change listeners** — subscribes via `FlagTracker.AddFlagValueChangeListener()`, which handles context-specific evaluation and old/new value tracking internally
- **Unregistration** — cancels the listener goroutine via context cancellation and removes the SDK subscription
- **Cleanup** — `closeAll()` is called when the SDK client entity shuts down, ensuring no orphaned goroutines

**Advertises the capability** by adding `flag-change-listeners` to the test service's capabilities list. All 8 contract tests pass.

---

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/v5/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new goroutine-based listener registrations that POST callbacks on flag updates; main risk is concurrency/lifecycle management causing leaks or flaky test behavior if listeners aren’t cleaned up correctly.
> 
> **Overview**
> Adds contract-test support for **flag change listeners** in the Go `testservice` by introducing new service commands to register/unregister listeners and a callback payload (`ListenerNotification`).
> 
> Implements a per-client `listenerRegistry` that subscribes to the SDK `FlagTracker` for either *any flag config change* or *value changes for a specific flag+context*, forwards events to the harness via HTTP POST, and ensures listeners are cancelled on `unregister` and when the client entity closes. The service now advertises `flag-change-listeners` and `flag-value-change-listeners` capabilities.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbb3c5387933af2422130caf1d7a1ed49ac7ab6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->