### PR TITLE
chore: Share development status in README

### DIFF
--- a/ldai/README.md
+++ b/ldai/README.md
@@ -1,6 +1,8 @@
 LaunchDarkly Server-side AI SDK for Go
 ==============================================
 
+[![Actions Status](https://github.com/launchdarkly/go-server-sdk/actions/workflows/ldai-ci.yml/badge.svg?branch=v7)](https://github.com/launchdarkly/go-server-sdk/actions/workflows/ldai-ci.yml)
+
 > [!CAUTION]
 > This AI SDK is in pre-release and not subject to backwards compatibility guarantees. The API may change based on feedback.
 >
@@ -11,8 +13,6 @@ LaunchDarkly Server-side AI SDK for Go
 [changelog]: https://github.com/launchdarkly/go-server-sdk/blob/v7/ldai/CHANGELOG.md
 [python-ai-sdk]: https://github.com/launchdarkly/python-server-sdk-ai/tree/main/packages/sdk/server-ai
 [node-ai-sdk]: https://github.com/launchdarkly/js-core/tree/main/packages/sdk/server-ai
-
-[![Actions Status](https://github.com/launchdarkly/go-server-sdk/actions/workflows/ldai-ci.yml/badge.svg?branch=v7)](https://github.com/launchdarkly/go-server-sdk/actions/workflows/ldai-ci.yml)
 
 LaunchDarkly overview
 -------------------------

--- a/ldai/README.md
+++ b/ldai/README.md
@@ -1,10 +1,16 @@
 LaunchDarkly Server-side AI SDK for Go
 ==============================================
 
-# ⛔️⛔️⛔️⛔️
 > [!CAUTION]
-> This library is a alpha version and should not be considered ready for production use while this message is visible.
-# ☝️☝️☝️☝️☝️☝️
+> This AI SDK is in pre-release and not subject to backwards compatibility guarantees. The API may change based on feedback.
+>
+> Pin to a specific minor version and review the [changelog] before upgrading.
+>
+> Active feature development is ongoing in the [Python][python-ai-sdk] and [Node.js][node-ai-sdk] AI SDKs, so this SDK will receive new features at a slower pace. Refer to those for the latest capabilities.
+
+[changelog]: https://github.com/launchdarkly/go-server-sdk/blob/v7/ldai/CHANGELOG.md
+[python-ai-sdk]: https://github.com/launchdarkly/python-server-sdk-ai/tree/main/packages/sdk/server-ai
+[node-ai-sdk]: https://github.com/launchdarkly/js-core/tree/main/packages/sdk/server-ai
 
 [![Actions Status](https://github.com/launchdarkly/go-server-sdk/actions/workflows/ldai-ci.yml/badge.svg?branch=v7)](https://github.com/launchdarkly/go-server-sdk/actions/workflows/ldai-ci.yml)
 


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality — N/A, documentation-only change
- [x] I have followed the repository's [pull request submission guidelines](../blob/v5/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions — N/A, documentation-only change

**Related issues**

AIC-1658

**Describe the solution you've provided**

Replaces the placeholder alpha warning in `ldai/README.md` with a more informative pre-release caution block that:

- States the SDK is pre-release and not subject to backwards compatibility guarantees
- Advises pinning to a specific minor version and reviewing the changelog before upgrading
- Notes that active feature development is ongoing in the Python and Node.js AI SDKs

The CI badge is positioned above the caution block for visibility. Reference-style links are used for the [changelog](https://github.com/launchdarkly/go-server-sdk/blob/v7/ldai/CHANGELOG.md), [Python AI SDK](https://github.com/launchdarkly/python-server-sdk-ai/tree/main/packages/sdk/server-ai), and [Node.js AI SDK](https://github.com/launchdarkly/js-core/tree/main/packages/sdk/server-ai).

**Human review checklist**

- [ ] Verify the changelog link (`/blob/v7/ldai/CHANGELOG.md`) resolves correctly on the `v7` branch
- [ ] Confirm the `> [!CAUTION]` block renders as expected on GitHub
- [ ] Confirm the reference-style links (`[changelog]`, `[python-ai-sdk]`, `[node-ai-sdk]`) resolve correctly outside the blockquote

**Describe alternatives you've considered**

N/A — this aligns the Go SDK's caution statement with the standardized wording being applied across LaunchDarkly AI SDKs.

**Additional context**

- Link to Devin run: https://app.devin.ai/sessions/71dd85303c70444ba2ae311e00a4c98c
- Requested by: @jsonbailey

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no impact on runtime behavior; main risk is incorrect links or GitHub markdown rendering.
> 
> **Overview**
> Updates `ldai/README.md` to replace the placeholder alpha warning with a more explicit *pre-release* caution block, including guidance to pin minor versions and review the `CHANGELOG` before upgrading.
> 
> Also adds reference links to the Go AI SDK changelog and to the Python/Node AI SDKs, and repositions the CI badge above the caution notice for visibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77b4dd40151163a32b30de3773fbeb38af88e034. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->