### PR TITLE
fix: Improve usage reporting

### DIFF
--- a/ldai/client.go
+++ b/ldai/client.go
@@ -224,7 +224,8 @@ func interpolateTemplate(template string, variables map[string]interface{}) (str
 	return m.RenderString(variables)
 }
 
-// JudgeConfig evaluates an AI Config, tracking it as a judge function. See CompletionConfig for details.
+// JudgeConfig retrieves and processes a Judge AI Config based on the provided key, LaunchDarkly context, and
+// variables. This includes the model configuration and the customized messages for evaluation.
 //
 // This method extends the provided variables with reserved judge variables:
 // - "message_history": "{{message_history}}"
@@ -232,6 +233,8 @@ func interpolateTemplate(template string, variables map[string]interface{}) (str
 //
 // These literal placeholder strings preserve the Mustache templates through the first interpolation
 // (during config fetch), allowing Judge.Evaluate() to perform a second interpolation with actual values.
+//
+// To send analytic events to LaunchDarkly related to the AI Config, call methods on the returned Tracker.
 func (c *Client) JudgeConfig(
 	key string,
 	context ldcontext.Context,

--- a/ldai/client.go
+++ b/ldai/client.go
@@ -79,7 +79,8 @@ func (c *Client) logConfigWarning(key string, format string, args ...interface{}
 	c.logger.Warnf(prefix+format, args...)
 }
 
-// CompletionConfig evaluates an AI Completion Config named by a given key for the given context.
+// CompletionConfig retrieves and processes a Completion AI Config based on the provided key, LaunchDarkly context,
+// and variables. This includes the model configuration and the customized messages.
 //
 // The config's messages will undergo Mustache template interpolation using the provided variables, which may be
 // nil. If the config cannot be evaluated or LaunchDarkly is unreachable, the default value is returned. Note that

--- a/ldai/client.go
+++ b/ldai/client.go
@@ -40,16 +40,43 @@ type Client struct {
 	logger interfaces.LDLoggers
 }
 
+const (
+	// usageCompletionConfig is the event key for completion config usage tracking.
+	usageCompletionConfig = "$ld:ai:usage:completion-config"
+	// usageJudgeConfig is the event key for judge config usage tracking.
+	usageJudgeConfig = "$ld:ai:usage:judge-config"
+	// sdkInfoEvent is the event key for SDK info tracking.
+	sdkInfoEvent = "$ld:ai:sdk:info"
+)
+
 // NewClient creates a new AI Client. The provided SDK interface must not be nil. The client will use the provided SDK's
 // loggers to log warnings and errors.
+//
+// Upon construction, the client fires a single $ld:ai:sdk:info tracking event containing SDK metadata.
 func NewClient(sdk ServerSDK) (*Client, error) {
 	if sdk == nil {
 		return nil, fmt.Errorf("sdk must not be nil")
 	}
-	return &Client{
+	c := &Client{
 		sdk:    sdk,
 		logger: sdk.Loggers(),
-	}, nil
+	}
+	c.trackSDKInfo()
+	return c, nil
+}
+
+func (c *Client) trackSDKInfo() {
+	ctx, err := ldcontext.NewBuilder("ld-internal-tracking").Kind("ld_ai").Anonymous(true).TryBuild()
+	if err != nil {
+		c.logger.Warnf("AI Client: failed to build SDK info context: %v", err)
+		return
+	}
+	data := ldvalue.ObjectBuild().
+		Set("aiSdkName", ldvalue.String("launchdarkly-go-server-sdk-ai")).
+		Set("aiSdkVersion", ldvalue.String(Version)).
+		Set("aiSdkLanguage", ldvalue.String("go")).
+		Build()
+	_ = c.sdk.TrackMetric(sdkInfoEvent, ctx, 1, data)
 }
 
 func (c *Client) logConfigWarning(key string, format string, args ...interface{}) {
@@ -57,21 +84,34 @@ func (c *Client) logConfigWarning(key string, format string, args ...interface{}
 	c.logger.Warnf(prefix+format, args...)
 }
 
-// Config evaluates an AI Config named by a given key for the given context.
+// CompletionConfig evaluates an AI Completion Config named by a given key for the given context.
 //
 // The config's messages will undergo Mustache template interpolation using the provided variables, which may be
 // nil. If the config cannot be evaluated or LaunchDarkly is unreachable, the default value is returned. Note that
 // the messages in the default will not undergo template interpolation.
 //
 // To send analytic events to LaunchDarkly related to the AI Config, call methods on the returned Tracker.
+func (c *Client) CompletionConfig(
+	key string,
+	context ldcontext.Context,
+	defaultValue Config,
+	variables map[string]interface{},
+) (Config, *Tracker) {
+	data := ldvalue.ObjectBuild().Set("configKey", ldvalue.String(key)).Build()
+	_ = c.sdk.TrackMetric(usageCompletionConfig, context, 1, data)
+	return c.evaluateConfig(key, context, defaultValue, variables)
+}
+
+// Config evaluates an AI Config named by a given key for the given context.
+//
+// Deprecated: Use CompletionConfig instead.
 func (c *Client) Config(
 	key string,
 	context ldcontext.Context,
 	defaultValue Config,
 	variables map[string]interface{},
 ) (Config, *Tracker) {
-	_ = c.sdk.TrackMetric("$ld:ai:config:function:single", context, 1, ldvalue.String(key))
-	return c.evaluateConfig(key, context, defaultValue, variables)
+	return c.CompletionConfig(key, context, defaultValue, variables)
 }
 
 // evaluateConfig fetches and interpolates an AI Config without emitting any metric.
@@ -189,7 +229,7 @@ func interpolateTemplate(template string, variables map[string]interface{}) (str
 	return m.RenderString(variables)
 }
 
-// JudgeConfig evaluates an AI Config, tracking it as a judge function. See Config for details.
+// JudgeConfig evaluates an AI Config, tracking it as a judge function. See CompletionConfig for details.
 //
 // This method extends the provided variables with reserved judge variables:
 // - "message_history": "{{message_history}}"
@@ -203,7 +243,8 @@ func (c *Client) JudgeConfig(
 	defaultValue Config,
 	variables map[string]interface{},
 ) (Config, *Tracker) {
-	_ = c.sdk.TrackMetric("$ld:ai:judge:function:single", context, 1, ldvalue.String(key))
+	data := ldvalue.ObjectBuild().Set("configKey", ldvalue.String(key)).Build()
+	_ = c.sdk.TrackMetric(usageJudgeConfig, context, 1, data)
 
 	// Extend variables with reserved judge placeholders
 	extendedVariables := make(map[string]interface{})

--- a/ldai/client.go
+++ b/ldai/client.go
@@ -41,18 +41,13 @@ type Client struct {
 }
 
 const (
-	// usageCompletionConfig is the event key for completion config usage tracking.
+	sdkInfoEvent          = "$ld:ai:sdk:info"
 	usageCompletionConfig = "$ld:ai:usage:completion-config"
-	// usageJudgeConfig is the event key for judge config usage tracking.
-	usageJudgeConfig = "$ld:ai:usage:judge-config"
-	// sdkInfoEvent is the event key for SDK info tracking.
-	sdkInfoEvent = "$ld:ai:sdk:info"
+	usageJudgeConfig      = "$ld:ai:usage:judge-config"
 )
 
 // NewClient creates a new AI Client. The provided SDK interface must not be nil. The client will use the provided SDK's
 // loggers to log warnings and errors.
-//
-// Upon construction, the client fires a single $ld:ai:sdk:info tracking event containing SDK metadata.
 func NewClient(sdk ServerSDK) (*Client, error) {
 	if sdk == nil {
 		return nil, fmt.Errorf("sdk must not be nil")

--- a/ldai/client.go
+++ b/ldai/client.go
@@ -67,9 +67,9 @@ func (c *Client) trackSDKInfo() {
 		return
 	}
 	data := ldvalue.ObjectBuild().
-		Set("aiSdkName", ldvalue.String("launchdarkly-go-server-sdk-ai")).
+		Set("aiSdkName", ldvalue.String(SDKName)).
 		Set("aiSdkVersion", ldvalue.String(Version)).
-		Set("aiSdkLanguage", ldvalue.String("go")).
+		Set("aiSdkLanguage", ldvalue.String(SDKLanguage)).
 		Build()
 	_ = c.sdk.TrackMetric(sdkInfoEvent, ctx, 1, data)
 }

--- a/ldai/client.go
+++ b/ldai/client.go
@@ -56,22 +56,23 @@ func NewClient(sdk ServerSDK) (*Client, error) {
 		sdk:    sdk,
 		logger: sdk.Loggers(),
 	}
-	c.trackSDKInfo()
+	if err := c.trackSDKInfo(); err != nil {
+		c.logger.Warnf("AI Client: failed to track SDK info: %v", err)
+	}
 	return c, nil
 }
 
-func (c *Client) trackSDKInfo() {
+func (c *Client) trackSDKInfo() error {
 	ctx, err := ldcontext.NewBuilder("ld-internal-tracking").Kind("ld_ai").Anonymous(true).TryBuild()
 	if err != nil {
-		c.logger.Warnf("AI Client: failed to build SDK info context: %v", err)
-		return
+		return err
 	}
 	data := ldvalue.ObjectBuild().
 		Set("aiSdkName", ldvalue.String(SDKName)).
 		Set("aiSdkVersion", ldvalue.String(Version)).
 		Set("aiSdkLanguage", ldvalue.String(SDKLanguage)).
 		Build()
-	_ = c.sdk.TrackMetric(sdkInfoEvent, ctx, 1, data)
+	return c.sdk.TrackMetric(sdkInfoEvent, ctx, 1, data)
 }
 
 func (c *Client) logConfigWarning(key string, format string, args ...interface{}) {

--- a/ldai/client_test.go
+++ b/ldai/client_test.go
@@ -67,9 +67,24 @@ func TestNewClientReturnsErrorWhenSDKIsNil(t *testing.T) {
 }
 
 func TestNewClient(t *testing.T) {
-	client, err := NewClient(newMockSDK(nil, nil))
+	mockSDK := newMockSDK(nil, nil)
+	client, err := NewClient(mockSDK)
 	require.NoError(t, err)
 	require.NotNil(t, client)
+
+	// Verify SDK info event was fired on construction.
+	require.Len(t, mockSDK.events, 1)
+	evt := mockSDK.events[0]
+	assert.Equal(t, "$ld:ai:sdk:info", evt.eventName)
+	assert.Equal(t, float64(1), evt.metricValue)
+	assert.Equal(t, "launchdarkly-go-server-sdk-ai", evt.data.GetByKey("aiSdkName").StringValue())
+	assert.Equal(t, Version, evt.data.GetByKey("aiSdkVersion").StringValue())
+	assert.Equal(t, "go", evt.data.GetByKey("aiSdkLanguage").StringValue())
+
+	// Verify the context is anonymous with kind ld_ai.
+	assert.Equal(t, "ld-internal-tracking", evt.context.Key())
+	assert.True(t, evt.context.Anonymous())
+	assert.Equal(t, ldcontext.Kind("ld_ai"), evt.context.Kind())
 }
 
 func TestEvalErrorReturnsDefault(t *testing.T) {
@@ -302,11 +317,47 @@ func TestCanSetDefaultConfigFields(t *testing.T) {
 	assert.Equal(t, datamodel.System, msg[1].Role)
 }
 
-func TestConfigMethodTracking(t *testing.T) {
+func TestCompletionConfigMethodTracking(t *testing.T) {
 	mockSDK := newMockSDK(nil, nil)
 	client, err := NewClient(mockSDK)
 	require.NoError(t, err)
 	require.NotNil(t, client)
+
+	// Clear the SDK info event from construction.
+	mockSDK.events = nil
+
+	defaultConfig := NewConfig().WithEnabled(false).Build()
+	context := ldcontext.New("user-key")
+	configKey := "test-config-key"
+
+	config, tracker := client.CompletionConfig(configKey, context, defaultConfig, nil)
+
+	require.NotNil(t, config)
+	require.NotNil(t, tracker)
+
+	expectedData := ldvalue.ObjectBuild().Set("configKey", ldvalue.String(configKey)).Build()
+	expectedEvents := []mockEvent{
+		{
+			eventName:   "$ld:ai:usage:completion-config",
+			context:     context,
+			metricValue: 1,
+			data:        expectedData,
+		},
+	}
+
+	assert.ElementsMatch(t, expectedEvents, mockSDK.events)
+}
+
+// TestDeprecatedConfigDelegatesToCompletionConfig verifies the deprecated Config method delegates
+// to CompletionConfig and emits the same usage event.
+func TestDeprecatedConfigDelegatesToCompletionConfig(t *testing.T) {
+	mockSDK := newMockSDK(nil, nil)
+	client, err := NewClient(mockSDK)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	// Clear the SDK info event from construction.
+	mockSDK.events = nil
 
 	defaultConfig := NewConfig().WithEnabled(false).Build()
 	context := ldcontext.New("user-key")
@@ -317,12 +368,13 @@ func TestConfigMethodTracking(t *testing.T) {
 	require.NotNil(t, config)
 	require.NotNil(t, tracker)
 
+	expectedData := ldvalue.ObjectBuild().Set("configKey", ldvalue.String(configKey)).Build()
 	expectedEvents := []mockEvent{
 		{
-			eventName:   "$ld:ai:config:function:single",
+			eventName:   "$ld:ai:usage:completion-config",
 			context:     context,
 			metricValue: 1,
-			data:        ldvalue.String(configKey),
+			data:        expectedData,
 		},
 	}
 
@@ -330,7 +382,7 @@ func TestConfigMethodTracking(t *testing.T) {
 }
 
 // TestJudgeConfigMethodTracking verifies that JudgeConfig emits only the judge metric,
-// not the config metric, so judge evaluations are not double-counted on the dashboard.
+// not the completion-config metric, so judge evaluations are not double-counted on the dashboard.
 func TestJudgeConfigMethodTracking(t *testing.T) {
 	json := []byte(`{
 		"_ldMeta": {"variationKey": "1", "enabled": true},
@@ -343,6 +395,9 @@ func TestJudgeConfigMethodTracking(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, client)
 
+	// Clear the SDK info event from construction.
+	mockSDK.events = nil
+
 	defaultConfig := Disabled()
 	context := ldcontext.New("user-key")
 	configKey := "judge-config-key"
@@ -353,16 +408,17 @@ func TestJudgeConfigMethodTracking(t *testing.T) {
 	require.NotNil(t, tracker)
 
 	// Only the judge metric should be emitted; evaluateConfig does not emit any metric.
+	expectedData := ldvalue.ObjectBuild().Set("configKey", ldvalue.String(configKey)).Build()
 	expectedEvents := []mockEvent{
 		{
-			eventName:   "$ld:ai:judge:function:single",
+			eventName:   "$ld:ai:usage:judge-config",
 			context:     context,
 			metricValue: 1,
-			data:        ldvalue.String(configKey),
+			data:        expectedData,
 		},
 	}
 	assert.ElementsMatch(t, expectedEvents, mockSDK.events,
-		"JudgeConfig must not emit $ld:ai:config:function:single to avoid double-counting")
+		"JudgeConfig must not emit $ld:ai:usage:completion-config to avoid double-counting")
 }
 
 func TestCanSetModelParameters(t *testing.T) {

--- a/ldai/package_info.go
+++ b/ldai/package_info.go
@@ -1,5 +1,13 @@
 // Package ldai contains an AI SDK suitable for usage with generative AI applications.
 package ldai
 
-// Version is the current version string of the ldai package. This is updated by our release scripts.
-const Version = "0.8.0" // {{ x-release-please-version }}
+const (
+	// Version is the current version string of the ldai package. This is updated by our release scripts.
+	Version = "0.8.0" // {{ x-release-please-version }}
+
+	// SDKName is the canonical name of this AI SDK package.
+	SDKName = "launchdarkly-go-server-sdk-ai"
+
+	// SDKLanguage is the programming language of this AI SDK.
+	SDKLanguage = "go"
+)


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/v7/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

- Implements [AIC-1636](https://launchdarkly.atlassian.net/browse/AIC-1636)
- Spec: https://github.com/launchdarkly/sdk-specs/pull/132 and https://github.com/launchdarkly/sdk-specs/pull/135
- JS reference: https://github.com/launchdarkly/js-core/pull/1108
- Python reference: https://github.com/launchdarkly/python-server-sdk-ai/pull/92
- .NET reference: https://github.com/launchdarkly/dotnet-core/pull/228

**Describe the solution you've provided**

Updates the Go AI SDK's usage tracking to align with the updated spec. Four categories of changes:

1. **Renamed usage tracking event keys** to the unified `$ld:ai:usage:*` prefix:
   | Old Key | New Key |
   |---|---|
   | `$ld:ai:config:function:single` | `$ld:ai:usage:completion-config` |
   | `$ld:ai:judge:function:single` | `$ld:ai:usage:judge-config` |

2. **Added SDK info tracking on construction** (`$ld:ai:sdk:info`). `NewClient` now fires a one-time tracking event with `aiSdkName`, `aiSdkVersion`, and `aiSdkLanguage`, using an anonymous context (kind `ld_ai`, key `ld-internal-tracking`). SDK metadata constants (`SDKName`, `SDKLanguage`) are defined in `package_info.go` alongside `Version`.

3. **Renamed `Config` method to `CompletionConfig`**. The old `Config` method is preserved as a deprecated proxy to `CompletionConfig`.

4. **Changed usage tracking data format** from a plain string to an object containing `configKey`, consistent with the other SDK implementations.

Note: This SDK does not currently have agent config, createChat, or createJudge methods, so only the `completion-config` and `judge-config` usage event keys needed updating.

**Human review checklist**

- [ ] Verify event key strings exactly match the spec (`$ld:ai:sdk:info`, `$ld:ai:usage:completion-config`, `$ld:ai:usage:judge-config`)
- [ ] Verify the anonymous context (kind `ld_ai`, key `ld-internal-tracking`) matches spec requirement 1.2.2.1
- [ ] Confirm the SDK name `"launchdarkly-go-server-sdk-ai"` is correct for this package (now in `package_info.go`)
- [ ] Verify that SDK info tracking firing per `Client` instantiation (rather than once globally) aligns with spec intent
- [ ] Note: the deprecated `Config` method delegates to `CompletionConfig`, so it will also emit the `$ld:ai:usage:completion-config` tracking event — confirm this is desired behavior
- [ ] Confirm that exporting `SDKName` and `SDKLanguage` as public constants is acceptable for the package API surface

**Updates since last revision**

Addressed reviewer feedback:
- Alphabetized event key constants
- Removed unnecessary doc comment on `NewClient`
- Updated `CompletionConfig` and `JudgeConfig` doc comments with clearer descriptions
- Moved SDK name and language into `package_info.go` as exported constants (`SDKName`, `SDKLanguage`)

**Additional context**

- Link to Devin run: https://app.devin.ai/sessions/8eca2a61efec4ceb92a13c9e9d5969b9
- Requested by: @jsonbailey
- All tests pass locally
- CI note: `Windows, Go 1.24` failure is a pre-existing flaky test in `ldfilewatch` (unrelated to these changes); all `ldai` checks pass
 on all platforms

[AIC-1636]: https://launchdarkly.atlassian.net/browse/AIC-1636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes analytics/telemetry semantics (new event keys/payloads and a new constructor-time metric) and introduces a new public API (`CompletionConfig`) while deprecating `Config`, which may affect downstream expectations around tracking and call patterns.
> 
> **Overview**
> Updates the Go AI SDK’s metric reporting to match the latest spec by **renaming usage event keys** to the `$ld:ai:usage:*` namespace and changing the metric `data` payload from a raw string to an object containing `configKey`.
> 
> `NewClient` now emits a one-time `$ld:ai:sdk:info` metric on construction using an anonymous `ld_ai` context and SDK metadata (`SDKName`, `SDKLanguage`, `Version`).
> 
> Renames `Client.Config` usage to `CompletionConfig` (with `Config` kept as a deprecated delegating wrapper) and updates `JudgeConfig` tracking to the new judge usage event; tests are updated/added to assert the new events and payloads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d2ca436c933d12db5acffc440edd35fbe73a8f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/go-server-sdk/pull/353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
