### PR TITLE
chore: Update release process and change sdkname before release

### DIFF
--- a/ldai/client_test.go
+++ b/ldai/client_test.go
@@ -77,7 +77,7 @@ func TestNewClient(t *testing.T) {
 	evt := mockSDK.events[0]
 	assert.Equal(t, "$ld:ai:sdk:info", evt.eventName)
 	assert.Equal(t, float64(1), evt.metricValue)
-	assert.Equal(t, "launchdarkly-go-server-sdk-ai", evt.data.GetByKey("aiSdkName").StringValue())
+	assert.Equal(t, "go-server-sdk/ldai", evt.data.GetByKey("aiSdkName").StringValue())
 	assert.Equal(t, Version, evt.data.GetByKey("aiSdkVersion").StringValue())
 	assert.Equal(t, "go", evt.data.GetByKey("aiSdkLanguage").StringValue())
 

--- a/ldai/package_info.go
+++ b/ldai/package_info.go
@@ -6,7 +6,7 @@ const (
 	Version = "0.8.0" // {{ x-release-please-version }}
 
 	// SDKName is the canonical name of this AI SDK package.
-	SDKName = "launchdarkly-go-server-sdk-ai"
+	SDKName = "go-server-sdk/ldai"
 
 	// SDKLanguage is the programming language of this AI SDK.
 	SDKLanguage = "go"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,6 @@
       "bump-minor-pre-major" : true,
       "versioning" : "default",
       "include-component-in-tag" : false,
-      "bootstrap-sha" : "25fcfa1ba34928c6dc6d1ee29f4504b7614fa55c",
       "extra-files" : [
         "internal/version.go"
       ],

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -41,7 +41,6 @@
     "ldmiddleware" : {
       "package-name": "ldmiddleware",
       "release-type" : "go",
-      "release-as": "0.1.0",
       "tag-separator": "/",
       "versioning" : "default",
       "extra-files" : [


### PR DESCRIPTION
We cut the 0.1.0 release of the middleware so we can remove the release-as.
The bootstrap sha is also no longer needed.
The sdkname has not been release yet so we are making a minor fix as a chore.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to SDK identification metadata and release automation config, with only a test assertion updated to match the new name.
> 
> **Overview**
> Updates the `ldai` SDK identifier from `launchdarkly-go-server-sdk-ai` to `go-server-sdk/ldai` and adjusts the constructor tracking-event test to assert the new `aiSdkName` value.
> 
> Simplifies `release-please-config.json` by removing the root `bootstrap-sha` and dropping the forced `release-as` override for `ldmiddleware`, relying on standard versioning going forward.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 201799341964d47b33d05bf767bc9a1edb0efb92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->