### PR TITLE
chore: Update the version of golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,7 @@
+version: "2"
+
 run:
-  deadline: 120s
+  timeout: 120s
   tests: false
 
 linters:
@@ -10,14 +12,10 @@ linters:
     - goconst
     - gochecknoglobals
     - gochecknoinits
-    - goconst
     - gocritic
     - gocyclo
     - godox
-    - gofmt
-    - goimports
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - lll
@@ -27,25 +25,28 @@ linters:
     - prealloc
     - revive
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unparam
     - unused
     - whitespace
-  fast: false
+  settings:
+    revive:
+      rules:
+        - name: exported
+          arguments:
+            - disableStutteringCheck
 
-linters-settings:
-  gofmt:
-    simplify: false
-  goimports:
-    local-prefixes: gopkg.in/launchdarkly,github.com/launchdarkly
-  revive:
-    rules:
-      - name: exported
-        arguments:
-          - disableStutteringCheck
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: false
+    goimports:
+      local-prefixes:
+        - gopkg.in/launchdarkly
+        - github.com/launchdarkly
 
 issues:
-  exclude-use-default: false
   max-same-issues: 1000

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GOLANGCI_LINT_VERSION=v1.64.5
+GOLANGCI_LINT_VERSION=v2.9.0
 
 LINTER=./bin/golangci-lint
 LINTER_VERSION_FILE=./bin/.golangci-lint-version-$(GOLANGCI_LINT_VERSION)

--- a/interfaces/flagstate/flags_state.go
+++ b/interfaces/flagstate/flags_state.go
@@ -203,7 +203,7 @@ func (b *AllFlagsBuilder) AddFlag(flagKey string, flag FlagState) *AllFlagsBuild
 	// include them or 2. they must be included because of experimentation
 	if b.options.detailsOnlyIfTracked {
 		if !flag.TrackEvents && !flag.TrackReason &&
-			!(flag.DebugEventsUntilDate != 0 && flag.DebugEventsUntilDate > ldtime.UnixMillisNow()) {
+			(flag.DebugEventsUntilDate == 0 || flag.DebugEventsUntilDate <= ldtime.UnixMillisNow()) {
 			flag.OmitDetails = true
 		}
 	}

--- a/internal/datasystem/fdv1_datasystem.go
+++ b/internal/datasystem/fdv1_datasystem.go
@@ -90,7 +90,7 @@ func createDataSource(
 		factory = ldcomponents.StreamingDataSource()
 	}
 	contextCopy := *context
-	contextCopy.BasicClientContext.DataSourceUpdateSink = dataSourceUpdateSink
+	contextCopy.DataSourceUpdateSink = dataSourceUpdateSink
 	return factory.Build(&contextCopy)
 }
 


### PR DESCRIPTION
We recently updated this repository and introduced a build for go 1.26. Unfortunately, the version of the go linter we were using didn't support go 1.26. This was found when another development branch failed to build during CI.

In the 1st commit, the version of golangci-lint has been updated to the version that supports go 1.26. This required a version upgrade of the linter from v1 to v2. Some breaking changes occurred when v2 was introduced, so the 1st commit also updates the linter's configuration file to be compatible with v2.

This table summarizes the differences between 1 and v2 of the linter that required changes in the `.golangci.yml` configuration file:

Issue | v1 (current) | v2 (required)
-- | -- | --
Version declaration | _(missing)_ | version: "2" required at top
Timeout | run.deadline: 120s | run.timeout: 120s
Fast option | linters.fast: false | Removed in v2
Duplicate entry | goconst listed twice | Remove duplicate
Formatters | gofmt, goimports in linters.enable | Move to formatters.enable
Merged linters | gosimple, stylecheck in linters.enable | Removed — merged into staticcheck
Built-in linter | typecheck in linters.enable | Removed — always-on in v2, can't be explicitly enabled
Settings key | linters-settings: (top-level) | linters.settings: (nested under linters)
Formatter settings | linters-settings.gofmt, linters-settings.goimports | Move to formatters.settings
Default exclusions | issues.exclude-use-default: false | Removed — no-presets is already the v2 default

After updating the major version of golangci-lint, a couple new lint errors popped up. The 2nd commit fixes those issues.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/v5/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly build/lint tooling changes; the only runtime-impacting edits are small conditional/field assignment tweaks that are unlikely to affect behavior beyond edge cases.
> 
> **Overview**
> Upgrades `golangci-lint` from `v1.64.5` to `v2.9.0` and updates `.golangci.yml` for v2 (adds `version: "2"`, switches `deadline`→`timeout`, moves `gofmt`/`goimports` into `formatters`, and relocates linter settings under `linters.settings`).
> 
> Fixes new lint failures by tightening the `AllFlagsBuilder.AddFlag` condition for omitting details based on `DebugEventsUntilDate`, and by updating `createDataSource` to assign `DataSourceUpdateSink` on the copied context via the new field rather than `BasicClientContext`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da3143b64f6b1032984d11b85096594f9e191664. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->