### PR TITLE
fix: Prevent context attributes from influencing judge template parsing (SEC-8020)

### DIFF
--- a/ldai/client.go
+++ b/ldai/client.go
@@ -16,6 +16,9 @@ import (
 // Defines the Mustache variable name used to access the provided context.
 const ldContextVariable = "ldctx"
 
+// JudgePlaceholderMessageHistory and JudgePlaceholderResponseToEvaluate are the literal placeholder
+// strings shared between JudgeConfig (pass 1) and Judge.buildMessages (pass 2). Both must use the
+// same values or substitution silently fails.
 const (
 	JudgePlaceholderMessageHistory     = "{{message_history}}"
 	JudgePlaceholderResponseToEvaluate = "{{response_to_evaluate}}"
@@ -85,11 +88,11 @@ func (c *Client) logConfigWarning(key string, format string, args ...interface{}
 	c.logger.Warnf(prefix+format, args...)
 }
 
-// The config's messages will undergo Mustache template interpolation using the provided variables, which may be
-// nil. If the config cannot be evaluated or LaunchDarkly is unreachable, the default value is returned. Note that
-// the messages in the default will not undergo template interpolation.
+// CompletionConfig retrieves an AI Config and interpolates its message templates using the provided
+// variables. Returns the default value if the config cannot be evaluated. Template interpolation is
+// not applied to the default value's messages.
 //
-// To send analytic events to LaunchDarkly related to the AI Config, call methods on the returned Tracker.
+// To send analytic events to LaunchDarkly, call methods on the returned Tracker.
 func (c *Client) CompletionConfig(
 	key string,
 	context ldcontext.Context,
@@ -228,6 +231,11 @@ func interpolateTemplate(template string, variables map[string]interface{}) (str
 	return m.RenderString(variables)
 }
 
+// JudgeConfig retrieves a Judge AI Config and interpolates its message templates. The reserved
+// variables message_history and response_to_evaluate are preserved as literal placeholders for
+// substitution by Judge.buildMessages during evaluation.
+//
+// To send analytic events to LaunchDarkly, call methods on the returned Tracker.
 func (c *Client) JudgeConfig(
 	key string,
 	context ldcontext.Context,

--- a/ldai/client.go
+++ b/ldai/client.go
@@ -16,6 +16,11 @@ import (
 // Defines the Mustache variable name used to access the provided context.
 const ldContextVariable = "ldctx"
 
+const (
+	JudgePlaceholderMessageHistory     = "{{message_history}}"
+	JudgePlaceholderResponseToEvaluate = "{{response_to_evaluate}}"
+)
+
 // ServerSDK defines the required methods for the AI SDK to interact with LaunchDarkly. These methods are
 // satisfied by the LaunchDarkly Go Server SDK.
 type ServerSDK interface {
@@ -80,9 +85,6 @@ func (c *Client) logConfigWarning(key string, format string, args ...interface{}
 	c.logger.Warnf(prefix+format, args...)
 }
 
-// CompletionConfig retrieves and processes a Completion AI Config based on the provided key, LaunchDarkly context,
-// and variables. This includes the model configuration and the customized messages.
-//
 // The config's messages will undergo Mustache template interpolation using the provided variables, which may be
 // nil. If the config cannot be evaluated or LaunchDarkly is unreachable, the default value is returned. Note that
 // the messages in the default will not undergo template interpolation.
@@ -226,17 +228,6 @@ func interpolateTemplate(template string, variables map[string]interface{}) (str
 	return m.RenderString(variables)
 }
 
-// JudgeConfig retrieves and processes a Judge AI Config based on the provided key, LaunchDarkly context, and
-// variables. This includes the model configuration and the customized messages for evaluation.
-//
-// This method extends the provided variables with reserved judge variables:
-// - "message_history": "{{message_history}}"
-// - "response_to_evaluate": "{{response_to_evaluate}}"
-//
-// These literal placeholder strings preserve the Mustache templates through the first interpolation
-// (during config fetch), allowing Judge.Evaluate() to perform a second interpolation with actual values.
-//
-// To send analytic events to LaunchDarkly related to the AI Config, call methods on the returned Tracker.
 func (c *Client) JudgeConfig(
 	key string,
 	context ldcontext.Context,
@@ -259,8 +250,8 @@ func (c *Client) JudgeConfig(
 
 	// Inject reserved variables as literal placeholder strings
 	// These will be preserved through the first interpolation and resolved during Judge.Evaluate()
-	extendedVariables["message_history"] = "{{message_history}}"
-	extendedVariables["response_to_evaluate"] = "{{response_to_evaluate}}"
+	extendedVariables["message_history"] = JudgePlaceholderMessageHistory
+	extendedVariables["response_to_evaluate"] = JudgePlaceholderResponseToEvaluate
 
 	return c.evaluateConfig(key, context, defaultValue, extendedVariables)
 }

--- a/ldai/judge/judge.go
+++ b/ldai/judge/judge.go
@@ -5,7 +5,6 @@ import (
 	"math/rand"
 	"strings"
 
-	"github.com/alexkappa/mustache"
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 	"github.com/launchdarkly/go-server-sdk/ldai"
 	"github.com/launchdarkly/go-server-sdk/ldai/datamodel"
@@ -124,26 +123,20 @@ func (j *Judge) GetProvider() Provider {
 }
 
 func (j *Judge) buildMessages(input, output string) []datamodel.Message {
-	vars := map[string]interface{}{
-		"message_history":      input,
-		"response_to_evaluate": output,
-	}
+	// Use literal string replacement instead of a template engine to prevent
+	// template injection: attacker-controlled values from pass 1 (e.g. Mustache
+	// delimiter-change tags like {{=[ ]=}}) would otherwise be interpreted as
+	// control syntax by a second Mustache pass, blinding the judge.
+	replacer := strings.NewReplacer(
+		ldai.JudgePlaceholderMessageHistory, input,
+		ldai.JudgePlaceholderResponseToEvaluate, output,
+	)
 
 	messages := j.config.Messages()
 	result := make([]datamodel.Message, len(messages))
 
 	for i, msg := range messages {
-		m := mustache.New()
-		if err := m.ParseString(msg.Content); err != nil {
-			result[i] = datamodel.Message{Content: msg.Content, Role: msg.Role}
-			continue
-		}
-		content, err := m.RenderString(vars)
-		if err != nil {
-			result[i] = datamodel.Message{Content: msg.Content, Role: msg.Role}
-			continue
-		}
-		result[i] = datamodel.Message{Content: content, Role: msg.Role}
+		result[i] = datamodel.Message{Content: replacer.Replace(msg.Content), Role: msg.Role}
 	}
 
 	return result

--- a/ldai/judge/judge.go
+++ b/ldai/judge/judge.go
@@ -123,10 +123,8 @@ func (j *Judge) GetProvider() Provider {
 }
 
 func (j *Judge) buildMessages(input, output string) []datamodel.Message {
-	// Use literal string replacement instead of a template engine to prevent
-	// template injection: attacker-controlled values from pass 1 (e.g. Mustache
-	// delimiter-change tags like {{=[ ]=}}) would otherwise be interpreted as
-	// control syntax by a second Mustache pass, blinding the judge.
+	// Use string replacement to prevent context attributes like {{=[ ]=}}) from
+	// influencing judge template parsing.
 	replacer := strings.NewReplacer(
 		ldai.JudgePlaceholderMessageHistory, input,
 		ldai.JudgePlaceholderResponseToEvaluate, output,

--- a/ldai/judge/judge_test.go
+++ b/ldai/judge/judge_test.go
@@ -947,3 +947,110 @@ func indexOfForTest(s, substr string) int {
 	}
 	return -1
 }
+
+func newMinimalJudge(t *testing.T, content string) *Judge {
+	t.Helper()
+	config := &mockConfig{
+		evaluationMetricKey: "metric",
+		messages:            []datamodel.Message{{Role: datamodel.User, Content: content}},
+	}
+	j, err := New(config, &mockTracker{}, &mockProvider{
+		response: StructuredResponse{
+			Content: map[string]interface{}{
+				"evaluations": map[string]interface{}{
+					"metric": map[string]interface{}{"score": 1.0, "reasoning": "ok"},
+				},
+			},
+		},
+	}, "key", nil)
+	require.NoError(t, err)
+	return j
+}
+
+// TestBuildMessages_InjectionVariants is a regression test for HackerOne report #3591852.
+// It covers the full set of Mustache control sequences an attacker could inject via a
+// user-controlled context variable. All variants must be treated as inert literal text by
+// pass 2 — none should cause a placeholder to go unsubstituted.
+func TestBuildMessages_InjectionVariants(t *testing.T) {
+	variants := []struct {
+		name    string
+		payload string // injected via {{ldctx.user.name}} in the template
+	}{
+		{"delimiter change brackets", "{{=[ ]=}}"},
+		{"delimiter change angle", "{{=<% %>=}}"},
+		{"partial", "{{> evil}}"},
+		{"comment", "{{! drop everything }}"},
+		{"triple stache", "{{{raw}}}"},
+		{"section", "{{#section}}inject{{/section}}"},
+		{"inverted section", "{{^section}}inject{{/section}}"},
+	}
+
+	for _, tt := range variants {
+		t.Run(tt.name, func(t *testing.T) {
+			// Hand-craft the pass-1 output: user.name resolved to the attack payload,
+			// reserved placeholder survived as a literal string.
+			afterPass1 := "Auditing " + tt.payload + ": " + ldai.JudgePlaceholderMessageHistory
+
+			// Pass 2: judge substitutes placeholders
+			judge := newMinimalJudge(t, afterPass1)
+			actualHistory := "ACTUAL MESSAGE HISTORY"
+			messages := judge.buildMessages(actualHistory, "some output")
+
+			require.Len(t, messages, 1)
+			assert.Contains(t, messages[0].Content, actualHistory,
+				"payload %q must not blind the judge to the actual history", tt.payload)
+			assert.NotContains(t, messages[0].Content, ldai.JudgePlaceholderMessageHistory,
+				"placeholder must be fully substituted after payload %q", tt.payload)
+		})
+	}
+}
+
+// TestBuildMessages_InjectionViaResponse verifies that injection payloads in the response
+// being evaluated (not just the history) are equally neutralized.
+func TestBuildMessages_InjectionViaResponse(t *testing.T) {
+	// Pass-1 output: no user vars resolved, both placeholders survived as literal strings.
+	afterPass1 := "History: " + ldai.JudgePlaceholderMessageHistory +
+		"\nResponse: " + ldai.JudgePlaceholderResponseToEvaluate
+
+	judge := newMinimalJudge(t, afterPass1)
+	maliciousResponse := "{{=[ ]=}} INJECTION ATTEMPT"
+	messages := judge.buildMessages("normal history", maliciousResponse)
+
+	require.Len(t, messages, 1)
+	assert.Contains(t, messages[0].Content, maliciousResponse,
+		"malicious content in response must appear verbatim — not silently dropped")
+	assert.NotContains(t, messages[0].Content, ldai.JudgePlaceholderResponseToEvaluate,
+		"response placeholder must be fully substituted")
+}
+
+// TestBuildMessages_MultiplePlaceholderOccurrences verifies that when a template contains
+// the same placeholder more than once, every occurrence is substituted.
+func TestBuildMessages_MultiplePlaceholderOccurrences(t *testing.T) {
+	template := ldai.JudgePlaceholderMessageHistory + " | " + ldai.JudgePlaceholderMessageHistory
+	judge := newMinimalJudge(t, template)
+	messages := judge.buildMessages("HISTORY", "RESPONSE")
+
+	require.Len(t, messages, 1)
+	assert.Equal(t, "HISTORY | HISTORY", messages[0].Content)
+}
+
+// TestBuildMessages_MustacheSyntaxInContent verifies that Mustache-like syntax inside the
+// actual history or response values is treated as literal text and not silently consumed.
+// The old Mustache-based pass 2 would have rendered unrecognized tags (e.g. {{user}}) as
+// empty strings, corrupting content such as code samples or questions about templating.
+func TestBuildMessages_MustacheSyntaxInContent(t *testing.T) {
+	template := "History: " + ldai.JudgePlaceholderMessageHistory +
+		"\nResponse: " + ldai.JudgePlaceholderResponseToEvaluate
+	judge := newMinimalJudge(t, template)
+
+	historyWithMustache := "How do I use {{user}} in Mustache?"
+	responseWithMustache := "Use {{user}} like this: {{#user}}Hello{{/user}}"
+
+	messages := judge.buildMessages(historyWithMustache, responseWithMustache)
+
+	require.Len(t, messages, 1)
+	assert.Contains(t, messages[0].Content, historyWithMustache,
+		"Mustache-like syntax in history must be preserved verbatim")
+	assert.Contains(t, messages[0].Content, responseWithMustache,
+		"Mustache-like syntax in response must be preserved verbatim")
+}


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/v5/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes judge message rendering logic to avoid Mustache parsing on user-controlled content, which can affect evaluation prompts and is security-adjacent. Risk is limited to judge prompt construction but could change output text in edge cases.
> 
> **Overview**
> Prevents user-controlled context attributes containing Mustache control sequences from affecting judge prompt construction by replacing the pass-2 Mustache render with literal placeholder string substitution in `Judge.buildMessages`.
> 
> Centralizes the reserved judge placeholders (`{{message_history}}`, `{{response_to_evaluate}}`) as shared constants in `ldai` and updates `JudgeConfig` to inject those constants. Adds regression tests covering Mustache injection variants, multiple placeholder occurrences, and preserving Mustache-like syntax in history/response text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1793aa55fc04343f49efa1980593a67003fc0c98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->