### PR TITLE
test: Fix flaky end-to-end tests

### DIFF
--- a/ldclient_end_to_end_fdv2_test.go
+++ b/ldclient_end_to_end_fdv2_test.go
@@ -64,7 +64,8 @@ func TestFDV2DefaultIsTwoPhaseInit(t *testing.T) {
 		require.NoError(t, err)
 		defer client.Close()
 
-		assert.Equal(t, string(interfaces.DataSourceStateValid), string(client.GetDataSourceStatusProvider().GetStatus().State))
+		reached := client.GetDataSourceStatusProvider().WaitFor(interfaces.DataSourceStateValid, time.Second*5)
+		require.True(t, reached, "timed out waiting for data source to reach VALID state")
 
 		value, _ := client.BoolVariation(alwaysTrueFlag.Key, testUser, false)
 		assert.True(t, value)
@@ -104,7 +105,8 @@ func TestFDV2CanFallBackToV1(t *testing.T) {
 		require.NoError(t, err)
 		defer client.Close()
 
-		assert.Equal(t, string(interfaces.DataSourceStateValid), string(client.GetDataSourceStatusProvider().GetStatus().State))
+		reached := client.GetDataSourceStatusProvider().WaitFor(interfaces.DataSourceStateValid, time.Second*5)
+		require.True(t, reached, "timed out waiting for data source to reach VALID state")
 
 		assertNoMoreRequests(t, pollV2SyncReqCh)
 		assertNoMoreRequests(t, streamV2SyncReqCh)
@@ -144,7 +146,8 @@ func TestFDV2StreamingSynchronizer(t *testing.T) {
 		require.NoError(t, err)
 		defer client.Close()
 
-		assert.Equal(t, string(interfaces.DataSourceStateValid), string(client.GetDataSourceStatusProvider().GetStatus().State))
+		reached := client.GetDataSourceStatusProvider().WaitFor(interfaces.DataSourceStateValid, time.Second*5)
+		require.True(t, reached, "timed out waiting for data source to reach VALID state")
 
 		value, _ := client.BoolVariation(alwaysTrueFlag.Key, testUser, false)
 		assert.True(t, value)
@@ -238,7 +241,8 @@ func TestFDV2StreamingSynchronizeReconnectsWithNonFatalError(t *testing.T) {
 		require.NoError(t, err)
 		defer client.Close()
 
-		assert.Equal(t, string(interfaces.DataSourceStateValid), string(client.GetDataSourceStatusProvider().GetStatus().State))
+		reached := client.GetDataSourceStatusProvider().WaitFor(interfaces.DataSourceStateValid, time.Second*5)
+		require.True(t, reached, "timed out waiting for data source to reach VALID state")
 
 		value, _ := client.BoolVariation(alwaysTrueFlag.Key, testUser, false)
 		assert.True(t, value)
@@ -402,7 +406,8 @@ func TestFDV2FileInitializerWillDeferToFirstSynchronizer(t *testing.T) {
 			require.NoError(t, err)
 			defer client.Close()
 
-			assert.Equal(t, string(interfaces.DataSourceStateValid), string(client.GetDataSourceStatusProvider().GetStatus().State))
+			reached := client.GetDataSourceStatusProvider().WaitFor(interfaces.DataSourceStateValid, time.Second*5)
+			require.True(t, reached, "timed out waiting for data source to reach VALID state")
 
 			value, _ := client.BoolVariation(alwaysTrueFlag.Key, testUser, false)
 			assert.True(t, value)


### PR DESCRIPTION
While working with the Go server SDK, I noticed that some tests were intermittently failing in CI. These tests were unrelated to the changes that I was making. After digging into the failures, I found that the failing tests were asserting that an LDClient object was in the "VALID" state immedaitely after initializing the object. In CI, the state was being reported as "INITIALIZING". When I simply re-ran the tests in the CI system, the tests passed.

This commit updates tests cases in the end-to-end tests to wait for the LDClient to reach the "VALID" state. I've used the WaitFor() method that's built into the client. The test times out if the client hasn't reached the expected state within 5 seconds.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/v5/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adds bounded waits to avoid timing-related flakes; no production logic is modified.
> 
> **Overview**
> Updates several FDv2 end-to-end tests to **wait for initialization to complete** instead of asserting the data source is immediately `VALID` after client creation.
> 
> Each affected test now calls `client.GetDataSourceStatusProvider().WaitFor(interfaces.DataSourceStateValid, 5s)` and fails with a clear timeout message if the state never becomes `VALID`, reducing intermittent CI failures due to startup timing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecedbd6462b71229f016722ee189a5d3e2d92e3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->