### PR TITLE
feat!: Add per-execution runId, at-most-once tracking, and cross-process tracker resumption

### DIFF
--- a/ldai/README.md
+++ b/ldai/README.md
@@ -47,10 +47,11 @@ Fetch a model configuration for a specific LaunchDarkly context:
 ```go
 // The default value 'ldai.Disabled()' be returned if LaunchDarkly is unavailable or the config
 // cannot be fetched. To customize the default value, use ldai.NewConfig().
-config, tracker := aiClient.Config("your-model-key", ldcontext.New("user-key"), ldai.Disabled(), nil)
+config := aiClient.CompletionConfig("your-model-key", ldcontext.New("user-key"), ldai.Disabled(), nil)
 
-// Access the methods on config, and optionally use the returned tracker to generate analytic events
-// related to usage of the model config.
+// Access the methods on config. To generate analytic events related to usage of the model config,
+// obtain a tracker by calling config.CreateTracker().
+tracker := config.CreateTracker()
 ```
 Learn more
 -----------

--- a/ldai/client.go
+++ b/ldai/client.go
@@ -1,6 +1,7 @@
 package ldai
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 
@@ -116,6 +117,46 @@ func (c *Client) Config(
 	return c.CompletionConfig(key, context, defaultValue, variables)
 }
 
+// CreateTracker reconstructs a Tracker from a resumption token and the given context.
+// This is used for cross-process scenarios (e.g., deferred feedback) where the original tracker
+// is no longer available but its runId must be reused. The token is obtained from Tracker.ResumptionToken().
+// The reconstructed tracker will have empty modelName and providerName since these are not included
+// in the token.
+func (c *Client) CreateTracker(token string, context ldcontext.Context) (*Tracker, error) {
+	decoded, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return nil, fmt.Errorf("invalid resumption token: %w", err)
+	}
+	var payload resumptionPayload
+	if err := json.Unmarshal(decoded, &payload); err != nil {
+		return nil, fmt.Errorf("invalid resumption token: %w", err)
+	}
+
+	trackData := ldvalue.ObjectBuild().
+		Set("runId", ldvalue.String(payload.RunID)).
+		Set("variationKey", ldvalue.String(payload.VariationKey)).
+		Set("configKey", ldvalue.String(payload.ConfigKey)).
+		Set("version", ldvalue.Int(payload.Version)).
+		Set("providerName", ldvalue.String("")).
+		Set("modelName", ldvalue.String("")).
+		Build()
+
+	emptyConfig := Disabled()
+
+	return &Tracker{
+		key:          payload.ConfigKey,
+		runID:        payload.RunID,
+		variationKey: payload.VariationKey,
+		version:      payload.Version,
+		config:       &emptyConfig,
+		trackData:    trackData,
+		events:       c.sdk,
+		context:      context,
+		logger:       c.logger,
+		stopwatch:    &defaultStopwatch{},
+	}, nil
+}
+
 // evaluateConfig fetches and interpolates an AI Config without emitting any metric.
 // Callers (Config, JudgeConfig) are meant to emit their own metric before calling this.
 func (c *Client) evaluateConfig(
@@ -130,13 +171,13 @@ func (c *Client) evaluateConfig(
 	// empty object.)
 	if result.Type() != ldvalue.ObjectType {
 		c.logConfigWarning(key, "unmarshalling failed, expected JSON object but got %s", result.Type().String())
-		return defaultValue, newTracker(key, "", 1, c.sdk, &defaultValue, context, c.logger)
+		return defaultValue, newTracker(key, newRunID(), "", 1, c.sdk, &defaultValue, context, c.logger)
 	}
 
 	var parsed datamodel.Config
 	if err := json.Unmarshal([]byte(result.JSONString()), &parsed); err != nil {
 		c.logConfigWarning(key, "unmarshalling failed: %v", err)
-		return defaultValue, newTracker(key, "", 1, c.sdk, &defaultValue, context, c.logger)
+		return defaultValue, newTracker(key, newRunID(), "", 1, c.sdk, &defaultValue, context, c.logger)
 	}
 
 	mergedVariables := map[string]interface{}{
@@ -186,7 +227,14 @@ func (c *Client) evaluateConfig(
 		version = *parsed.Meta.Version
 	}
 
-	return cfg, newTracker(key, parsed.Meta.VariationKey, version, c.sdk, &cfg, context, c.logger)
+	if cfg.Enabled() {
+		variationKey := parsed.Meta.VariationKey
+		cfg.trackerFactory = func() *Tracker {
+			return newTracker(key, newRunID(), variationKey, version, c.sdk, &cfg, context, c.logger)
+		}
+	}
+
+	return cfg, newTracker(key, newRunID(), parsed.Meta.VariationKey, version, c.sdk, &cfg, context, c.logger)
 }
 
 func getAllAttributes(context ldcontext.Context) map[string]interface{} {

--- a/ldai/client.go
+++ b/ldai/client.go
@@ -192,11 +192,9 @@ func (c *Client) evaluateConfig(
 		version = *parsed.Meta.Version
 	}
 
-	if cfg.Enabled() {
-		variationKey := parsed.Meta.VariationKey
-		cfg.trackerFactory = func() *Tracker {
-			return newTracker(c.sdk, newRunID(), key, variationKey, version, context, &cfg, c.logger)
-		}
+	variationKey := parsed.Meta.VariationKey
+	cfg.trackerFactory = func() *Tracker {
+		return newTracker(c.sdk, newRunID(), key, variationKey, version, context, &cfg, c.logger)
 	}
 
 	return cfg, newTracker(c.sdk, newRunID(), key, parsed.Meta.VariationKey, version, context, &cfg, c.logger)

--- a/ldai/client.go
+++ b/ldai/client.go
@@ -122,6 +122,15 @@ func (c *Client) CreateTracker(token string, context ldcontext.Context) (*Tracke
 	return TrackerFromResumptionToken(token, c.sdk, context)
 }
 
+// returnDefault sets a tracker factory on a copy of def (so CreateTracker always works) and
+// returns it along with an initial tracker. Used for all error-path returns in evaluateConfig.
+func (c *Client) returnDefault(key string, context ldcontext.Context, def Config) (Config, *Tracker) {
+	def.trackerFactory = func() *Tracker {
+		return newTracker(c.sdk, newRunID(), key, "", 1, context, &def, c.logger)
+	}
+	return def, newTracker(c.sdk, newRunID(), key, "", 1, context, &def, c.logger)
+}
+
 // evaluateConfig fetches and interpolates an AI Config without emitting any metric.
 // Callers (Config, JudgeConfig) are meant to emit their own metric before calling this.
 func (c *Client) evaluateConfig(
@@ -136,13 +145,13 @@ func (c *Client) evaluateConfig(
 	// empty object.)
 	if result.Type() != ldvalue.ObjectType {
 		c.logConfigWarning(key, "unmarshalling failed, expected JSON object but got %s", result.Type().String())
-		return defaultValue, newTracker(c.sdk, newRunID(), key, "", 1, context, &defaultValue, c.logger)
+		return c.returnDefault(key, context, defaultValue)
 	}
 
 	var parsed datamodel.Config
 	if err := json.Unmarshal([]byte(result.JSONString()), &parsed); err != nil {
 		c.logConfigWarning(key, "unmarshalling failed: %v", err)
-		return defaultValue, newTracker(c.sdk, newRunID(), key, "", 1, context, &defaultValue, c.logger)
+		return c.returnDefault(key, context, defaultValue)
 	}
 
 	mergedVariables := map[string]interface{}{
@@ -180,7 +189,7 @@ func (c *Client) evaluateConfig(
 			c.logConfigWarning(key,
 				"malformed message at index %d: %v", i, err,
 			)
-			return defaultValue, &Tracker{}
+			return c.returnDefault(key, context, defaultValue)
 		}
 		builder.WithMessage(content, msg.Role)
 	}

--- a/ldai/client.go
+++ b/ldai/client.go
@@ -1,7 +1,6 @@
 package ldai
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 
@@ -118,43 +117,9 @@ func (c *Client) Config(
 }
 
 // CreateTracker reconstructs a Tracker from a resumption token and the given context.
-// This is used for cross-process scenarios (e.g., deferred feedback) where the original tracker
-// is no longer available but its runId must be reused. The token is obtained from Tracker.ResumptionToken().
-// The reconstructed tracker will have empty modelName and providerName since these are not included
-// in the token.
+// This delegates to TrackerFromResumptionToken. See that function for details.
 func (c *Client) CreateTracker(token string, context ldcontext.Context) (*Tracker, error) {
-	decoded, err := base64.RawURLEncoding.DecodeString(token)
-	if err != nil {
-		return nil, fmt.Errorf("invalid resumption token: %w", err)
-	}
-	var payload resumptionPayload
-	if err := json.Unmarshal(decoded, &payload); err != nil {
-		return nil, fmt.Errorf("invalid resumption token: %w", err)
-	}
-
-	trackData := ldvalue.ObjectBuild().
-		Set("runId", ldvalue.String(payload.RunID)).
-		Set("variationKey", ldvalue.String(payload.VariationKey)).
-		Set("configKey", ldvalue.String(payload.ConfigKey)).
-		Set("version", ldvalue.Int(payload.Version)).
-		Set("providerName", ldvalue.String("")).
-		Set("modelName", ldvalue.String("")).
-		Build()
-
-	emptyConfig := Disabled()
-
-	return &Tracker{
-		key:          payload.ConfigKey,
-		runID:        payload.RunID,
-		variationKey: payload.VariationKey,
-		version:      payload.Version,
-		config:       &emptyConfig,
-		trackData:    trackData,
-		events:       c.sdk,
-		context:      context,
-		logger:       c.logger,
-		stopwatch:    &defaultStopwatch{},
-	}, nil
+	return TrackerFromResumptionToken(token, c.sdk, context)
 }
 
 // evaluateConfig fetches and interpolates an AI Config without emitting any metric.

--- a/ldai/client.go
+++ b/ldai/client.go
@@ -171,13 +171,13 @@ func (c *Client) evaluateConfig(
 	// empty object.)
 	if result.Type() != ldvalue.ObjectType {
 		c.logConfigWarning(key, "unmarshalling failed, expected JSON object but got %s", result.Type().String())
-		return defaultValue, newTracker(key, newRunID(), "", 1, c.sdk, &defaultValue, context, c.logger)
+		return defaultValue, newTracker(c.sdk, newRunID(), key, "", 1, context, &defaultValue, c.logger)
 	}
 
 	var parsed datamodel.Config
 	if err := json.Unmarshal([]byte(result.JSONString()), &parsed); err != nil {
 		c.logConfigWarning(key, "unmarshalling failed: %v", err)
-		return defaultValue, newTracker(key, newRunID(), "", 1, c.sdk, &defaultValue, context, c.logger)
+		return defaultValue, newTracker(c.sdk, newRunID(), key, "", 1, context, &defaultValue, c.logger)
 	}
 
 	mergedVariables := map[string]interface{}{
@@ -230,11 +230,11 @@ func (c *Client) evaluateConfig(
 	if cfg.Enabled() {
 		variationKey := parsed.Meta.VariationKey
 		cfg.trackerFactory = func() *Tracker {
-			return newTracker(key, newRunID(), variationKey, version, c.sdk, &cfg, context, c.logger)
+			return newTracker(c.sdk, newRunID(), key, variationKey, version, context, &cfg, c.logger)
 		}
 	}
 
-	return cfg, newTracker(key, newRunID(), parsed.Meta.VariationKey, version, c.sdk, &cfg, context, c.logger)
+	return cfg, newTracker(c.sdk, newRunID(), key, parsed.Meta.VariationKey, version, context, &cfg, c.logger)
 }
 
 func getAllAttributes(context ldcontext.Context) map[string]interface{} {

--- a/ldai/client.go
+++ b/ldai/client.go
@@ -92,28 +92,16 @@ func (c *Client) logConfigWarning(key string, format string, args ...interface{}
 // variables. Returns the default value if the config cannot be evaluated. Template interpolation is
 // not applied to the default value's messages.
 //
-// To send analytic events to LaunchDarkly, call methods on the returned Tracker.
+// To send analytic events to LaunchDarkly, call CreateTracker on the returned Config to obtain a Tracker.
 func (c *Client) CompletionConfig(
 	key string,
 	context ldcontext.Context,
 	defaultValue Config,
 	variables map[string]interface{},
-) (Config, *Tracker) {
+) Config {
 	data := ldvalue.ObjectBuild().Set("configKey", ldvalue.String(key)).Build()
 	_ = c.sdk.TrackMetric(usageCompletionConfig, context, 1, data)
 	return c.evaluateConfig(key, context, defaultValue, variables)
-}
-
-// Config evaluates an AI Config named by a given key for the given context.
-//
-// Deprecated: Use CompletionConfig instead.
-func (c *Client) Config(
-	key string,
-	context ldcontext.Context,
-	defaultValue Config,
-	variables map[string]interface{},
-) (Config, *Tracker) {
-	return c.CompletionConfig(key, context, defaultValue, variables)
 }
 
 // CreateTracker reconstructs a Tracker from a resumption token and the given context.
@@ -123,22 +111,22 @@ func (c *Client) CreateTracker(token string, context ldcontext.Context) (*Tracke
 }
 
 // returnDefault sets a tracker factory on a copy of def (so CreateTracker always works) and
-// returns it along with an initial tracker. Used for all error-path returns in evaluateConfig.
-func (c *Client) returnDefault(key string, context ldcontext.Context, def Config) (Config, *Tracker) {
+// returns the resulting Config. Used for all error-path returns in evaluateConfig.
+func (c *Client) returnDefault(key string, context ldcontext.Context, def Config) Config {
 	def.trackerFactory = func() *Tracker {
 		return newTracker(c.sdk, newRunID(), key, "", 1, context, &def, c.logger)
 	}
-	return def, newTracker(c.sdk, newRunID(), key, "", 1, context, &def, c.logger)
+	return def
 }
 
 // evaluateConfig fetches and interpolates an AI Config without emitting any metric.
-// Callers (Config, JudgeConfig) are meant to emit their own metric before calling this.
+// Callers (CompletionConfig, JudgeConfig) are meant to emit their own metric before calling this.
 func (c *Client) evaluateConfig(
 	key string,
 	context ldcontext.Context,
 	defaultValue Config,
 	variables map[string]interface{},
-) (Config, *Tracker) {
+) Config {
 	result, _ := c.sdk.JSONVariation(key, context, defaultValue.AsLdValue())
 
 	// The spec requires the config to at least be an object (although all properties are optional, so it may be an
@@ -206,7 +194,7 @@ func (c *Client) evaluateConfig(
 		return newTracker(c.sdk, newRunID(), key, variationKey, version, context, &cfg, c.logger)
 	}
 
-	return cfg, newTracker(c.sdk, newRunID(), key, parsed.Meta.VariationKey, version, context, &cfg, c.logger)
+	return cfg
 }
 
 func getAllAttributes(context ldcontext.Context) map[string]interface{} {
@@ -255,13 +243,13 @@ func interpolateTemplate(template string, variables map[string]interface{}) (str
 // variables message_history and response_to_evaluate are preserved as literal placeholders for
 // substitution by Judge.buildMessages during evaluation.
 //
-// To send analytic events to LaunchDarkly, call methods on the returned Tracker.
+// To send analytic events to LaunchDarkly, call CreateTracker on the returned Config to obtain a Tracker.
 func (c *Client) JudgeConfig(
 	key string,
 	context ldcontext.Context,
 	defaultValue Config,
 	variables map[string]interface{},
-) (Config, *Tracker) {
+) Config {
 	data := ldvalue.ObjectBuild().Set("configKey", ldvalue.String(key)).Build()
 	_ = c.sdk.TrackMetric(usageJudgeConfig, context, 1, data)
 

--- a/ldai/client_test.go
+++ b/ldai/client_test.go
@@ -846,7 +846,7 @@ func TestCreateTracker_ManuallyBuiltConfig_ReturnsNil(t *testing.T) {
 	assert.Nil(t, cfg.CreateTracker(), "manually built config should not have a tracker factory")
 }
 
-func TestCreateTracker_DisabledConfig_ReturnsNil(t *testing.T) {
+func TestCreateTracker_DisabledConfig_ReturnsTracker(t *testing.T) {
 	json := []byte(`{
 		"_ldMeta": {"variationKey": "1", "enabled": false},
 		"messages": [{"content": "hello", "role": "user"}]
@@ -857,7 +857,7 @@ func TestCreateTracker_DisabledConfig_ReturnsNil(t *testing.T) {
 
 	cfg, _ := client.CompletionConfig("key", ldcontext.New("user"), Disabled(), nil)
 	assert.False(t, cfg.Enabled())
-	assert.Nil(t, cfg.CreateTracker(), "disabled config should not have a tracker factory")
+	assert.NotNil(t, cfg.CreateTracker(), "disabled config should still have a tracker factory")
 }
 
 func TestCreateTracker_EnabledConfig_ReturnsTracker(t *testing.T) {

--- a/ldai/client_test.go
+++ b/ldai/client_test.go
@@ -96,8 +96,8 @@ func TestEvalErrorReturnsDefault(t *testing.T) {
 
 	defaultVal := NewConfig().Enable().WithMessage("hello", datamodel.User).Build()
 
-	cfg, tracker := client.Config("key", ldcontext.New("user"), defaultVal, nil)
-	assert.NotNil(t, tracker)
+	cfg := client.CompletionConfig("key", ldcontext.New("user"), defaultVal, nil)
+	assert.NotNil(t, cfg.CreateTracker())
 	assert.Equal(t, defaultVal.Enabled(), cfg.Enabled())
 	assert.Equal(t, defaultVal.Messages(), cfg.Messages())
 	assert.Equal(t, defaultVal.ModelName(), cfg.ModelName())
@@ -117,7 +117,7 @@ func TestParseMultipleMessages(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, client)
 
-	cfg, _ := client.Config("key", ldcontext.New("user"), Disabled(), nil)
+	cfg := client.CompletionConfig("key", ldcontext.New("user"), Disabled(), nil)
 
 	assert.ElementsMatch(t, cfg.Messages(), []datamodel.Message{
 		{Content: "hello", Role: datamodel.User},
@@ -143,7 +143,7 @@ func TestParseModelName(t *testing.T) {
 			require.NotNil(t, client)
 
 			defaultVal := NewConfig().Enable().WithMessage("hello", datamodel.User).Build()
-			cfg, _ := client.Config("key", ldcontext.New("user"), defaultVal, nil)
+			cfg := client.CompletionConfig("key", ldcontext.New("user"), defaultVal, nil)
 
 			assert.Equal(t, test.expected, cfg.ModelName())
 		})
@@ -167,7 +167,7 @@ func TestParseProviderName(t *testing.T) {
 			require.NotNil(t, client)
 
 			defaultVal := NewConfig().Enable().WithMessage("hello", datamodel.User).Build()
-			cfg, _ := client.Config("key", ldcontext.New("user"), defaultVal, nil)
+			cfg := client.CompletionConfig("key", ldcontext.New("user"), defaultVal, nil)
 
 			assert.Equal(t, test.expected, cfg.ProviderName())
 		})
@@ -195,7 +195,7 @@ func TestParseInvalidConfigReturnsDefault(t *testing.T) {
 
 			defaultVal := NewConfig().Enable().WithMessage("hello", datamodel.User).Build()
 
-			cfg, _ := client.Config("key", ldcontext.New("user"), defaultVal, nil)
+			cfg := client.CompletionConfig("key", ldcontext.New("user"), defaultVal, nil)
 			// Verify config data matches the default
 			assert.Equal(t, defaultVal.AsLdValue(), cfg.AsLdValue())
 			// Verify CreateTracker() now works (returnDefault always injects a factory)
@@ -225,7 +225,7 @@ func TestParseDisabledConfigs(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, client)
 
-			cfg, _ := client.Config("key", ldcontext.New("user"), defaultVal, nil)
+			cfg := client.CompletionConfig("key", ldcontext.New("user"), defaultVal, nil)
 
 			// We *shouldn't* be getting the default value, because these are all valid configs that should
 			// be parsed as disabled.
@@ -255,7 +255,7 @@ func TestParseModelParams(t *testing.T) {
 			require.NotNil(t, client)
 
 			defaultVal := NewConfig().Enable().WithMessage("hello", datamodel.User).Build()
-			cfg, _ := client.Config("key", ldcontext.New("user"), defaultVal, nil)
+			cfg := client.CompletionConfig("key", ldcontext.New("user"), defaultVal, nil)
 
 			for k, v := range test.expected {
 				p, ok := cfg.ModelParam(k)
@@ -288,7 +288,7 @@ func TestParseCustomModelParams(t *testing.T) {
 			require.NotNil(t, client)
 
 			defaultVal := NewConfig().Enable().WithMessage("hello", datamodel.User).Build()
-			cfg, _ := client.Config("key", ldcontext.New("user"), defaultVal, nil)
+			cfg := client.CompletionConfig("key", ldcontext.New("user"), defaultVal, nil)
 
 			for k, v := range test.expected {
 				p, ok := cfg.CustomModelParam(k)
@@ -311,7 +311,7 @@ func TestCanSetDefaultConfigFields(t *testing.T) {
 		WithProviderName("provider").
 		WithModelName("model").Build()
 
-	cfg, _ := client.Config("key", ldcontext.New("user"), defaultVal, nil)
+	cfg := client.CompletionConfig("key", ldcontext.New("user"), defaultVal, nil)
 
 	assert.True(t, cfg.Enabled())
 	assert.Equal(t, "provider", cfg.ProviderName())
@@ -338,43 +338,9 @@ func TestCompletionConfigMethodTracking(t *testing.T) {
 	context := ldcontext.New("user-key")
 	configKey := "test-config-key"
 
-	config, tracker := client.CompletionConfig(configKey, context, defaultConfig, nil)
+	config := client.CompletionConfig(configKey, context, defaultConfig, nil)
 
-	require.NotNil(t, config)
-	require.NotNil(t, tracker)
-
-	expectedData := ldvalue.ObjectBuild().Set("configKey", ldvalue.String(configKey)).Build()
-	expectedEvents := []mockEvent{
-		{
-			eventName:   "$ld:ai:usage:completion-config",
-			context:     context,
-			metricValue: 1,
-			data:        expectedData,
-		},
-	}
-
-	assert.ElementsMatch(t, expectedEvents, mockSDK.events)
-}
-
-// TestDeprecatedConfigDelegatesToCompletionConfig verifies the deprecated Config method delegates
-// to CompletionConfig and emits the same usage event.
-func TestDeprecatedConfigDelegatesToCompletionConfig(t *testing.T) {
-	mockSDK := newMockSDK(nil, nil)
-	client, err := NewClient(mockSDK)
-	require.NoError(t, err)
-	require.NotNil(t, client)
-
-	// Clear the SDK info event from construction.
-	mockSDK.events = nil
-
-	defaultConfig := NewConfig().WithEnabled(false).Build()
-	context := ldcontext.New("user-key")
-	configKey := "test-config-key"
-
-	config, tracker := client.Config(configKey, context, defaultConfig, nil)
-
-	require.NotNil(t, config)
-	require.NotNil(t, tracker)
+	require.NotNil(t, config.CreateTracker())
 
 	expectedData := ldvalue.ObjectBuild().Set("configKey", ldvalue.String(configKey)).Build()
 	expectedEvents := []mockEvent{
@@ -410,10 +376,9 @@ func TestJudgeConfigMethodTracking(t *testing.T) {
 	context := ldcontext.New("user-key")
 	configKey := "judge-config-key"
 
-	config, tracker := client.JudgeConfig(configKey, context, defaultConfig, nil)
+	config := client.JudgeConfig(configKey, context, defaultConfig, nil)
 
-	require.NotNil(t, config)
-	require.NotNil(t, tracker)
+	require.NotNil(t, config.CreateTracker())
 
 	// Only the judge metric should be emitted; evaluateConfig does not emit any metric.
 	expectedData := ldvalue.ObjectBuild().Set("configKey", ldvalue.String(configKey)).Build()
@@ -435,7 +400,7 @@ func TestCanSetModelParameters(t *testing.T) {
 	require.NotNil(t, client)
 
 	defaultVal := NewConfig().WithModelParam("foo", ldvalue.String("bar")).Build()
-	cfg, _ := client.Config("key", ldcontext.New("user"), defaultVal, nil)
+	cfg := client.CompletionConfig("key", ldcontext.New("user"), defaultVal, nil)
 
 	t.Run("param is present", func(t *testing.T) {
 		p, ok := cfg.ModelParam("foo")
@@ -456,7 +421,7 @@ func TestCanSetCustomModelParameters(t *testing.T) {
 	require.NotNil(t, client)
 
 	defaultVal := NewConfig().WithCustomModelParam("foo", ldvalue.String("bar")).Build()
-	cfg, _ := client.Config("key", ldcontext.New("user"), defaultVal, nil)
+	cfg := client.CompletionConfig("key", ldcontext.New("user"), defaultVal, nil)
 
 	t.Run("param is present", func(t *testing.T) {
 		p, ok := cfg.CustomModelParam("foo")
@@ -480,7 +445,7 @@ func TestNormalAndCustomParamsDoNotInterfere(t *testing.T) {
 		WithModelParam("foo", ldvalue.String("bar")).
 		WithCustomModelParam("foo", ldvalue.String("baz")).Build()
 
-	cfg, _ := client.Config("key", ldcontext.New("user"), defaultVal, nil)
+	cfg := client.CompletionConfig("key", ldcontext.New("user"), defaultVal, nil)
 
 	foo1, ok := cfg.ModelParam("foo")
 	require.True(t, ok)
@@ -499,7 +464,7 @@ func TestCannotOverwriteMessages(t *testing.T) {
 	defaultVal := NewConfig().
 		WithMessage("hello", datamodel.Assistant).Build()
 
-	cfg, _ := client.Config("key", ldcontext.New("user"), defaultVal, nil)
+	cfg := client.CompletionConfig("key", ldcontext.New("user"), defaultVal, nil)
 
 	cfg.Messages()[0].Content = "changed"
 	cfg.Messages()[0].Role = datamodel.User
@@ -518,7 +483,7 @@ func eval(t *testing.T, prompt string, ctx ldcontext.Context, variables map[stri
 
 	client, err := NewClient(newMockSDK(json, nil))
 	require.NoError(t, err)
-	cfg, _ := client.Config("key", ctx, Disabled(), variables)
+	cfg := client.CompletionConfig("key", ctx, Disabled(), variables)
 	if len(cfg.Messages()) == 0 {
 		return "", errors.New("no messages interpolated")
 	}
@@ -700,7 +665,7 @@ func TestParseJudgeSpecificFields(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, client)
 
-	cfg, _ := client.Config("key", ldcontext.New("user"), Disabled(), nil)
+	cfg := client.CompletionConfig("key", ldcontext.New("user"), Disabled(), nil)
 
 	assert.Equal(t, "judge", cfg.Mode())
 	assert.Equal(t, "toxicity", cfg.EvaluationMetricKey())
@@ -728,7 +693,7 @@ func TestParseEvaluationMetricKeys(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, client)
 
-	cfg, _ := client.Config("key", ldcontext.New("user"), Disabled(), nil)
+	cfg := client.CompletionConfig("key", ldcontext.New("user"), Disabled(), nil)
 
 	assert.Equal(t, "judge", cfg.Mode())
 	assert.Equal(t, "", cfg.EvaluationMetricKey())
@@ -750,7 +715,7 @@ func TestParseEvaluationMetricKeyPriority(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, client)
 
-	cfg, _ := client.Config("key", ldcontext.New("user"), Disabled(), nil)
+	cfg := client.CompletionConfig("key", ldcontext.New("user"), Disabled(), nil)
 
 	assert.Equal(t, "judge", cfg.Mode())
 	// Both fields should be parsed
@@ -813,7 +778,7 @@ func TestJudgeConfig_PreservesReservedPlaceholders(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, client)
 
-	cfg, _ := client.JudgeConfig("judge-key", ldcontext.New("user"), Disabled(), nil)
+	cfg := client.JudgeConfig("judge-key", ldcontext.New("user"), Disabled(), nil)
 
 	msgs := cfg.Messages()
 	require.Len(t, msgs, 2)
@@ -837,7 +802,7 @@ func TestConfig_WithoutReservedVarsWipesJudgePlaceholders(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, client)
 
-	cfg, _ := client.Config("key", ldcontext.New("user"), Disabled(), nil)
+	cfg := client.CompletionConfig("key", ldcontext.New("user"), Disabled(), nil)
 
 	msgs := cfg.Messages()
 	require.Len(t, msgs, 1)
@@ -858,7 +823,7 @@ func TestCreateTracker_DisabledConfig_ReturnsTracker(t *testing.T) {
 	client, err := NewClient(newMockSDK(json, nil))
 	require.NoError(t, err)
 
-	cfg, _ := client.CompletionConfig("key", ldcontext.New("user"), Disabled(), nil)
+	cfg := client.CompletionConfig("key", ldcontext.New("user"), Disabled(), nil)
 	assert.False(t, cfg.Enabled())
 	assert.NotNil(t, cfg.CreateTracker(), "disabled config should still have a tracker factory")
 }
@@ -874,7 +839,7 @@ func TestCreateTracker_EnabledConfig_ReturnsTracker(t *testing.T) {
 	client, err := NewClient(newMockSDK(json, nil))
 	require.NoError(t, err)
 
-	cfg, _ := client.CompletionConfig("key", ldcontext.New("user"), Disabled(), nil)
+	cfg := client.CompletionConfig("key", ldcontext.New("user"), Disabled(), nil)
 	assert.True(t, cfg.Enabled())
 
 	tracker := cfg.CreateTracker()
@@ -894,7 +859,7 @@ func TestCreateTracker_FreshRunIdPerCall(t *testing.T) {
 	// Clear SDK info event
 	mockSDK.events = nil
 
-	cfg, _ := client.CompletionConfig("key", ldcontext.New("user"), Disabled(), nil)
+	cfg := client.CompletionConfig("key", ldcontext.New("user"), Disabled(), nil)
 
 	tracker1 := cfg.CreateTracker()
 	tracker2 := cfg.CreateTracker()
@@ -937,7 +902,7 @@ func TestCreateTracker_TrackerHasCorrectMetadata(t *testing.T) {
 	// Clear SDK info event
 	mockSDK.events = nil
 
-	cfg, _ := client.CompletionConfig("my-config", ldcontext.New("user"), Disabled(), nil)
+	cfg := client.CompletionConfig("my-config", ldcontext.New("user"), Disabled(), nil)
 
 	tracker := cfg.CreateTracker()
 	require.NotNil(t, tracker)
@@ -974,7 +939,7 @@ func TestCreateTracker_JudgeConfigHasFactory(t *testing.T) {
 	client, err := NewClient(newMockSDK(json, nil))
 	require.NoError(t, err)
 
-	cfg, _ := client.JudgeConfig("judge-key", ldcontext.New("user"), Disabled(), nil)
+	cfg := client.JudgeConfig("judge-key", ldcontext.New("user"), Disabled(), nil)
 	assert.True(t, cfg.Enabled())
 
 	tracker := cfg.CreateTracker()
@@ -996,7 +961,7 @@ func TestClient_CreateTracker_RoundTrip(t *testing.T) {
 	// Clear SDK info event
 	mockSDK.events = nil
 
-	cfg, _ := client.CompletionConfig("my-config", ldcontext.New("user"), Disabled(), nil)
+	cfg := client.CompletionConfig("my-config", ldcontext.New("user"), Disabled(), nil)
 	originalTracker := cfg.CreateTracker()
 	require.NotNil(t, originalTracker)
 

--- a/ldai/client_test.go
+++ b/ldai/client_test.go
@@ -196,7 +196,10 @@ func TestParseInvalidConfigReturnsDefault(t *testing.T) {
 			defaultVal := NewConfig().Enable().WithMessage("hello", datamodel.User).Build()
 
 			cfg, _ := client.Config("key", ldcontext.New("user"), defaultVal, nil)
-			assert.Equal(t, defaultVal, cfg)
+			// Verify config data matches the default
+			assert.Equal(t, defaultVal.AsLdValue(), cfg.AsLdValue())
+			// Verify CreateTracker() now works (returnDefault always injects a factory)
+			assert.NotNil(t, cfg.CreateTracker())
 
 			sdk.log.AssertMessageMatch(t, true, ldlog.Warn, "AI Config 'key':")
 		})

--- a/ldai/client_test.go
+++ b/ldai/client_test.go
@@ -1,6 +1,8 @@
 package ldai
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -96,7 +98,10 @@ func TestEvalErrorReturnsDefault(t *testing.T) {
 
 	cfg, tracker := client.Config("key", ldcontext.New("user"), defaultVal, nil)
 	assert.NotNil(t, tracker)
-	assert.Equal(t, defaultVal, cfg)
+	assert.Equal(t, defaultVal.Enabled(), cfg.Enabled())
+	assert.Equal(t, defaultVal.Messages(), cfg.Messages())
+	assert.Equal(t, defaultVal.ModelName(), cfg.ModelName())
+	assert.Equal(t, defaultVal.ProviderName(), cfg.ProviderName())
 }
 
 func TestParseMultipleMessages(t *testing.T) {
@@ -834,4 +839,237 @@ func TestConfig_WithoutReservedVarsWipesJudgePlaceholders(t *testing.T) {
 	msgs := cfg.Messages()
 	require.Len(t, msgs, 1)
 	assert.Equal(t, "Input: \nOutput: ", msgs[0].Content, "Config without reserved vars renders placeholders as empty")
+}
+
+func TestCreateTracker_ManuallyBuiltConfig_ReturnsNil(t *testing.T) {
+	cfg := NewConfig().Enable().WithMessage("hello", datamodel.User).Build()
+	assert.Nil(t, cfg.CreateTracker(), "manually built config should not have a tracker factory")
+}
+
+func TestCreateTracker_DisabledConfig_ReturnsNil(t *testing.T) {
+	json := []byte(`{
+		"_ldMeta": {"variationKey": "1", "enabled": false},
+		"messages": [{"content": "hello", "role": "user"}]
+	}`)
+
+	client, err := NewClient(newMockSDK(json, nil))
+	require.NoError(t, err)
+
+	cfg, _ := client.CompletionConfig("key", ldcontext.New("user"), Disabled(), nil)
+	assert.False(t, cfg.Enabled())
+	assert.Nil(t, cfg.CreateTracker(), "disabled config should not have a tracker factory")
+}
+
+func TestCreateTracker_EnabledConfig_ReturnsTracker(t *testing.T) {
+	json := []byte(`{
+		"_ldMeta": {"variationKey": "1", "enabled": true},
+		"model": {"name": "gpt-4"},
+		"provider": {"name": "openai"},
+		"messages": [{"content": "hello", "role": "user"}]
+	}`)
+
+	client, err := NewClient(newMockSDK(json, nil))
+	require.NoError(t, err)
+
+	cfg, _ := client.CompletionConfig("key", ldcontext.New("user"), Disabled(), nil)
+	assert.True(t, cfg.Enabled())
+
+	tracker := cfg.CreateTracker()
+	require.NotNil(t, tracker, "enabled config should have a tracker factory")
+}
+
+func TestCreateTracker_FreshRunIdPerCall(t *testing.T) {
+	json := []byte(`{
+		"_ldMeta": {"variationKey": "1", "enabled": true},
+		"messages": [{"content": "hello", "role": "user"}]
+	}`)
+
+	mockSDK := newMockSDK(json, nil)
+	client, err := NewClient(mockSDK)
+	require.NoError(t, err)
+
+	// Clear SDK info event
+	mockSDK.events = nil
+
+	cfg, _ := client.CompletionConfig("key", ldcontext.New("user"), Disabled(), nil)
+
+	tracker1 := cfg.CreateTracker()
+	tracker2 := cfg.CreateTracker()
+	require.NotNil(t, tracker1)
+	require.NotNil(t, tracker2)
+
+	// Each tracker should be able to track independently. Track success on both to emit events.
+	_ = tracker1.TrackSuccess()
+	_ = tracker2.TrackSuccess()
+
+	// Filter out the usage event; we only want the generation events.
+	var genEvents []mockEvent
+	for _, e := range mockSDK.events {
+		if e.eventName == "$ld:ai:generation:success" {
+			genEvents = append(genEvents, e)
+		}
+	}
+
+	require.Len(t, genEvents, 2, "each tracker should emit its own event")
+
+	runId1 := genEvents[0].data.GetByKey("runId").StringValue()
+	runId2 := genEvents[1].data.GetByKey("runId").StringValue()
+	assert.NotEmpty(t, runId1)
+	assert.NotEmpty(t, runId2)
+	assert.NotEqual(t, runId1, runId2, "each tracker must have a unique runId")
+}
+
+func TestCreateTracker_TrackerHasCorrectMetadata(t *testing.T) {
+	json := []byte(`{
+		"_ldMeta": {"variationKey": "var-1", "enabled": true, "version": 5},
+		"model": {"name": "gpt-4"},
+		"provider": {"name": "openai"},
+		"messages": [{"content": "hello", "role": "user"}]
+	}`)
+
+	mockSDK := newMockSDK(json, nil)
+	client, err := NewClient(mockSDK)
+	require.NoError(t, err)
+
+	// Clear SDK info event
+	mockSDK.events = nil
+
+	cfg, _ := client.CompletionConfig("my-config", ldcontext.New("user"), Disabled(), nil)
+
+	tracker := cfg.CreateTracker()
+	require.NotNil(t, tracker)
+
+	_ = tracker.TrackSuccess()
+
+	// Filter for the generation event (skip usage event)
+	var genEvent *mockEvent
+	for i, e := range mockSDK.events {
+		if e.eventName == "$ld:ai:generation:success" {
+			genEvent = &mockSDK.events[i]
+			break
+		}
+	}
+	require.NotNil(t, genEvent)
+
+	data := genEvent.data
+	assert.Equal(t, "my-config", data.GetByKey("configKey").StringValue())
+	assert.Equal(t, "var-1", data.GetByKey("variationKey").StringValue())
+	assert.Equal(t, 5, data.GetByKey("version").IntValue())
+	assert.Equal(t, "openai", data.GetByKey("providerName").StringValue())
+	assert.Equal(t, "gpt-4", data.GetByKey("modelName").StringValue())
+	assert.NotEmpty(t, data.GetByKey("runId").StringValue())
+}
+
+func TestCreateTracker_JudgeConfigHasFactory(t *testing.T) {
+	json := []byte(`{
+		"_ldMeta": {"variationKey": "1", "enabled": true},
+		"mode": "judge",
+		"evaluationMetricKey": "toxicity",
+		"messages": [{"content": "test", "role": "system"}]
+	}`)
+
+	client, err := NewClient(newMockSDK(json, nil))
+	require.NoError(t, err)
+
+	cfg, _ := client.JudgeConfig("judge-key", ldcontext.New("user"), Disabled(), nil)
+	assert.True(t, cfg.Enabled())
+
+	tracker := cfg.CreateTracker()
+	require.NotNil(t, tracker, "enabled judge config should have a tracker factory")
+}
+
+func TestClient_CreateTracker_RoundTrip(t *testing.T) {
+	configJSON := []byte(`{
+		"_ldMeta": {"variationKey": "var-1", "enabled": true, "version": 5},
+		"model": {"name": "gpt-4"},
+		"provider": {"name": "openai"},
+		"messages": [{"content": "hello", "role": "user"}]
+	}`)
+
+	mockSDK := newMockSDK(configJSON, nil)
+	client, err := NewClient(mockSDK)
+	require.NoError(t, err)
+
+	// Clear SDK info event
+	mockSDK.events = nil
+
+	cfg, _ := client.CompletionConfig("my-config", ldcontext.New("user"), Disabled(), nil)
+	originalTracker := cfg.CreateTracker()
+	require.NotNil(t, originalTracker)
+
+	token := originalTracker.ResumptionToken()
+	require.NotEmpty(t, token)
+
+	// Reconstruct from token with a different context
+	newContext := ldcontext.New("other-user")
+	reconstructed, err := client.CreateTracker(token, newContext)
+	require.NoError(t, err)
+	require.NotNil(t, reconstructed)
+
+	// The reconstructed tracker should produce the same resumption token
+	assert.Equal(t, token, reconstructed.ResumptionToken())
+
+	// Track feedback on the reconstructed tracker and verify it uses the original runId
+	_ = originalTracker.TrackSuccess()
+	_ = reconstructed.TrackFeedback(FeedbackPositive)
+
+	var successEvent, feedbackEvent *mockEvent
+	for i, e := range mockSDK.events {
+		switch e.eventName {
+		case "$ld:ai:generation:success":
+			successEvent = &mockSDK.events[i]
+		case "$ld:ai:feedback:user:positive":
+			feedbackEvent = &mockSDK.events[i]
+		}
+	}
+	require.NotNil(t, successEvent)
+	require.NotNil(t, feedbackEvent)
+
+	// Both events should share the same runId
+	originalRunId := successEvent.data.GetByKey("runId").StringValue()
+	reconstructedRunId := feedbackEvent.data.GetByKey("runId").StringValue()
+	assert.Equal(t, originalRunId, reconstructedRunId, "reconstructed tracker must reuse the original runId")
+
+	// Reconstructed tracker should use the new context
+	assert.Equal(t, newContext, feedbackEvent.context)
+
+	// Verify metadata preserved
+	assert.Equal(t, "my-config", feedbackEvent.data.GetByKey("configKey").StringValue())
+	assert.Equal(t, "var-1", feedbackEvent.data.GetByKey("variationKey").StringValue())
+	assert.Equal(t, 5, feedbackEvent.data.GetByKey("version").IntValue())
+
+	// modelName and providerName should be empty on reconstructed tracker
+	assert.Equal(t, "", feedbackEvent.data.GetByKey("modelName").StringValue())
+	assert.Equal(t, "", feedbackEvent.data.GetByKey("providerName").StringValue())
+}
+
+func TestClient_CreateTracker_InvalidToken(t *testing.T) {
+	mockSDK := newMockSDK(nil, nil)
+	client, err := NewClient(mockSDK)
+	require.NoError(t, err)
+
+	t.Run("invalid base64", func(t *testing.T) {
+		_, err := client.CreateTracker("not-valid-base64!!!", ldcontext.New("user"))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid resumption token")
+	})
+
+	t.Run("valid base64 but invalid JSON", func(t *testing.T) {
+		token := base64.RawURLEncoding.EncodeToString([]byte("not json"))
+		_, err := client.CreateTracker(token, ldcontext.New("user"))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid resumption token")
+	})
+
+	t.Run("valid token with missing fields uses zero values", func(t *testing.T) {
+		payload, _ := json.Marshal(map[string]interface{}{"runId": "test-run"})
+		token := base64.RawURLEncoding.EncodeToString(payload)
+		tracker, err := client.CreateTracker(token, ldcontext.New("user"))
+		require.NoError(t, err)
+		require.NotNil(t, tracker)
+
+		// Should work with partial data
+		resumeToken := tracker.ResumptionToken()
+		assert.NotEmpty(t, resumeToken)
+	})
 }

--- a/ldai/config.go
+++ b/ldai/config.go
@@ -88,8 +88,11 @@ func (c *Config) JudgeConfiguration() *datamodel.JudgeConfiguration {
 	}
 }
 
-// CreateTracker creates a new Tracker with a fresh runId for tracking metrics related to this
-// AI Config evaluation. Each call returns a new, independent Tracker instance.
+// CreateTracker returns a new Tracker for a fresh AI Config evaluation. Each call mints a
+// new runId (a UUIDv4) that LaunchDarkly uses to correlate the run's events — duration,
+// token usage, success/error, and feedback — in metrics views. Call this once per AI Config
+// evaluation; metrics from different runIds cannot be combined.
+//
 // Returns nil if the config was not obtained via the Client.
 func (c *Config) CreateTracker() *Tracker {
 	if c.trackerFactory == nil {

--- a/ldai/config.go
+++ b/ldai/config.go
@@ -88,10 +88,10 @@ func (c *Config) JudgeConfiguration() *datamodel.JudgeConfiguration {
 	}
 }
 
-// CreateTracker returns a new Tracker for a fresh AI Config evaluation. Each call mints a
-// new runId (a UUIDv4) that LaunchDarkly uses to correlate the run's events — duration,
-// token usage, success/error, and feedback — in metrics views. Call this once per AI Config
-// evaluation; metrics from different runIds cannot be combined.
+// CreateTracker returns a new Tracker for a fresh AI run. Each call mints
+// a new runId (a UUIDv4) that LaunchDarkly uses to correlate the run's
+// events in metrics views. Call this once per AI run; metrics from
+// different runIds cannot be combined.
 //
 // Returns nil if the config was not obtained via the Client.
 func (c *Config) CreateTracker() *Tracker {

--- a/ldai/config.go
+++ b/ldai/config.go
@@ -90,7 +90,7 @@ func (c *Config) JudgeConfiguration() *datamodel.JudgeConfiguration {
 
 // CreateTracker creates a new Tracker with a fresh runId for tracking metrics related to this
 // AI Config evaluation. Each call returns a new, independent Tracker instance.
-// Returns nil if the config is disabled or was not obtained via the Client.
+// Returns nil if the config was not obtained via the Client.
 func (c *Config) CreateTracker() *Tracker {
 	if c.trackerFactory == nil {
 		return nil

--- a/ldai/config.go
+++ b/ldai/config.go
@@ -11,7 +11,8 @@ import (
 
 // Config represents an AI Config.
 type Config struct {
-	c datamodel.Config
+	c              datamodel.Config
+	trackerFactory func() *Tracker
 }
 
 // VariationKey is used internally by LaunchDarkly.
@@ -85,6 +86,16 @@ func (c *Config) JudgeConfiguration() *datamodel.JudgeConfiguration {
 	return &datamodel.JudgeConfiguration{
 		Judges: slices.Clone(c.c.JudgeConfiguration.Judges),
 	}
+}
+
+// CreateTracker creates a new Tracker with a fresh runId for tracking metrics related to this
+// AI Config evaluation. Each call returns a new, independent Tracker instance.
+// Returns nil if the config is disabled or was not obtained via the Client.
+func (c *Config) CreateTracker() *Tracker {
+	if c.trackerFactory == nil {
+		return nil
+	}
+	return c.trackerFactory()
 }
 
 // AsLdValue is used internally.

--- a/ldai/go.mod
+++ b/ldai/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/alexkappa/mustache v1.0.0
+	github.com/google/uuid v1.1.1
 	github.com/launchdarkly/go-sdk-common/v3 v3.3.0
 	github.com/launchdarkly/go-server-sdk/v7 v7.7.0
 	github.com/stretchr/testify v1.9.0
@@ -11,7 +12,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/google/uuid v1.1.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/launchdarkly/go-jsonstream/v3 v3.1.0 // indirect
 	github.com/launchdarkly/go-sdk-events/v3 v3.4.0 // indirect

--- a/ldai/judge/judge_test.go
+++ b/ldai/judge/judge_test.go
@@ -750,7 +750,7 @@ func TestDoubleInterpolation_ReservedVariables(t *testing.T) {
 	// The config from LaunchDarkly has templates with {{message_history}} and {{response_to_evaluate}}
 	rawTemplate := "Input: {{message_history}}\nOutput: {{response_to_evaluate}}"
 
-	// Simulate first interpolation (done by client.Config when fetching judge config)
+	// Simulate first interpolation (done by client.JudgeConfig when fetching judge config)
 	// Variables passed should include literal placeholder strings
 	variablesForFirstInterpolation := map[string]interface{}{
 		"message_history":      "{{message_history}}",      // Literal string!

--- a/ldai/tracker.go
+++ b/ldai/tracker.go
@@ -1,6 +1,7 @@
 package ldai
 
 import (
+	"crypto/rand"
 	"fmt"
 	"time"
 
@@ -26,6 +27,14 @@ const (
 	//nolint:gosec
 	tokenOutput = "$ld:ai:tokens:output"
 )
+
+func newRunID() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+}
 
 // TokenUsage represents the token usage returned by a model provider for a specific request.
 type TokenUsage struct {
@@ -110,6 +119,7 @@ type Stopwatch interface {
 // Unless otherwise noted, the Tracker's method are not safe for concurrent use.
 type Tracker struct {
 	key       string
+	runID     string
 	config    *Config
 	context   ldcontext.Context
 	events    EventSink
@@ -168,7 +178,10 @@ func newTrackerWithStopwatch(
 		panic("LaunchDarkly SDK programmer error: config must never be nil")
 	}
 
+	runID := newRunID()
+
 	trackData := ldvalue.ObjectBuild().
+		Set("runId", ldvalue.String(runID)).
 		Set("variationKey", ldvalue.String(variationKey)).
 		Set("configKey", ldvalue.String(key)).
 		Set("version", ldvalue.Int(version)).
@@ -178,6 +191,7 @@ func newTrackerWithStopwatch(
 
 	return &Tracker{
 		key:       key,
+		runID:     runID,
 		config:    config,
 		trackData: trackData,
 		events:    events,
@@ -196,6 +210,10 @@ func (t *Tracker) logWarning(format string, args ...interface{}) {
 // tracked here. See also TrackRequest.
 // The duration in milliseconds must fit within a float64.
 func (t *Tracker) TrackDuration(dur time.Duration) error {
+	if t.duration.IsSome() {
+		t.logWarning("Duration has already been tracked for this execution.")
+		return nil
+	}
 	t.duration = ldcommon.Some(dur)
 	return t.events.TrackMetric(duration, t.context, float64(dur.Milliseconds()), t.trackData)
 }
@@ -203,6 +221,10 @@ func (t *Tracker) TrackDuration(dur time.Duration) error {
 // TrackFeedback tracks the feedback provided by a user for a model evaluation. If the feedback is not
 // FeedbackPositive or FeedbackNegative, returns an error and does not track anything.
 func (t *Tracker) TrackFeedback(feedback Feedback) error {
+	if t.feedback.IsSome() {
+		t.logWarning("Feedback has already been tracked for this execution.")
+		return nil
+	}
 	switch feedback {
 	case FeedbackPositive:
 		t.feedback = ldcommon.Some(feedback)
@@ -217,6 +239,10 @@ func (t *Tracker) TrackFeedback(feedback Feedback) error {
 
 // TrackSuccess tracks a successful model evaluation.
 func (t *Tracker) TrackSuccess() error {
+	if t.success.IsSome() {
+		t.logWarning("Success/error has already been tracked for this execution.")
+		return nil
+	}
 	t.success = ldcommon.Some(true)
 
 	return t.events.TrackMetric(generationSuccess, t.context, 1, t.trackData)
@@ -224,6 +250,10 @@ func (t *Tracker) TrackSuccess() error {
 
 // TrackError tracks an unsuccessful model evaluation.
 func (t *Tracker) TrackError() error {
+	if t.success.IsSome() {
+		t.logWarning("Success/error has already been tracked for this execution.")
+		return nil
+	}
 	t.success = ldcommon.Some(false)
 
 	return t.events.TrackMetric(generationError, t.context, 1, t.trackData)
@@ -231,12 +261,21 @@ func (t *Tracker) TrackError() error {
 
 // TrackTimeToFirstToken tracks the time to the first token of the streamed response.
 func (t *Tracker) TrackTimeToFirstToken(dur time.Duration) error {
+	if t.timeToFirstToken.IsSome() {
+		t.logWarning("Time to first token has already been tracked for this execution.")
+		return nil
+	}
 	t.timeToFirstToken = ldcommon.Some(dur)
 	return t.events.TrackMetric(timeToFirstToken, t.context, float64(dur.Milliseconds()), t.trackData)
 }
 
 // TrackUsage tracks the token usage for a model evaluation.
 func (t *Tracker) TrackUsage(usage TokenUsage) error {
+	if t.tokens.IsSome() {
+		t.logWarning("Usage has already been tracked for this execution.")
+		return nil
+	}
+
 	if usage.Set() {
 		t.tokens = ldcommon.Some(usage)
 	}

--- a/ldai/tracker.go
+++ b/ldai/tracker.go
@@ -192,14 +192,16 @@ func newTrackerWithStopwatch(
 		panic("LaunchDarkly SDK programmer error: config must never be nil")
 	}
 
-	trackData := ldvalue.ObjectBuild().
+	builder := ldvalue.ObjectBuild().
 		Set("runId", ldvalue.String(runID)).
-		Set("variationKey", ldvalue.String(variationKey)).
 		Set("configKey", ldvalue.String(key)).
 		Set("version", ldvalue.Int(version)).
 		Set("providerName", ldvalue.String(config.ProviderName())).
-		Set("modelName", ldvalue.String(config.ModelName())).
-		Build()
+		Set("modelName", ldvalue.String(config.ModelName()))
+	if variationKey != "" {
+		builder.Set("variationKey", ldvalue.String(variationKey))
+	}
+	trackData := builder.Build()
 
 	return &Tracker{
 		key:          key,
@@ -249,14 +251,16 @@ func TrackerFromResumptionToken(token string, sdk ServerSDK, context ldcontext.C
 		return nil, fmt.Errorf("invalid resumption token: %w", err)
 	}
 
-	trackData := ldvalue.ObjectBuild().
+	builder := ldvalue.ObjectBuild().
 		Set("runId", ldvalue.String(payload.RunID)).
-		Set("variationKey", ldvalue.String(payload.VariationKey)).
 		Set("configKey", ldvalue.String(payload.ConfigKey)).
 		Set("version", ldvalue.Int(payload.Version)).
 		Set("providerName", ldvalue.String("")).
-		Set("modelName", ldvalue.String("")).
-		Build()
+		Set("modelName", ldvalue.String(""))
+	if payload.VariationKey != "" {
+		builder.Set("variationKey", ldvalue.String(payload.VariationKey))
+	}
+	trackData := builder.Build()
 
 	emptyConfig := Disabled()
 

--- a/ldai/tracker.go
+++ b/ldai/tracker.go
@@ -31,6 +31,10 @@ const (
 	tokenOutput = "$ld:ai:tokens:output"
 )
 
+// newRunID returns a fresh UUIDv4 that LaunchDarkly uses to group all metric
+// events emitted by one Tracker into a single AI run, so latency, token usage,
+// and success/error can be analyzed together. Each call to CreateTracker on
+// the AI Config mints a new runId.
 func newRunID() string {
 	return uuid.New().String()
 }
@@ -124,6 +128,12 @@ type resumptionPayload struct {
 
 // Tracker is used to track metrics for AI Config evaluation.
 // Unless otherwise noted, the Tracker's method are not safe for concurrent use.
+//
+// All events a Tracker emits — duration, token usage, success/error, time-to-first-token,
+// and feedback — share a runId (a UUIDv4) so LaunchDarkly can correlate them in metrics
+// views as a single AI run. Each Tracker is single-use; call CreateTracker on the AI Config
+// to start a new run. A ResumptionToken preserves the runId, so events emitted by a Tracker
+// reconstructed in another process correlate with the original run.
 type Tracker struct {
 	key          string
 	runID        string

--- a/ldai/tracker.go
+++ b/ldai/tracker.go
@@ -121,7 +121,7 @@ type Stopwatch interface {
 type resumptionPayload struct {
 	RunID        string `json:"runId"`
 	ConfigKey    string `json:"configKey"`
-	VariationKey string `json:"variationKey"`
+	VariationKey string `json:"variationKey,omitempty"`
 	Version      int    `json:"version"`
 }
 
@@ -163,28 +163,28 @@ func (d *defaultStopwatch) Stop() time.Duration {
 
 // newTracker creates a new Tracker with the specified runID, key, event sink, config, context, and loggers.
 func newTracker(
-	key string,
+	events EventSink,
 	runID string,
+	key string,
 	variationKey string,
 	version int,
-	events EventSink,
-	config *Config,
 	ctx ldcontext.Context,
+	config *Config,
 	loggers interfaces.LDLoggers,
 ) *Tracker {
-	return newTrackerWithStopwatch(key, runID, variationKey, version, events, config, ctx, loggers, &defaultStopwatch{})
+	return newTrackerWithStopwatch(events, runID, key, variationKey, version, ctx, config, loggers, &defaultStopwatch{})
 }
 
 // newTrackerWithStopwatch creates a new Tracker with the specified runID, key, event sink, config, context, loggers,
 // and stopwatch. This method is used for testing purposes.
 func newTrackerWithStopwatch(
-	key string,
+	events EventSink,
 	runID string,
+	key string,
 	variationKey string,
 	version int,
-	events EventSink,
-	config *Config,
 	ctx ldcontext.Context,
+	config *Config,
 	loggers interfaces.LDLoggers,
 	stopwatch Stopwatch,
 ) *Tracker {

--- a/ldai/tracker.go
+++ b/ldai/tracker.go
@@ -234,6 +234,46 @@ func (t *Tracker) ResumptionToken() string {
 	return base64.RawURLEncoding.EncodeToString(jsonBytes)
 }
 
+// TrackerFromResumptionToken reconstructs a Tracker from a resumption token and the given context.
+// This is used for cross-process scenarios (e.g., deferred feedback) where the original tracker
+// is no longer available but its runId must be reused. The token is obtained from Tracker.ResumptionToken().
+// The reconstructed tracker will have empty modelName and providerName since these are not included
+// in the token.
+func TrackerFromResumptionToken(token string, sdk ServerSDK, context ldcontext.Context) (*Tracker, error) {
+	decoded, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return nil, fmt.Errorf("invalid resumption token: %w", err)
+	}
+	var payload resumptionPayload
+	if err := json.Unmarshal(decoded, &payload); err != nil {
+		return nil, fmt.Errorf("invalid resumption token: %w", err)
+	}
+
+	trackData := ldvalue.ObjectBuild().
+		Set("runId", ldvalue.String(payload.RunID)).
+		Set("variationKey", ldvalue.String(payload.VariationKey)).
+		Set("configKey", ldvalue.String(payload.ConfigKey)).
+		Set("version", ldvalue.Int(payload.Version)).
+		Set("providerName", ldvalue.String("")).
+		Set("modelName", ldvalue.String("")).
+		Build()
+
+	emptyConfig := Disabled()
+
+	return &Tracker{
+		key:          payload.ConfigKey,
+		runID:        payload.RunID,
+		variationKey: payload.VariationKey,
+		version:      payload.Version,
+		config:       &emptyConfig,
+		trackData:    trackData,
+		events:       sdk,
+		context:      context,
+		logger:       sdk.Loggers(),
+		stopwatch:    &defaultStopwatch{},
+	}, nil
+}
+
 // TrackDuration tracks the duration of a task. For example, the duration of a model evaluation request may be
 // tracked here. See also TrackRequest.
 // The duration in milliseconds must fit within a float64.

--- a/ldai/tracker.go
+++ b/ldai/tracker.go
@@ -32,9 +32,8 @@ const (
 )
 
 // newRunID returns a fresh UUIDv4 that LaunchDarkly uses to group all metric
-// events emitted by one Tracker into a single AI run, so latency, token usage,
-// and success/error can be analyzed together. Each call to CreateTracker on
-// the AI Config mints a new runId.
+// events emitted by one Tracker into a single AI run, so they can be analyzed
+// together. Each call to CreateTracker on the AI Config mints a new runId.
 func newRunID() string {
 	return uuid.New().String()
 }
@@ -126,13 +125,13 @@ type resumptionPayload struct {
 	Version      int    `json:"version"`
 }
 
-// Tracker is used to track metrics for AI Config evaluation.
-// Unless otherwise noted, the Tracker's method are not safe for concurrent use.
+// Tracker records metrics for a single AI run.
+// Unless otherwise noted, the Tracker's methods are not safe for concurrent use.
 //
-// All events a Tracker emits — duration, token usage, success/error, time-to-first-token,
-// and feedback — share a runId (a UUIDv4) so LaunchDarkly can correlate them in metrics
-// views as a single AI run. Each Tracker is single-use; call CreateTracker on the AI Config
-// to start a new run. A ResumptionToken preserves the runId, so events emitted by a Tracker
+// All events a Tracker emits share a runId (a UUIDv4) so LaunchDarkly can
+// correlate them in metrics views. See individual track methods for their
+// specific semantics. Call CreateTracker on the AI Config to start a new run.
+// A ResumptionToken preserves the runId, so events emitted by a Tracker
 // reconstructed in another process correlate with the original run.
 type Tracker struct {
 	key          string
@@ -288,6 +287,8 @@ func TrackerFromResumptionToken(token string, sdk ServerSDK, context ldcontext.C
 // TrackDuration tracks the duration of a task. For example, the duration of a model evaluation request may be
 // tracked here. See also TrackRequest.
 // The duration in milliseconds must fit within a float64.
+//
+// Records at most once per Tracker; further calls are ignored.
 func (t *Tracker) TrackDuration(dur time.Duration) error {
 	if t.duration.IsSome() {
 		t.logWarning("Skipping TrackDuration: duration already recorded on this tracker. "+
@@ -300,6 +301,8 @@ func (t *Tracker) TrackDuration(dur time.Duration) error {
 
 // TrackFeedback tracks the feedback provided by a user for a model evaluation. If the feedback is not
 // FeedbackPositive or FeedbackNegative, returns an error and does not track anything.
+//
+// Records at most once per Tracker; further calls are ignored.
 func (t *Tracker) TrackFeedback(feedback Feedback) error {
 	if t.feedback.IsSome() {
 		t.logWarning("Skipping TrackFeedback: feedback already recorded on this tracker. "+
@@ -319,6 +322,9 @@ func (t *Tracker) TrackFeedback(feedback Feedback) error {
 }
 
 // TrackSuccess tracks a successful model evaluation.
+//
+// Records at most once per Tracker. TrackSuccess and TrackError share state;
+// only one of the two can record per Tracker, and subsequent calls are ignored.
 func (t *Tracker) TrackSuccess() error {
 	if t.success.IsSome() {
 		t.logWarning("Skipping TrackSuccess: success/error already recorded on this tracker. "+
@@ -331,6 +337,9 @@ func (t *Tracker) TrackSuccess() error {
 }
 
 // TrackError tracks an unsuccessful model evaluation.
+//
+// Records at most once per Tracker. TrackSuccess and TrackError share state;
+// only one of the two can record per Tracker, and subsequent calls are ignored.
 func (t *Tracker) TrackError() error {
 	if t.success.IsSome() {
 		t.logWarning("Skipping TrackError: success/error already recorded on this tracker. "+
@@ -343,6 +352,8 @@ func (t *Tracker) TrackError() error {
 }
 
 // TrackTimeToFirstToken tracks the time to the first token of the streamed response.
+//
+// Records at most once per Tracker; further calls are ignored.
 func (t *Tracker) TrackTimeToFirstToken(dur time.Duration) error {
 	if t.timeToFirstToken.IsSome() {
 		t.logWarning("Skipping TrackTimeToFirstToken: time-to-first-token already recorded on this tracker. "+
@@ -354,6 +365,8 @@ func (t *Tracker) TrackTimeToFirstToken(dur time.Duration) error {
 }
 
 // TrackUsage tracks the token usage for a model evaluation.
+//
+// Records at most once per Tracker; further calls are ignored.
 func (t *Tracker) TrackUsage(usage TokenUsage) error {
 	if t.tokens.IsSome() {
 		t.logWarning("Skipping TrackUsage: token usage already recorded on this tracker. "+
@@ -404,7 +417,6 @@ func measureDurationOfTask[T any, A any](
 }
 
 // GetSummary returns a summary of all metrics that have been tracked using this tracker.
-// If the same metric has been tracked multiple times, this returns the most recent value.
 func (t *Tracker) GetSummary() MetricSummary {
 	return MetricSummary{
 		Duration:         t.duration,
@@ -428,6 +440,10 @@ func (t *Tracker) GetSummary() MetricSummary {
 //  2. Any metrics that were that set in the ProviderResponse
 //     2a) If Latency was not set in the ProviderResponse's Metrics field, an automatically measured duration.
 //  3. Any token usage that was set in the ProviderResponse.
+//
+// Because each inner metric is at-most-once per Tracker, calling TrackRequest
+// twice on the same Tracker will run the task again but produce no additional
+// metric events.
 func (t *Tracker) TrackRequest(task func(c *Config) (ProviderResponse, error)) (ProviderResponse, error) {
 	usage, duration, err := measureDurationOfTask(t.stopwatch, t.config, task)
 	if err != nil {
@@ -467,6 +483,9 @@ func (t *Tracker) TrackRequest(task func(c *Config) (ProviderResponse, error)) (
 }
 
 // TrackJudgeResponse tracks the evaluation scores from a judge response.
+//
+// May be called multiple times per Tracker; each call records the scores from
+// the given response.
 func (t *Tracker) TrackJudgeResponse(response datamodel.JudgeResponse) error {
 	if !response.Success {
 		return nil

--- a/ldai/tracker.go
+++ b/ldai/tracker.go
@@ -1,11 +1,12 @@
 package ldai
 
 import (
-	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/google/uuid"
 
 	ldcommon "github.com/launchdarkly/go-sdk-common/v3"
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
@@ -31,11 +32,7 @@ const (
 )
 
 func newRunID() string {
-	b := make([]byte, 16)
-	_, _ = rand.Read(b)
-	b[6] = (b[6] & 0x0f) | 0x40
-	b[8] = (b[8] & 0x3f) | 0x80
-	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+	return uuid.New().String()
 }
 
 // TokenUsage represents the token usage returned by a model provider for a specific request.

--- a/ldai/tracker.go
+++ b/ldai/tracker.go
@@ -283,7 +283,7 @@ func TrackerFromResumptionToken(token string, sdk ServerSDK, context ldcontext.C
 // The duration in milliseconds must fit within a float64.
 func (t *Tracker) TrackDuration(dur time.Duration) error {
 	if t.duration.IsSome() {
-		t.logWarning("Duration has already been tracked for this execution. %s", t.trackData.JSONString())
+		t.logWarning("Skipping TrackDuration: duration already recorded on this tracker. Call CreateTracker on the AI Config for a new run. %s", t.trackData.JSONString())
 		return nil
 	}
 	t.duration = ldcommon.Some(dur)
@@ -294,7 +294,7 @@ func (t *Tracker) TrackDuration(dur time.Duration) error {
 // FeedbackPositive or FeedbackNegative, returns an error and does not track anything.
 func (t *Tracker) TrackFeedback(feedback Feedback) error {
 	if t.feedback.IsSome() {
-		t.logWarning("Feedback has already been tracked for this execution. %s", t.trackData.JSONString())
+		t.logWarning("Skipping TrackFeedback: feedback already recorded on this tracker. Call CreateTracker on the AI Config for a new run. %s", t.trackData.JSONString())
 		return nil
 	}
 	switch feedback {
@@ -312,7 +312,7 @@ func (t *Tracker) TrackFeedback(feedback Feedback) error {
 // TrackSuccess tracks a successful model evaluation.
 func (t *Tracker) TrackSuccess() error {
 	if t.success.IsSome() {
-		t.logWarning("Success/error has already been tracked for this execution. %s", t.trackData.JSONString())
+		t.logWarning("Skipping TrackSuccess: success/error already recorded on this tracker. Call CreateTracker on the AI Config for a new run. %s", t.trackData.JSONString())
 		return nil
 	}
 	t.success = ldcommon.Some(true)
@@ -323,7 +323,7 @@ func (t *Tracker) TrackSuccess() error {
 // TrackError tracks an unsuccessful model evaluation.
 func (t *Tracker) TrackError() error {
 	if t.success.IsSome() {
-		t.logWarning("Success/error has already been tracked for this execution. %s", t.trackData.JSONString())
+		t.logWarning("Skipping TrackError: success/error already recorded on this tracker. Call CreateTracker on the AI Config for a new run. %s", t.trackData.JSONString())
 		return nil
 	}
 	t.success = ldcommon.Some(false)
@@ -334,7 +334,7 @@ func (t *Tracker) TrackError() error {
 // TrackTimeToFirstToken tracks the time to the first token of the streamed response.
 func (t *Tracker) TrackTimeToFirstToken(dur time.Duration) error {
 	if t.timeToFirstToken.IsSome() {
-		t.logWarning("Time to first token has already been tracked for this execution. %s", t.trackData.JSONString())
+		t.logWarning("Skipping TrackTimeToFirstToken: time-to-first-token already recorded on this tracker. Call CreateTracker on the AI Config for a new run. %s", t.trackData.JSONString())
 		return nil
 	}
 	t.timeToFirstToken = ldcommon.Some(dur)
@@ -344,7 +344,7 @@ func (t *Tracker) TrackTimeToFirstToken(dur time.Duration) error {
 // TrackUsage tracks the token usage for a model evaluation.
 func (t *Tracker) TrackUsage(usage TokenUsage) error {
 	if t.tokens.IsSome() {
-		t.logWarning("Usage has already been tracked for this execution. %s", t.trackData.JSONString())
+		t.logWarning("Skipping TrackUsage: token usage already recorded on this tracker. Call CreateTracker on the AI Config for a new run. %s", t.trackData.JSONString())
 		return nil
 	}
 

--- a/ldai/tracker.go
+++ b/ldai/tracker.go
@@ -283,7 +283,8 @@ func TrackerFromResumptionToken(token string, sdk ServerSDK, context ldcontext.C
 // The duration in milliseconds must fit within a float64.
 func (t *Tracker) TrackDuration(dur time.Duration) error {
 	if t.duration.IsSome() {
-		t.logWarning("Skipping TrackDuration: duration already recorded on this tracker. Call CreateTracker on the AI Config for a new run. %s", t.trackData.JSONString())
+		t.logWarning("Skipping TrackDuration: duration already recorded on this tracker. "+
+			"Call CreateTracker on the AI Config for a new run. %s", t.trackData.JSONString())
 		return nil
 	}
 	t.duration = ldcommon.Some(dur)
@@ -294,7 +295,8 @@ func (t *Tracker) TrackDuration(dur time.Duration) error {
 // FeedbackPositive or FeedbackNegative, returns an error and does not track anything.
 func (t *Tracker) TrackFeedback(feedback Feedback) error {
 	if t.feedback.IsSome() {
-		t.logWarning("Skipping TrackFeedback: feedback already recorded on this tracker. Call CreateTracker on the AI Config for a new run. %s", t.trackData.JSONString())
+		t.logWarning("Skipping TrackFeedback: feedback already recorded on this tracker. "+
+			"Call CreateTracker on the AI Config for a new run. %s", t.trackData.JSONString())
 		return nil
 	}
 	switch feedback {
@@ -312,7 +314,8 @@ func (t *Tracker) TrackFeedback(feedback Feedback) error {
 // TrackSuccess tracks a successful model evaluation.
 func (t *Tracker) TrackSuccess() error {
 	if t.success.IsSome() {
-		t.logWarning("Skipping TrackSuccess: success/error already recorded on this tracker. Call CreateTracker on the AI Config for a new run. %s", t.trackData.JSONString())
+		t.logWarning("Skipping TrackSuccess: success/error already recorded on this tracker. "+
+			"Call CreateTracker on the AI Config for a new run. %s", t.trackData.JSONString())
 		return nil
 	}
 	t.success = ldcommon.Some(true)
@@ -323,7 +326,8 @@ func (t *Tracker) TrackSuccess() error {
 // TrackError tracks an unsuccessful model evaluation.
 func (t *Tracker) TrackError() error {
 	if t.success.IsSome() {
-		t.logWarning("Skipping TrackError: success/error already recorded on this tracker. Call CreateTracker on the AI Config for a new run. %s", t.trackData.JSONString())
+		t.logWarning("Skipping TrackError: success/error already recorded on this tracker. "+
+			"Call CreateTracker on the AI Config for a new run. %s", t.trackData.JSONString())
 		return nil
 	}
 	t.success = ldcommon.Some(false)
@@ -334,7 +338,8 @@ func (t *Tracker) TrackError() error {
 // TrackTimeToFirstToken tracks the time to the first token of the streamed response.
 func (t *Tracker) TrackTimeToFirstToken(dur time.Duration) error {
 	if t.timeToFirstToken.IsSome() {
-		t.logWarning("Skipping TrackTimeToFirstToken: time-to-first-token already recorded on this tracker. Call CreateTracker on the AI Config for a new run. %s", t.trackData.JSONString())
+		t.logWarning("Skipping TrackTimeToFirstToken: time-to-first-token already recorded on this tracker. "+
+			"Call CreateTracker on the AI Config for a new run. %s", t.trackData.JSONString())
 		return nil
 	}
 	t.timeToFirstToken = ldcommon.Some(dur)
@@ -344,7 +349,8 @@ func (t *Tracker) TrackTimeToFirstToken(dur time.Duration) error {
 // TrackUsage tracks the token usage for a model evaluation.
 func (t *Tracker) TrackUsage(usage TokenUsage) error {
 	if t.tokens.IsSome() {
-		t.logWarning("Skipping TrackUsage: token usage already recorded on this tracker. Call CreateTracker on the AI Config for a new run. %s", t.trackData.JSONString())
+		t.logWarning("Skipping TrackUsage: token usage already recorded on this tracker. "+
+			"Call CreateTracker on the AI Config for a new run. %s", t.trackData.JSONString())
 		return nil
 	}
 

--- a/ldai/tracker.go
+++ b/ldai/tracker.go
@@ -239,7 +239,7 @@ func (t *Tracker) ResumptionToken() string {
 // The duration in milliseconds must fit within a float64.
 func (t *Tracker) TrackDuration(dur time.Duration) error {
 	if t.duration.IsSome() {
-		t.logWarning("Duration has already been tracked for this execution.")
+		t.logWarning("Duration has already been tracked for this execution. %s", t.trackData.JSONString())
 		return nil
 	}
 	t.duration = ldcommon.Some(dur)
@@ -250,7 +250,7 @@ func (t *Tracker) TrackDuration(dur time.Duration) error {
 // FeedbackPositive or FeedbackNegative, returns an error and does not track anything.
 func (t *Tracker) TrackFeedback(feedback Feedback) error {
 	if t.feedback.IsSome() {
-		t.logWarning("Feedback has already been tracked for this execution.")
+		t.logWarning("Feedback has already been tracked for this execution. %s", t.trackData.JSONString())
 		return nil
 	}
 	switch feedback {
@@ -268,7 +268,7 @@ func (t *Tracker) TrackFeedback(feedback Feedback) error {
 // TrackSuccess tracks a successful model evaluation.
 func (t *Tracker) TrackSuccess() error {
 	if t.success.IsSome() {
-		t.logWarning("Success/error has already been tracked for this execution.")
+		t.logWarning("Success/error has already been tracked for this execution. %s", t.trackData.JSONString())
 		return nil
 	}
 	t.success = ldcommon.Some(true)
@@ -279,7 +279,7 @@ func (t *Tracker) TrackSuccess() error {
 // TrackError tracks an unsuccessful model evaluation.
 func (t *Tracker) TrackError() error {
 	if t.success.IsSome() {
-		t.logWarning("Success/error has already been tracked for this execution.")
+		t.logWarning("Success/error has already been tracked for this execution. %s", t.trackData.JSONString())
 		return nil
 	}
 	t.success = ldcommon.Some(false)
@@ -290,7 +290,7 @@ func (t *Tracker) TrackError() error {
 // TrackTimeToFirstToken tracks the time to the first token of the streamed response.
 func (t *Tracker) TrackTimeToFirstToken(dur time.Duration) error {
 	if t.timeToFirstToken.IsSome() {
-		t.logWarning("Time to first token has already been tracked for this execution.")
+		t.logWarning("Time to first token has already been tracked for this execution. %s", t.trackData.JSONString())
 		return nil
 	}
 	t.timeToFirstToken = ldcommon.Some(dur)
@@ -300,7 +300,7 @@ func (t *Tracker) TrackTimeToFirstToken(dur time.Duration) error {
 // TrackUsage tracks the token usage for a model evaluation.
 func (t *Tracker) TrackUsage(usage TokenUsage) error {
 	if t.tokens.IsSome() {
-		t.logWarning("Usage has already been tracked for this execution.")
+		t.logWarning("Usage has already been tracked for this execution. %s", t.trackData.JSONString())
 		return nil
 	}
 

--- a/ldai/tracker.go
+++ b/ldai/tracker.go
@@ -2,6 +2,8 @@ package ldai
 
 import (
 	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -115,17 +117,27 @@ type Stopwatch interface {
 	Stop() time.Duration
 }
 
+// resumptionPayload is the JSON structure encoded into a resumption token.
+type resumptionPayload struct {
+	RunID        string `json:"runId"`
+	ConfigKey    string `json:"configKey"`
+	VariationKey string `json:"variationKey"`
+	Version      int    `json:"version"`
+}
+
 // Tracker is used to track metrics for AI Config evaluation.
 // Unless otherwise noted, the Tracker's method are not safe for concurrent use.
 type Tracker struct {
-	key       string
-	runID     string
-	config    *Config
-	context   ldcontext.Context
-	events    EventSink
-	trackData ldvalue.Value
-	logger    interfaces.LDLoggers
-	stopwatch Stopwatch
+	key          string
+	runID        string
+	variationKey string
+	version      int
+	config       *Config
+	context      ldcontext.Context
+	events       EventSink
+	trackData    ldvalue.Value
+	logger       interfaces.LDLoggers
+	stopwatch    Stopwatch
 
 	duration         ldcommon.Option[time.Duration]
 	feedback         ldcommon.Option[Feedback]
@@ -149,9 +161,10 @@ func (d *defaultStopwatch) Stop() time.Duration {
 	return time.Since(d.start)
 }
 
-// newTracker creates a new Tracker with the specified key, event sink, config, context, and loggers.
+// newTracker creates a new Tracker with the specified runID, key, event sink, config, context, and loggers.
 func newTracker(
 	key string,
+	runID string,
 	variationKey string,
 	version int,
 	events EventSink,
@@ -159,13 +172,14 @@ func newTracker(
 	ctx ldcontext.Context,
 	loggers interfaces.LDLoggers,
 ) *Tracker {
-	return newTrackerWithStopwatch(key, variationKey, version, events, config, ctx, loggers, &defaultStopwatch{})
+	return newTrackerWithStopwatch(key, runID, variationKey, version, events, config, ctx, loggers, &defaultStopwatch{})
 }
 
-// newTrackerWithStopwatch creates a new Tracker with the specified key, event sink, config, context, loggers, and
-// stopwatch. This method is used for testing purposes.
+// newTrackerWithStopwatch creates a new Tracker with the specified runID, key, event sink, config, context, loggers,
+// and stopwatch. This method is used for testing purposes.
 func newTrackerWithStopwatch(
 	key string,
+	runID string,
 	variationKey string,
 	version int,
 	events EventSink,
@@ -178,8 +192,6 @@ func newTrackerWithStopwatch(
 		panic("LaunchDarkly SDK programmer error: config must never be nil")
 	}
 
-	runID := newRunID()
-
 	trackData := ldvalue.ObjectBuild().
 		Set("runId", ldvalue.String(runID)).
 		Set("variationKey", ldvalue.String(variationKey)).
@@ -190,20 +202,36 @@ func newTrackerWithStopwatch(
 		Build()
 
 	return &Tracker{
-		key:       key,
-		runID:     runID,
-		config:    config,
-		trackData: trackData,
-		events:    events,
-		context:   ctx,
-		logger:    loggers,
-		stopwatch: stopwatch,
+		key:          key,
+		runID:        runID,
+		variationKey: variationKey,
+		version:      version,
+		config:       config,
+		trackData:    trackData,
+		events:       events,
+		context:      ctx,
+		logger:       loggers,
+		stopwatch:    stopwatch,
 	}
 }
 
 func (t *Tracker) logWarning(format string, args ...interface{}) {
 	prefix := "AI Config tracker for '" + t.key + "': "
 	t.logger.Warnf(prefix+format, args...)
+}
+
+// ResumptionToken returns a URL-safe Base64-encoded token that can be used to reconstruct a tracker
+// in a different process (e.g., for deferred feedback). The token contains the runId, configKey,
+// variationKey, and version. It does not contain modelName or providerName.
+func (t *Tracker) ResumptionToken() string {
+	payload := resumptionPayload{
+		RunID:        t.runID,
+		ConfigKey:    t.key,
+		VariationKey: t.variationKey,
+		Version:      t.version,
+	}
+	jsonBytes, _ := json.Marshal(payload)
+	return base64.RawURLEncoding.EncodeToString(jsonBytes)
 }
 
 // TrackDuration tracks the duration of a task. For example, the duration of a model evaluation request may be

--- a/ldai/tracker_test.go
+++ b/ldai/tracker_test.go
@@ -50,14 +50,16 @@ func TestTracker_NewDoesNotPanicWithConfig(t *testing.T) {
 }
 
 func makeTrackData(configKey, variationKey string, version int, config *Config, runId string) ldvalue.Value {
-	return ldvalue.ObjectBuild().
+	builder := ldvalue.ObjectBuild().
 		Set("runId", ldvalue.String(runId)).
-		Set("variationKey", ldvalue.String(variationKey)).
 		Set("configKey", ldvalue.String(configKey)).
 		Set("version", ldvalue.Int(version)).
 		Set("providerName", ldvalue.String(config.ProviderName())).
-		Set("modelName", ldvalue.String(config.ModelName())).
-		Build()
+		Set("modelName", ldvalue.String(config.ModelName()))
+	if variationKey != "" {
+		builder.Set("variationKey", ldvalue.String(variationKey))
+	}
+	return builder.Build()
 }
 
 func extractRunId(t *testing.T, events *mockEvents) string {

--- a/ldai/tracker_test.go
+++ b/ldai/tracker_test.go
@@ -1,6 +1,8 @@
 package ldai
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -37,13 +39,13 @@ func (m *mockEvents) TrackMetric(eventName string, context ldcontext.Context, me
 
 func TestTracker_NewPanicsWithNilConfig(t *testing.T) {
 	assert.Panics(t, func() {
-		newTracker("key", "variationKey", 1, newMockEvents(), nil, ldcontext.New("key"), nil)
+		newTracker("key", newRunID(), "variationKey", 1, newMockEvents(), nil, ldcontext.New("key"), nil)
 	})
 }
 
 func TestTracker_NewDoesNotPanicWithConfig(t *testing.T) {
 	assert.NotPanics(t, func() {
-		newTracker("key", "variationKey", 1, newMockEvents(), &Config{}, ldcontext.New("key"), nil)
+		newTracker("key", newRunID(), "variationKey", 1, newMockEvents(), &Config{}, ldcontext.New("key"), nil)
 	})
 }
 
@@ -69,7 +71,7 @@ func extractRunId(t *testing.T, events *mockEvents) string {
 func TestTracker_TrackSuccess(t *testing.T) {
 	events := newMockEvents()
 	config := &Config{}
-	tracker := newTracker("key", "variationKey", 1, events, config, ldcontext.New("key"), nil)
+	tracker := newTracker("key", newRunID(), "variationKey", 1, events, config, ldcontext.New("key"), nil)
 	assert.NoError(t, tracker.TrackSuccess())
 
 	runId := extractRunId(t, events)
@@ -88,7 +90,7 @@ func TestTracker_TrackSuccess(t *testing.T) {
 func TestTracker_TrackError(t *testing.T) {
 	events := newMockEvents()
 	config := &Config{}
-	tracker := newTracker("key", "variationKey", 2, events, config, ldcontext.New("key"), nil)
+	tracker := newTracker("key", newRunID(), "variationKey", 2, events, config, ldcontext.New("key"), nil)
 	assert.NoError(t, tracker.TrackError())
 
 	runId := extractRunId(t, events)
@@ -107,7 +109,7 @@ func TestTracker_TrackError(t *testing.T) {
 func TestTracker_TrackRequest(t *testing.T) {
 	events := newMockEvents()
 	config := &Config{}
-	tracker := newTracker("key", "variationKey", 3, events, config, ldcontext.New("key"), nil)
+	tracker := newTracker("key", newRunID(), "variationKey", 3, events, config, ldcontext.New("key"), nil)
 
 	expectedResponse := ProviderResponse{
 		Usage: TokenUsage{
@@ -169,7 +171,7 @@ func TestTracker_TrackRequestReceivesConfig(t *testing.T) {
 		Enable().
 		Build()
 
-	tracker := newTracker("key", "variationKey", 4, events, &expectedConfig, ldcontext.New("key"), nil)
+	tracker := newTracker("key", newRunID(), "variationKey", 4, events, &expectedConfig, ldcontext.New("key"), nil)
 
 	var gotConfig *Config
 	_, _ = tracker.TrackRequest(func(c *Config) (ProviderResponse, error) {
@@ -193,7 +195,7 @@ func TestTracker_LatencyMeasuredIfNotProvided(t *testing.T) {
 	config := &Config{}
 
 	tracker := newTrackerWithStopwatch(
-		"key", "variationKey", 5, events, config, ldcontext.New("key"), nil, mockStopwatch(42*time.Millisecond))
+		"key", newRunID(), "variationKey", 5, events, config, ldcontext.New("key"), nil, mockStopwatch(42*time.Millisecond))
 
 	expectedResponse := ProviderResponse{
 		Usage: TokenUsage{
@@ -217,7 +219,7 @@ func TestTracker_LatencyMeasuredIfNotProvided(t *testing.T) {
 func TestTracker_TrackDuration(t *testing.T) {
 	events := newMockEvents()
 	config := &Config{}
-	tracker := newTracker("key", "variationKey", 6, events, config, ldcontext.New("key"), nil)
+	tracker := newTracker("key", newRunID(), "variationKey", 6, events, config, ldcontext.New("key"), nil)
 
 	assert.NoError(t, tracker.TrackDuration(time.Millisecond*10))
 
@@ -236,7 +238,7 @@ func TestTracker_TrackFeedback(t *testing.T) {
 	t.Run("positive feedback", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", "variationKey", 7, events, config, ldcontext.New("key"), nil)
+		tracker := newTracker("key", newRunID(), "variationKey", 7, events, config, ldcontext.New("key"), nil)
 
 		assert.NoError(t, tracker.TrackFeedback(FeedbackPositive))
 
@@ -254,7 +256,7 @@ func TestTracker_TrackFeedback(t *testing.T) {
 	t.Run("negative feedback", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", "variationKey", 7, events, config, ldcontext.New("key"), nil)
+		tracker := newTracker("key", newRunID(), "variationKey", 7, events, config, ldcontext.New("key"), nil)
 
 		assert.NoError(t, tracker.TrackFeedback(FeedbackNegative))
 
@@ -272,7 +274,7 @@ func TestTracker_TrackFeedback(t *testing.T) {
 	t.Run("invalid feedback returns error", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", "variationKey", 7, events, config, ldcontext.New("key"), nil)
+		tracker := newTracker("key", newRunID(), "variationKey", 7, events, config, ldcontext.New("key"), nil)
 
 		assert.Error(t, tracker.TrackFeedback("not a valid feedback value"))
 		assert.Empty(t, events.events)
@@ -283,7 +285,7 @@ func TestTracker_TrackUsage(t *testing.T) {
 	t.Run("only one field set, only one event", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", "variationKey", 8, events, config, ldcontext.New("key"), nil)
+		tracker := newTracker("key", newRunID(), "variationKey", 8, events, config, ldcontext.New("key"), nil)
 
 		assert.NoError(t, tracker.TrackUsage(TokenUsage{
 			Total: 42,
@@ -303,7 +305,7 @@ func TestTracker_TrackUsage(t *testing.T) {
 	t.Run("all fields set, all events", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", "variationKey", 9, events, config, ldcontext.New("key"), nil)
+		tracker := newTracker("key", newRunID(), "variationKey", 9, events, config, ldcontext.New("key"), nil)
 
 		assert.NoError(t, tracker.TrackUsage(TokenUsage{
 			Total:  42,
@@ -340,7 +342,7 @@ func TestTracker_TrackUsage(t *testing.T) {
 func TestTracker_GetSummary(t *testing.T) {
 	t.Run("empty summary when nothing tracked", func(t *testing.T) {
 		events := newMockEvents()
-		tracker := newTracker("key", "variationKey", 10, events, &Config{}, ldcontext.New("key"), nil)
+		tracker := newTracker("key", newRunID(), "variationKey", 10, events, &Config{}, ldcontext.New("key"), nil)
 
 		summary := tracker.GetSummary()
 
@@ -353,7 +355,7 @@ func TestTracker_GetSummary(t *testing.T) {
 
 	t.Run("first duration is returned", func(t *testing.T) {
 		events := newMockEvents()
-		tracker := newTracker("key", "variationKey", 11, events, &Config{}, ldcontext.New("key"), nil)
+		tracker := newTracker("key", newRunID(), "variationKey", 11, events, &Config{}, ldcontext.New("key"), events.log.Loggers)
 
 		_ = tracker.TrackDuration(time.Millisecond * 10)
 		_ = tracker.TrackDuration(time.Millisecond * 20)
@@ -366,7 +368,7 @@ func TestTracker_GetSummary(t *testing.T) {
 
 	t.Run("first feedback is returned", func(t *testing.T) {
 		events := newMockEvents()
-		tracker := newTracker("key", "variationKey", 12, events, &Config{}, ldcontext.New("key"), nil)
+		tracker := newTracker("key", newRunID(), "variationKey", 12, events, &Config{}, ldcontext.New("key"), events.log.Loggers)
 
 		_ = tracker.TrackFeedback(FeedbackPositive)
 		_ = tracker.TrackFeedback(FeedbackNegative)
@@ -379,7 +381,7 @@ func TestTracker_GetSummary(t *testing.T) {
 
 	t.Run("success status tracked correctly", func(t *testing.T) {
 		events := newMockEvents()
-		tracker := newTracker("key", "variationKey", 13, events, &Config{}, ldcontext.New("key"), nil)
+		tracker := newTracker("key", newRunID(), "variationKey", 13, events, &Config{}, ldcontext.New("key"), nil)
 
 		_ = tracker.TrackSuccess()
 
@@ -391,7 +393,7 @@ func TestTracker_GetSummary(t *testing.T) {
 
 	t.Run("time to first token is returned", func(t *testing.T) {
 		events := newMockEvents()
-		tracker := newTracker("key", "variationKey", 14, events, &Config{}, ldcontext.New("key"), nil)
+		tracker := newTracker("key", newRunID(), "variationKey", 14, events, &Config{}, ldcontext.New("key"), nil)
 
 		duration := time.Millisecond * 30
 		_ = tracker.TrackTimeToFirstToken(duration)
@@ -404,7 +406,7 @@ func TestTracker_GetSummary(t *testing.T) {
 
 	t.Run("token usage is returned", func(t *testing.T) {
 		events := newMockEvents()
-		tracker := newTracker("key", "variationKey", 15, events, &Config{}, ldcontext.New("key"), nil)
+		tracker := newTracker("key", newRunID(), "variationKey", 15, events, &Config{}, ldcontext.New("key"), nil)
 
 		usage := TokenUsage{
 			Total:  100,
@@ -423,7 +425,7 @@ func TestTracker_GetSummary(t *testing.T) {
 func TestTracker_RunIdPresentInTrackData(t *testing.T) {
 	events := newMockEvents()
 	config := &Config{}
-	tracker := newTracker("key", "variationKey", 1, events, config, ldcontext.New("key"), nil)
+	tracker := newTracker("key", newRunID(), "variationKey", 1, events, config, ldcontext.New("key"), nil)
 	_ = tracker.TrackSuccess()
 
 	require.NotEmpty(t, events.events)
@@ -436,7 +438,7 @@ func TestTracker_AtMostOnce(t *testing.T) {
 	t.Run("TrackDuration only tracks once", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", "variationKey", 1, events, config, ldcontext.New("key"), nil)
+		tracker := newTracker("key", newRunID(), "variationKey", 1, events, config, ldcontext.New("key"), events.log.Loggers)
 
 		assert.NoError(t, tracker.TrackDuration(10*time.Millisecond))
 		assert.NoError(t, tracker.TrackDuration(20*time.Millisecond))
@@ -453,7 +455,7 @@ func TestTracker_AtMostOnce(t *testing.T) {
 	t.Run("TrackTimeToFirstToken only tracks once", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", "variationKey", 1, events, config, ldcontext.New("key"), nil)
+		tracker := newTracker("key", newRunID(), "variationKey", 1, events, config, ldcontext.New("key"), events.log.Loggers)
 
 		assert.NoError(t, tracker.TrackTimeToFirstToken(10*time.Millisecond))
 		assert.NoError(t, tracker.TrackTimeToFirstToken(20*time.Millisecond))
@@ -470,7 +472,7 @@ func TestTracker_AtMostOnce(t *testing.T) {
 	t.Run("TrackUsage only tracks once", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", "variationKey", 1, events, config, ldcontext.New("key"), nil)
+		tracker := newTracker("key", newRunID(), "variationKey", 1, events, config, ldcontext.New("key"), events.log.Loggers)
 
 		assert.NoError(t, tracker.TrackUsage(TokenUsage{Total: 10}))
 		assert.NoError(t, tracker.TrackUsage(TokenUsage{Total: 20}))
@@ -487,7 +489,7 @@ func TestTracker_AtMostOnce(t *testing.T) {
 	t.Run("TrackFeedback only tracks once", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", "variationKey", 1, events, config, ldcontext.New("key"), nil)
+		tracker := newTracker("key", newRunID(), "variationKey", 1, events, config, ldcontext.New("key"), events.log.Loggers)
 
 		assert.NoError(t, tracker.TrackFeedback(FeedbackPositive))
 		assert.NoError(t, tracker.TrackFeedback(FeedbackNegative))
@@ -504,7 +506,7 @@ func TestTracker_AtMostOnce(t *testing.T) {
 	t.Run("TrackSuccess only tracks once", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", "variationKey", 1, events, config, ldcontext.New("key"), nil)
+		tracker := newTracker("key", newRunID(), "variationKey", 1, events, config, ldcontext.New("key"), events.log.Loggers)
 
 		assert.NoError(t, tracker.TrackSuccess())
 		assert.NoError(t, tracker.TrackSuccess())
@@ -521,7 +523,7 @@ func TestTracker_AtMostOnce(t *testing.T) {
 	t.Run("TrackError only tracks once", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", "variationKey", 1, events, config, ldcontext.New("key"), nil)
+		tracker := newTracker("key", newRunID(), "variationKey", 1, events, config, ldcontext.New("key"), events.log.Loggers)
 
 		assert.NoError(t, tracker.TrackError())
 		assert.NoError(t, tracker.TrackError())
@@ -538,12 +540,58 @@ func TestTracker_AtMostOnce(t *testing.T) {
 	t.Run("TrackSuccess then TrackError only tracks success", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", "variationKey", 1, events, config, ldcontext.New("key"), nil)
+		tracker := newTracker("key", newRunID(), "variationKey", 1, events, config, ldcontext.New("key"), events.log.Loggers)
 
 		assert.NoError(t, tracker.TrackSuccess())
 		assert.NoError(t, tracker.TrackError())
 
 		assert.Equal(t, 1, len(events.events))
 		assert.Equal(t, "$ld:ai:generation:success", events.events[0].name)
+	})
+}
+
+func TestTracker_ResumptionToken(t *testing.T) {
+	t.Run("produces valid base64url-encoded token", func(t *testing.T) {
+		events := newMockEvents()
+		config := &Config{}
+		tracker := newTracker("my-config", newRunID(), "var-1", 3, events, config, ldcontext.New("key"), nil)
+
+		token := tracker.ResumptionToken()
+		assert.NotEmpty(t, token)
+
+		// Decode and verify
+		decoded, err := base64.RawURLEncoding.DecodeString(token)
+		require.NoError(t, err)
+
+		var payload struct {
+			RunID        string `json:"runId"`
+			ConfigKey    string `json:"configKey"`
+			VariationKey string `json:"variationKey"`
+			Version      int    `json:"version"`
+		}
+		require.NoError(t, json.Unmarshal(decoded, &payload))
+
+		assert.NotEmpty(t, payload.RunID)
+		assert.Equal(t, "my-config", payload.ConfigKey)
+		assert.Equal(t, "var-1", payload.VariationKey)
+		assert.Equal(t, 3, payload.Version)
+	})
+
+	t.Run("does not include modelName or providerName", func(t *testing.T) {
+		events := newMockEvents()
+		config := NewConfig().WithModelName("gpt-4").WithProviderName("openai").Build()
+		tracker := newTracker("key", newRunID(), "var", 1, events, &config, ldcontext.New("key"), nil)
+
+		token := tracker.ResumptionToken()
+		decoded, err := base64.RawURLEncoding.DecodeString(token)
+		require.NoError(t, err)
+
+		var raw map[string]interface{}
+		require.NoError(t, json.Unmarshal(decoded, &raw))
+
+		_, hasModel := raw["modelName"]
+		_, hasProvider := raw["providerName"]
+		assert.False(t, hasModel, "token should not contain modelName")
+		assert.False(t, hasProvider, "token should not contain providerName")
 	})
 }

--- a/ldai/tracker_test.go
+++ b/ldai/tracker_test.go
@@ -39,13 +39,13 @@ func (m *mockEvents) TrackMetric(eventName string, context ldcontext.Context, me
 
 func TestTracker_NewPanicsWithNilConfig(t *testing.T) {
 	assert.Panics(t, func() {
-		newTracker("key", newRunID(), "variationKey", 1, newMockEvents(), nil, ldcontext.New("key"), nil)
+		newTracker(newMockEvents(), newRunID(), "key", "variationKey", 1, ldcontext.New("key"), nil, nil)
 	})
 }
 
 func TestTracker_NewDoesNotPanicWithConfig(t *testing.T) {
 	assert.NotPanics(t, func() {
-		newTracker("key", newRunID(), "variationKey", 1, newMockEvents(), &Config{}, ldcontext.New("key"), nil)
+		newTracker(newMockEvents(), newRunID(), "key", "variationKey", 1, ldcontext.New("key"), &Config{}, nil)
 	})
 }
 
@@ -71,7 +71,7 @@ func extractRunId(t *testing.T, events *mockEvents) string {
 func TestTracker_TrackSuccess(t *testing.T) {
 	events := newMockEvents()
 	config := &Config{}
-	tracker := newTracker("key", newRunID(), "variationKey", 1, events, config, ldcontext.New("key"), nil)
+	tracker := newTracker(events, newRunID(), "key", "variationKey", 1, ldcontext.New("key"), config, nil)
 	assert.NoError(t, tracker.TrackSuccess())
 
 	runId := extractRunId(t, events)
@@ -90,7 +90,7 @@ func TestTracker_TrackSuccess(t *testing.T) {
 func TestTracker_TrackError(t *testing.T) {
 	events := newMockEvents()
 	config := &Config{}
-	tracker := newTracker("key", newRunID(), "variationKey", 2, events, config, ldcontext.New("key"), nil)
+	tracker := newTracker(events, newRunID(), "key", "variationKey", 2, ldcontext.New("key"), config, nil)
 	assert.NoError(t, tracker.TrackError())
 
 	runId := extractRunId(t, events)
@@ -109,7 +109,7 @@ func TestTracker_TrackError(t *testing.T) {
 func TestTracker_TrackRequest(t *testing.T) {
 	events := newMockEvents()
 	config := &Config{}
-	tracker := newTracker("key", newRunID(), "variationKey", 3, events, config, ldcontext.New("key"), nil)
+	tracker := newTracker(events, newRunID(), "key", "variationKey", 3, ldcontext.New("key"), config, nil)
 
 	expectedResponse := ProviderResponse{
 		Usage: TokenUsage{
@@ -171,7 +171,7 @@ func TestTracker_TrackRequestReceivesConfig(t *testing.T) {
 		Enable().
 		Build()
 
-	tracker := newTracker("key", newRunID(), "variationKey", 4, events, &expectedConfig, ldcontext.New("key"), nil)
+	tracker := newTracker(events, newRunID(), "key", "variationKey", 4, ldcontext.New("key"), &expectedConfig, nil)
 
 	var gotConfig *Config
 	_, _ = tracker.TrackRequest(func(c *Config) (ProviderResponse, error) {
@@ -195,7 +195,7 @@ func TestTracker_LatencyMeasuredIfNotProvided(t *testing.T) {
 	config := &Config{}
 
 	tracker := newTrackerWithStopwatch(
-		"key", newRunID(), "variationKey", 5, events, config, ldcontext.New("key"), nil, mockStopwatch(42*time.Millisecond))
+		events, newRunID(), "key", "variationKey", 5, ldcontext.New("key"), config, nil, mockStopwatch(42*time.Millisecond))
 
 	expectedResponse := ProviderResponse{
 		Usage: TokenUsage{
@@ -219,7 +219,7 @@ func TestTracker_LatencyMeasuredIfNotProvided(t *testing.T) {
 func TestTracker_TrackDuration(t *testing.T) {
 	events := newMockEvents()
 	config := &Config{}
-	tracker := newTracker("key", newRunID(), "variationKey", 6, events, config, ldcontext.New("key"), nil)
+	tracker := newTracker(events, newRunID(), "key", "variationKey", 6, ldcontext.New("key"), config, nil)
 
 	assert.NoError(t, tracker.TrackDuration(time.Millisecond*10))
 
@@ -238,7 +238,7 @@ func TestTracker_TrackFeedback(t *testing.T) {
 	t.Run("positive feedback", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", newRunID(), "variationKey", 7, events, config, ldcontext.New("key"), nil)
+		tracker := newTracker(events, newRunID(), "key", "variationKey", 7, ldcontext.New("key"), config, nil)
 
 		assert.NoError(t, tracker.TrackFeedback(FeedbackPositive))
 
@@ -256,7 +256,7 @@ func TestTracker_TrackFeedback(t *testing.T) {
 	t.Run("negative feedback", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", newRunID(), "variationKey", 7, events, config, ldcontext.New("key"), nil)
+		tracker := newTracker(events, newRunID(), "key", "variationKey", 7, ldcontext.New("key"), config, nil)
 
 		assert.NoError(t, tracker.TrackFeedback(FeedbackNegative))
 
@@ -274,7 +274,7 @@ func TestTracker_TrackFeedback(t *testing.T) {
 	t.Run("invalid feedback returns error", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", newRunID(), "variationKey", 7, events, config, ldcontext.New("key"), nil)
+		tracker := newTracker(events, newRunID(), "key", "variationKey", 7, ldcontext.New("key"), config, nil)
 
 		assert.Error(t, tracker.TrackFeedback("not a valid feedback value"))
 		assert.Empty(t, events.events)
@@ -285,7 +285,7 @@ func TestTracker_TrackUsage(t *testing.T) {
 	t.Run("only one field set, only one event", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", newRunID(), "variationKey", 8, events, config, ldcontext.New("key"), nil)
+		tracker := newTracker(events, newRunID(), "key", "variationKey", 8, ldcontext.New("key"), config, nil)
 
 		assert.NoError(t, tracker.TrackUsage(TokenUsage{
 			Total: 42,
@@ -305,7 +305,7 @@ func TestTracker_TrackUsage(t *testing.T) {
 	t.Run("all fields set, all events", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", newRunID(), "variationKey", 9, events, config, ldcontext.New("key"), nil)
+		tracker := newTracker(events, newRunID(), "key", "variationKey", 9, ldcontext.New("key"), config, nil)
 
 		assert.NoError(t, tracker.TrackUsage(TokenUsage{
 			Total:  42,
@@ -342,7 +342,7 @@ func TestTracker_TrackUsage(t *testing.T) {
 func TestTracker_GetSummary(t *testing.T) {
 	t.Run("empty summary when nothing tracked", func(t *testing.T) {
 		events := newMockEvents()
-		tracker := newTracker("key", newRunID(), "variationKey", 10, events, &Config{}, ldcontext.New("key"), nil)
+		tracker := newTracker(events, newRunID(), "key", "variationKey", 10, ldcontext.New("key"), &Config{}, nil)
 
 		summary := tracker.GetSummary()
 
@@ -355,7 +355,7 @@ func TestTracker_GetSummary(t *testing.T) {
 
 	t.Run("first duration is returned", func(t *testing.T) {
 		events := newMockEvents()
-		tracker := newTracker("key", newRunID(), "variationKey", 11, events, &Config{}, ldcontext.New("key"), events.log.Loggers)
+		tracker := newTracker(events, newRunID(), "key", "variationKey", 11, ldcontext.New("key"), &Config{}, events.log.Loggers)
 
 		_ = tracker.TrackDuration(time.Millisecond * 10)
 		_ = tracker.TrackDuration(time.Millisecond * 20)
@@ -368,7 +368,7 @@ func TestTracker_GetSummary(t *testing.T) {
 
 	t.Run("first feedback is returned", func(t *testing.T) {
 		events := newMockEvents()
-		tracker := newTracker("key", newRunID(), "variationKey", 12, events, &Config{}, ldcontext.New("key"), events.log.Loggers)
+		tracker := newTracker(events, newRunID(), "key", "variationKey", 12, ldcontext.New("key"), &Config{}, events.log.Loggers)
 
 		_ = tracker.TrackFeedback(FeedbackPositive)
 		_ = tracker.TrackFeedback(FeedbackNegative)
@@ -381,7 +381,7 @@ func TestTracker_GetSummary(t *testing.T) {
 
 	t.Run("success status tracked correctly", func(t *testing.T) {
 		events := newMockEvents()
-		tracker := newTracker("key", newRunID(), "variationKey", 13, events, &Config{}, ldcontext.New("key"), nil)
+		tracker := newTracker(events, newRunID(), "key", "variationKey", 13, ldcontext.New("key"), &Config{}, nil)
 
 		_ = tracker.TrackSuccess()
 
@@ -393,7 +393,7 @@ func TestTracker_GetSummary(t *testing.T) {
 
 	t.Run("time to first token is returned", func(t *testing.T) {
 		events := newMockEvents()
-		tracker := newTracker("key", newRunID(), "variationKey", 14, events, &Config{}, ldcontext.New("key"), nil)
+		tracker := newTracker(events, newRunID(), "key", "variationKey", 14, ldcontext.New("key"), &Config{}, nil)
 
 		duration := time.Millisecond * 30
 		_ = tracker.TrackTimeToFirstToken(duration)
@@ -406,7 +406,7 @@ func TestTracker_GetSummary(t *testing.T) {
 
 	t.Run("token usage is returned", func(t *testing.T) {
 		events := newMockEvents()
-		tracker := newTracker("key", newRunID(), "variationKey", 15, events, &Config{}, ldcontext.New("key"), nil)
+		tracker := newTracker(events, newRunID(), "key", "variationKey", 15, ldcontext.New("key"), &Config{}, nil)
 
 		usage := TokenUsage{
 			Total:  100,
@@ -425,7 +425,7 @@ func TestTracker_GetSummary(t *testing.T) {
 func TestTracker_RunIdPresentInTrackData(t *testing.T) {
 	events := newMockEvents()
 	config := &Config{}
-	tracker := newTracker("key", newRunID(), "variationKey", 1, events, config, ldcontext.New("key"), nil)
+	tracker := newTracker(events, newRunID(), "key", "variationKey", 1, ldcontext.New("key"), config, nil)
 	_ = tracker.TrackSuccess()
 
 	require.NotEmpty(t, events.events)
@@ -438,7 +438,7 @@ func TestTracker_AtMostOnce(t *testing.T) {
 	t.Run("TrackDuration only tracks once", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", newRunID(), "variationKey", 1, events, config, ldcontext.New("key"), events.log.Loggers)
+		tracker := newTracker(events, newRunID(), "key", "variationKey", 1, ldcontext.New("key"), config, events.log.Loggers)
 
 		assert.NoError(t, tracker.TrackDuration(10*time.Millisecond))
 		assert.NoError(t, tracker.TrackDuration(20*time.Millisecond))
@@ -455,7 +455,7 @@ func TestTracker_AtMostOnce(t *testing.T) {
 	t.Run("TrackTimeToFirstToken only tracks once", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", newRunID(), "variationKey", 1, events, config, ldcontext.New("key"), events.log.Loggers)
+		tracker := newTracker(events, newRunID(), "key", "variationKey", 1, ldcontext.New("key"), config, events.log.Loggers)
 
 		assert.NoError(t, tracker.TrackTimeToFirstToken(10*time.Millisecond))
 		assert.NoError(t, tracker.TrackTimeToFirstToken(20*time.Millisecond))
@@ -472,7 +472,7 @@ func TestTracker_AtMostOnce(t *testing.T) {
 	t.Run("TrackUsage only tracks once", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", newRunID(), "variationKey", 1, events, config, ldcontext.New("key"), events.log.Loggers)
+		tracker := newTracker(events, newRunID(), "key", "variationKey", 1, ldcontext.New("key"), config, events.log.Loggers)
 
 		assert.NoError(t, tracker.TrackUsage(TokenUsage{Total: 10}))
 		assert.NoError(t, tracker.TrackUsage(TokenUsage{Total: 20}))
@@ -489,7 +489,7 @@ func TestTracker_AtMostOnce(t *testing.T) {
 	t.Run("TrackFeedback only tracks once", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", newRunID(), "variationKey", 1, events, config, ldcontext.New("key"), events.log.Loggers)
+		tracker := newTracker(events, newRunID(), "key", "variationKey", 1, ldcontext.New("key"), config, events.log.Loggers)
 
 		assert.NoError(t, tracker.TrackFeedback(FeedbackPositive))
 		assert.NoError(t, tracker.TrackFeedback(FeedbackNegative))
@@ -506,7 +506,7 @@ func TestTracker_AtMostOnce(t *testing.T) {
 	t.Run("TrackSuccess only tracks once", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", newRunID(), "variationKey", 1, events, config, ldcontext.New("key"), events.log.Loggers)
+		tracker := newTracker(events, newRunID(), "key", "variationKey", 1, ldcontext.New("key"), config, events.log.Loggers)
 
 		assert.NoError(t, tracker.TrackSuccess())
 		assert.NoError(t, tracker.TrackSuccess())
@@ -523,7 +523,7 @@ func TestTracker_AtMostOnce(t *testing.T) {
 	t.Run("TrackError only tracks once", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", newRunID(), "variationKey", 1, events, config, ldcontext.New("key"), events.log.Loggers)
+		tracker := newTracker(events, newRunID(), "key", "variationKey", 1, ldcontext.New("key"), config, events.log.Loggers)
 
 		assert.NoError(t, tracker.TrackError())
 		assert.NoError(t, tracker.TrackError())
@@ -540,7 +540,7 @@ func TestTracker_AtMostOnce(t *testing.T) {
 	t.Run("TrackSuccess then TrackError only tracks success", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("key", newRunID(), "variationKey", 1, events, config, ldcontext.New("key"), events.log.Loggers)
+		tracker := newTracker(events, newRunID(), "key", "variationKey", 1, ldcontext.New("key"), config, events.log.Loggers)
 
 		assert.NoError(t, tracker.TrackSuccess())
 		assert.NoError(t, tracker.TrackError())
@@ -554,7 +554,7 @@ func TestTracker_ResumptionToken(t *testing.T) {
 	t.Run("produces valid base64url-encoded token", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
-		tracker := newTracker("my-config", newRunID(), "var-1", 3, events, config, ldcontext.New("key"), nil)
+		tracker := newTracker(events, newRunID(), "my-config", "var-1", 3, ldcontext.New("key"), config, nil)
 
 		token := tracker.ResumptionToken()
 		assert.NotEmpty(t, token)
@@ -580,7 +580,7 @@ func TestTracker_ResumptionToken(t *testing.T) {
 	t.Run("does not include modelName or providerName", func(t *testing.T) {
 		events := newMockEvents()
 		config := NewConfig().WithModelName("gpt-4").WithProviderName("openai").Build()
-		tracker := newTracker("key", newRunID(), "var", 1, events, &config, ldcontext.New("key"), nil)
+		tracker := newTracker(events, newRunID(), "key", "var", 1, ldcontext.New("key"), &config, nil)
 
 		token := tracker.ResumptionToken()
 		decoded, err := base64.RawURLEncoding.DecodeString(token)

--- a/ldai/tracker_test.go
+++ b/ldai/tracker_test.go
@@ -47,8 +47,9 @@ func TestTracker_NewDoesNotPanicWithConfig(t *testing.T) {
 	})
 }
 
-func makeTrackData(configKey, variationKey string, version int, config *Config) ldvalue.Value {
+func makeTrackData(configKey, variationKey string, version int, config *Config, runId string) ldvalue.Value {
 	return ldvalue.ObjectBuild().
+		Set("runId", ldvalue.String(runId)).
 		Set("variationKey", ldvalue.String(variationKey)).
 		Set("configKey", ldvalue.String(configKey)).
 		Set("version", ldvalue.Int(version)).
@@ -57,18 +58,27 @@ func makeTrackData(configKey, variationKey string, version int, config *Config) 
 		Build()
 }
 
+func extractRunId(t *testing.T, events *mockEvents) string {
+	t.Helper()
+	require.NotEmpty(t, events.events, "expected at least one event to extract runId")
+	runId := events.events[0].data.GetByKey("runId").StringValue()
+	require.NotEmpty(t, runId, "expected runId to be non-empty")
+	return runId
+}
+
 func TestTracker_TrackSuccess(t *testing.T) {
 	events := newMockEvents()
 	config := &Config{}
 	tracker := newTracker("key", "variationKey", 1, events, config, ldcontext.New("key"), nil)
 	assert.NoError(t, tracker.TrackSuccess())
 
+	runId := extractRunId(t, events)
 	expectedEvents := []trackEvent{
 		{
 			name:        "$ld:ai:generation:success",
 			context:     ldcontext.New("key"),
 			metricValue: 1.0,
-			data:        makeTrackData("key", "variationKey", 1, config),
+			data:        makeTrackData("key", "variationKey", 1, config, runId),
 		},
 	}
 
@@ -81,12 +91,13 @@ func TestTracker_TrackError(t *testing.T) {
 	tracker := newTracker("key", "variationKey", 2, events, config, ldcontext.New("key"), nil)
 	assert.NoError(t, tracker.TrackError())
 
+	runId := extractRunId(t, events)
 	expectedEvents := []trackEvent{
 		{
 			name:        "$ld:ai:generation:error",
 			context:     ldcontext.New("key"),
 			metricValue: 1.0,
-			data:        makeTrackData("key", "variationKey", 2, config),
+			data:        makeTrackData("key", "variationKey", 2, config, runId),
 		},
 	}
 
@@ -115,30 +126,31 @@ func TestTracker_TrackRequest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedResponse, r)
 
+	runId := extractRunId(t, events)
 	expectedEvents := []trackEvent{
 		{
 			name:        "$ld:ai:generation:success",
 			context:     ldcontext.New("key"),
 			metricValue: 1,
-			data:        makeTrackData("key", "variationKey", 3, config),
+			data:        makeTrackData("key", "variationKey", 3, config, runId),
 		},
 		{
 			name:        "$ld:ai:duration:total",
 			context:     ldcontext.New("key"),
 			metricValue: 10.0,
-			data:        makeTrackData("key", "variationKey", 3, config),
+			data:        makeTrackData("key", "variationKey", 3, config, runId),
 		},
 		{
 			name:        "$ld:ai:tokens:total",
 			context:     ldcontext.New("key"),
 			metricValue: 1,
-			data:        makeTrackData("key", "variationKey", 3, config),
+			data:        makeTrackData("key", "variationKey", 3, config, runId),
 		},
 		{
 			name:        "$ld:ai:tokens:ttf",
 			context:     ldcontext.New("key"),
 			metricValue: 42.0,
-			data:        makeTrackData("key", "variationKey", 3, config),
+			data:        makeTrackData("key", "variationKey", 3, config, runId),
 		},
 	}
 
@@ -209,40 +221,62 @@ func TestTracker_TrackDuration(t *testing.T) {
 
 	assert.NoError(t, tracker.TrackDuration(time.Millisecond*10))
 
+	runId := extractRunId(t, events)
 	expectedEvent := trackEvent{
 		name:        "$ld:ai:duration:total",
 		context:     ldcontext.New("key"),
 		metricValue: 10.0,
-		data:        makeTrackData("key", "variationKey", 6, config),
+		data:        makeTrackData("key", "variationKey", 6, config, runId),
 	}
 
 	assert.ElementsMatch(t, []trackEvent{expectedEvent}, events.events)
 }
 
 func TestTracker_TrackFeedback(t *testing.T) {
-	events := newMockEvents()
-	config := &Config{}
-	tracker := newTracker("key", "variationKey", 7, events, config, ldcontext.New("key"), nil)
+	t.Run("positive feedback", func(t *testing.T) {
+		events := newMockEvents()
+		config := &Config{}
+		tracker := newTracker("key", "variationKey", 7, events, config, ldcontext.New("key"), nil)
 
-	assert.NoError(t, tracker.TrackFeedback(FeedbackPositive))
-	assert.NoError(t, tracker.TrackFeedback(FeedbackNegative))
-	assert.Error(t, tracker.TrackFeedback("not a valid feedback value"))
+		assert.NoError(t, tracker.TrackFeedback(FeedbackPositive))
 
-	expectedPositiveEvent := trackEvent{
-		name:        "$ld:ai:feedback:user:positive",
-		context:     ldcontext.New("key"),
-		metricValue: 1.0,
-		data:        makeTrackData("key", "variationKey", 7, config),
-	}
+		runId := extractRunId(t, events)
+		expectedEvent := trackEvent{
+			name:        "$ld:ai:feedback:user:positive",
+			context:     ldcontext.New("key"),
+			metricValue: 1.0,
+			data:        makeTrackData("key", "variationKey", 7, config, runId),
+		}
 
-	expectedNegativeEvent := trackEvent{
-		name:        "$ld:ai:feedback:user:negative",
-		context:     ldcontext.New("key"),
-		metricValue: 1.0,
-		data:        makeTrackData("key", "variationKey", 7, config),
-	}
+		assert.ElementsMatch(t, []trackEvent{expectedEvent}, events.events)
+	})
 
-	assert.ElementsMatch(t, []trackEvent{expectedPositiveEvent, expectedNegativeEvent}, events.events)
+	t.Run("negative feedback", func(t *testing.T) {
+		events := newMockEvents()
+		config := &Config{}
+		tracker := newTracker("key", "variationKey", 7, events, config, ldcontext.New("key"), nil)
+
+		assert.NoError(t, tracker.TrackFeedback(FeedbackNegative))
+
+		runId := extractRunId(t, events)
+		expectedEvent := trackEvent{
+			name:        "$ld:ai:feedback:user:negative",
+			context:     ldcontext.New("key"),
+			metricValue: 1.0,
+			data:        makeTrackData("key", "variationKey", 7, config, runId),
+		}
+
+		assert.ElementsMatch(t, []trackEvent{expectedEvent}, events.events)
+	})
+
+	t.Run("invalid feedback returns error", func(t *testing.T) {
+		events := newMockEvents()
+		config := &Config{}
+		tracker := newTracker("key", "variationKey", 7, events, config, ldcontext.New("key"), nil)
+
+		assert.Error(t, tracker.TrackFeedback("not a valid feedback value"))
+		assert.Empty(t, events.events)
+	})
 }
 
 func TestTracker_TrackUsage(t *testing.T) {
@@ -255,11 +289,12 @@ func TestTracker_TrackUsage(t *testing.T) {
 			Total: 42,
 		}))
 
+		runId := extractRunId(t, events)
 		expectedEvent := trackEvent{
 			name:        "$ld:ai:tokens:total",
 			context:     ldcontext.New("key"),
 			metricValue: 42.0,
-			data:        makeTrackData("key", "variationKey", 8, config),
+			data:        makeTrackData("key", "variationKey", 8, config, runId),
 		}
 
 		assert.ElementsMatch(t, []trackEvent{expectedEvent}, events.events)
@@ -276,25 +311,26 @@ func TestTracker_TrackUsage(t *testing.T) {
 			Output: 22,
 		}))
 
+		runId := extractRunId(t, events)
 		expectedTotal := trackEvent{
 			name:        "$ld:ai:tokens:total",
 			context:     ldcontext.New("key"),
 			metricValue: 42.0,
-			data:        makeTrackData("key", "variationKey", 9, config),
+			data:        makeTrackData("key", "variationKey", 9, config, runId),
 		}
 
 		expectedInput := trackEvent{
 			name:        "$ld:ai:tokens:input",
 			context:     ldcontext.New("key"),
 			metricValue: 20.0,
-			data:        makeTrackData("key", "variationKey", 9, config),
+			data:        makeTrackData("key", "variationKey", 9, config, runId),
 		}
 
 		expectedOutput := trackEvent{
 			name:        "$ld:ai:tokens:output",
 			context:     ldcontext.New("key"),
 			metricValue: 22.0,
-			data:        makeTrackData("key", "variationKey", 9, config),
+			data:        makeTrackData("key", "variationKey", 9, config, runId),
 		}
 
 		assert.ElementsMatch(t, []trackEvent{expectedTotal, expectedInput, expectedOutput}, events.events)
@@ -315,7 +351,7 @@ func TestTracker_GetSummary(t *testing.T) {
 		assert.True(t, summary.TimeToFirstToken.IsNone())
 	})
 
-	t.Run("latest duration is returned", func(t *testing.T) {
+	t.Run("first duration is returned", func(t *testing.T) {
 		events := newMockEvents()
 		tracker := newTracker("key", "variationKey", 11, events, &Config{}, ldcontext.New("key"), nil)
 
@@ -325,10 +361,10 @@ func TestTracker_GetSummary(t *testing.T) {
 		summary := tracker.GetSummary()
 
 		assert.True(t, summary.Duration.IsSome())
-		assert.Equal(t, time.Millisecond*20, summary.Duration.Unwrap())
+		assert.Equal(t, time.Millisecond*10, summary.Duration.Unwrap())
 	})
 
-	t.Run("latest feedback is returned", func(t *testing.T) {
+	t.Run("first feedback is returned", func(t *testing.T) {
 		events := newMockEvents()
 		tracker := newTracker("key", "variationKey", 12, events, &Config{}, ldcontext.New("key"), nil)
 
@@ -338,7 +374,7 @@ func TestTracker_GetSummary(t *testing.T) {
 		summary := tracker.GetSummary()
 
 		assert.True(t, summary.Feedback.IsSome())
-		assert.Equal(t, FeedbackNegative, summary.Feedback.Unwrap())
+		assert.Equal(t, FeedbackPositive, summary.Feedback.Unwrap())
 	})
 
 	t.Run("success status tracked correctly", func(t *testing.T) {
@@ -351,13 +387,6 @@ func TestTracker_GetSummary(t *testing.T) {
 
 		assert.True(t, summary.Success.IsSome())
 		assert.True(t, summary.Success.Unwrap())
-
-		_ = tracker.TrackError()
-
-		summary = tracker.GetSummary()
-
-		assert.True(t, summary.Success.IsSome())
-		assert.False(t, summary.Success.Unwrap())
 	})
 
 	t.Run("time to first token is returned", func(t *testing.T) {
@@ -388,5 +417,133 @@ func TestTracker_GetSummary(t *testing.T) {
 
 		assert.True(t, summary.Tokens.IsSome())
 		assert.Equal(t, usage, summary.Tokens.Unwrap())
+	})
+}
+
+func TestTracker_RunIdPresentInTrackData(t *testing.T) {
+	events := newMockEvents()
+	config := &Config{}
+	tracker := newTracker("key", "variationKey", 1, events, config, ldcontext.New("key"), nil)
+	_ = tracker.TrackSuccess()
+
+	require.NotEmpty(t, events.events)
+	data := events.events[0].data
+	runId := data.GetByKey("runId").StringValue()
+	assert.NotEmpty(t, runId, "runId should be present and non-empty in track data")
+}
+
+func TestTracker_AtMostOnce(t *testing.T) {
+	t.Run("TrackDuration only tracks once", func(t *testing.T) {
+		events := newMockEvents()
+		config := &Config{}
+		tracker := newTracker("key", "variationKey", 1, events, config, ldcontext.New("key"), nil)
+
+		assert.NoError(t, tracker.TrackDuration(10*time.Millisecond))
+		assert.NoError(t, tracker.TrackDuration(20*time.Millisecond))
+
+		count := 0
+		for _, e := range events.events {
+			if e.name == "$ld:ai:duration:total" {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count, "TrackDuration should only emit one event")
+	})
+
+	t.Run("TrackTimeToFirstToken only tracks once", func(t *testing.T) {
+		events := newMockEvents()
+		config := &Config{}
+		tracker := newTracker("key", "variationKey", 1, events, config, ldcontext.New("key"), nil)
+
+		assert.NoError(t, tracker.TrackTimeToFirstToken(10*time.Millisecond))
+		assert.NoError(t, tracker.TrackTimeToFirstToken(20*time.Millisecond))
+
+		count := 0
+		for _, e := range events.events {
+			if e.name == "$ld:ai:tokens:ttf" {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count, "TrackTimeToFirstToken should only emit one event")
+	})
+
+	t.Run("TrackUsage only tracks once", func(t *testing.T) {
+		events := newMockEvents()
+		config := &Config{}
+		tracker := newTracker("key", "variationKey", 1, events, config, ldcontext.New("key"), nil)
+
+		assert.NoError(t, tracker.TrackUsage(TokenUsage{Total: 10}))
+		assert.NoError(t, tracker.TrackUsage(TokenUsage{Total: 20}))
+
+		count := 0
+		for _, e := range events.events {
+			if e.name == "$ld:ai:tokens:total" {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count, "TrackUsage should only emit one event")
+	})
+
+	t.Run("TrackFeedback only tracks once", func(t *testing.T) {
+		events := newMockEvents()
+		config := &Config{}
+		tracker := newTracker("key", "variationKey", 1, events, config, ldcontext.New("key"), nil)
+
+		assert.NoError(t, tracker.TrackFeedback(FeedbackPositive))
+		assert.NoError(t, tracker.TrackFeedback(FeedbackNegative))
+
+		count := 0
+		for _, e := range events.events {
+			if e.name == "$ld:ai:feedback:user:positive" || e.name == "$ld:ai:feedback:user:negative" {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count, "TrackFeedback should only emit one event")
+	})
+
+	t.Run("TrackSuccess only tracks once", func(t *testing.T) {
+		events := newMockEvents()
+		config := &Config{}
+		tracker := newTracker("key", "variationKey", 1, events, config, ldcontext.New("key"), nil)
+
+		assert.NoError(t, tracker.TrackSuccess())
+		assert.NoError(t, tracker.TrackSuccess())
+
+		count := 0
+		for _, e := range events.events {
+			if e.name == "$ld:ai:generation:success" {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count, "TrackSuccess should only emit one event")
+	})
+
+	t.Run("TrackError only tracks once", func(t *testing.T) {
+		events := newMockEvents()
+		config := &Config{}
+		tracker := newTracker("key", "variationKey", 1, events, config, ldcontext.New("key"), nil)
+
+		assert.NoError(t, tracker.TrackError())
+		assert.NoError(t, tracker.TrackError())
+
+		count := 0
+		for _, e := range events.events {
+			if e.name == "$ld:ai:generation:error" {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count, "TrackError should only emit one event")
+	})
+
+	t.Run("TrackSuccess then TrackError only tracks success", func(t *testing.T) {
+		events := newMockEvents()
+		config := &Config{}
+		tracker := newTracker("key", "variationKey", 1, events, config, ldcontext.New("key"), nil)
+
+		assert.NoError(t, tracker.TrackSuccess())
+		assert.NoError(t, tracker.TrackError())
+
+		assert.Equal(t, 1, len(events.events))
+		assert.Equal(t, "$ld:ai:generation:success", events.events[0].name)
 	})
 }


### PR DESCRIPTION
## Summary

- **Per-execution runId**: Every tracker includes a unique `runId` in all track event data for billing isolation and deduplication
- **At-most-once semantics**: Each metric type (duration, tokens, feedback, success/error, time-to-first-token) can only be tracked once per tracker instance; subsequent calls are dropped with a warning
- **`Config.CreateTracker()` factory**: Enabled configs carry a factory method that returns a new `*Tracker` with a fresh `runId` on each call. Returns `nil` for disabled or manually-built configs.
- **`Tracker.ResumptionToken()`**: Returns a URL-safe Base64-encoded (no padding) JSON token containing `{runId, configKey, variationKey, version}` for cross-process tracker reconstruction. Does not include `modelName` or `providerName`.
- **`Client.CreateTracker(token, context)`**: Reconstructs a tracker from a resumption token with a different context, reusing the original `runId`. `modelName` and `providerName` are empty strings on reconstructed trackers.
- **Test fixes**: Fixed 9 pre-existing nil logger panics in at-most-once and GetSummary tests

## Test plan

- [x] `Config.CreateTracker()` returns nil for manually-built configs
- [x] `Config.CreateTracker()` returns nil for disabled evaluated configs
- [x] `Config.CreateTracker()` returns a working tracker for enabled configs
- [x] Each `CreateTracker()` call produces a tracker with a unique runId
- [x] Factory-created trackers carry correct metadata (configKey, variationKey, version, modelName, providerName)
- [x] `JudgeConfig` also carries a factory on enabled configs
- [x] `ResumptionToken()` produces valid base64url-encoded token with correct fields
- [x] Token does not include modelName or providerName
- [x] Round-trip: create tracker → token → reconstruct → same runId and token
- [x] Reconstructed tracker uses the new context and has empty model/provider
- [x] Invalid tokens (bad base64, bad JSON, partial) return appropriate errors
- [x] All existing tests pass (ldai + ldai/judge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk due to breaking API changes (config methods no longer return a `*Tracker`) and changed analytics semantics (new `runId`, at-most-once metric emission, and cross-process tracker reconstruction). These changes directly affect event payloads and downstream metrics/billing correlation.
> 
> **Overview**
> **Refactors AI config evaluation to decouple tracking from fetch results.** `CompletionConfig`/`JudgeConfig` now return only a `Config`, and tracking is started via `Config.CreateTracker()` (README and tests updated accordingly).
> 
> **Adds per-execution `runId` and resumable tracking.** Trackers now include a UUID `runId` in all emitted metric data, expose `Tracker.ResumptionToken()` for cross-process continuation, and add `Client.CreateTracker(token, context)`/`TrackerFromResumptionToken` to reconstruct a tracker with a new context.
> 
> **Changes metric emission semantics.** Most `Tracker` metric methods (`TrackDuration`, `TrackUsage`, `TrackFeedback`, `TrackSuccess`/`TrackError`, `TrackTimeToFirstToken`) become *at-most-once* per tracker with warnings on repeated calls; only judge score tracking remains multi-call. `Config` now carries an internal tracker factory so even default/error-path configs can still create a tracker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a56c4f22008cf6825f0750d104bab91be887f08c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->