### PR TITLE
feat: Rename TrackUsage to TrackTokens

### DIFF
--- a/ldai/judge/judge.go
+++ b/ldai/judge/judge.go
@@ -21,7 +21,7 @@ type Config interface {
 
 type Tracker interface {
 	TrackJudgeResponse(response datamodel.JudgeResponse) error
-	TrackUsage(usage ldai.TokenUsage) error
+	TrackTokens(usage ldai.TokenUsage) error
 }
 
 type StructuredResponse struct {
@@ -91,7 +91,7 @@ func (j *Judge) Evaluate(input, output string, samplingRate float64) (*datamodel
 	}
 
 	if response.Usage.Total > 0 || response.Usage.Input > 0 || response.Usage.Output > 0 {
-		_ = j.tracker.TrackUsage(response.Usage)
+		_ = j.tracker.TrackTokens(response.Usage)
 	}
 
 	result := j.parseResponse(response.Content)

--- a/ldai/judge/judge_test.go
+++ b/ldai/judge/judge_test.go
@@ -51,7 +51,7 @@ func (m *mockTracker) TrackJudgeResponse(response datamodel.JudgeResponse) error
 	return nil
 }
 
-func (m *mockTracker) TrackUsage(usage ldai.TokenUsage) error {
+func (m *mockTracker) TrackTokens(usage ldai.TokenUsage) error {
 	m.usages = append(m.usages, usage)
 	return nil
 }

--- a/ldai/tracker.go
+++ b/ldai/tracker.go
@@ -406,6 +406,8 @@ func (t *Tracker) TrackTokens(usage TokenUsage) error {
 	return nil
 }
 
+// TrackUsage tracks token usage.
+//
 // Deprecated: Use TrackTokens instead.
 func (t *Tracker) TrackUsage(usage TokenUsage) error {
 	return t.TrackTokens(usage)

--- a/ldai/tracker.go
+++ b/ldai/tracker.go
@@ -364,12 +364,12 @@ func (t *Tracker) TrackTimeToFirstToken(dur time.Duration) error {
 	return t.events.TrackMetric(timeToFirstToken, t.context, float64(dur.Milliseconds()), t.trackData)
 }
 
-// TrackUsage tracks the token usage for a model evaluation.
+// TrackTokens tracks the token usage for a model evaluation.
 //
 // Records at most once per Tracker; further calls are ignored.
-func (t *Tracker) TrackUsage(usage TokenUsage) error {
+func (t *Tracker) TrackTokens(usage TokenUsage) error {
 	if t.tokens.IsSome() {
-		t.logWarning("Skipping TrackUsage: token usage already recorded on this tracker. "+
+		t.logWarning("Skipping TrackTokens: token usage already recorded on this tracker. "+
 			"Call CreateTracker on the AI Config for a new run. %s", t.trackData.JSONString())
 		return nil
 	}
@@ -404,6 +404,11 @@ func (t *Tracker) TrackUsage(usage TokenUsage) error {
 	}
 
 	return nil
+}
+
+// Deprecated: Use TrackTokens instead.
+func (t *Tracker) TrackUsage(usage TokenUsage) error {
+	return t.TrackTokens(usage)
 }
 
 func measureDurationOfTask[T any, A any](
@@ -475,8 +480,8 @@ func (t *Tracker) TrackRequest(task func(c *Config) (ProviderResponse, error)) (
 	}
 
 	if usage.Usage.Set() {
-		// TrackUsage logs errors.
-		_ = t.TrackUsage(usage.Usage)
+		// TrackTokens logs errors.
+		_ = t.TrackTokens(usage.Usage)
 	}
 
 	return usage, nil

--- a/ldai/tracker_test.go
+++ b/ldai/tracker_test.go
@@ -283,13 +283,13 @@ func TestTracker_TrackFeedback(t *testing.T) {
 	})
 }
 
-func TestTracker_TrackUsage(t *testing.T) {
+func TestTracker_TrackTokens(t *testing.T) {
 	t.Run("only one field set, only one event", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
 		tracker := newTracker(events, newRunID(), "key", "variationKey", 8, ldcontext.New("key"), config, nil)
 
-		assert.NoError(t, tracker.TrackUsage(TokenUsage{
+		assert.NoError(t, tracker.TrackTokens(TokenUsage{
 			Total: 42,
 		}))
 
@@ -309,7 +309,7 @@ func TestTracker_TrackUsage(t *testing.T) {
 		config := &Config{}
 		tracker := newTracker(events, newRunID(), "key", "variationKey", 9, ldcontext.New("key"), config, nil)
 
-		assert.NoError(t, tracker.TrackUsage(TokenUsage{
+		assert.NoError(t, tracker.TrackTokens(TokenUsage{
 			Total:  42,
 			Input:  20,
 			Output: 22,
@@ -415,7 +415,7 @@ func TestTracker_GetSummary(t *testing.T) {
 			Input:  40,
 			Output: 60,
 		}
-		_ = tracker.TrackUsage(usage)
+		_ = tracker.TrackTokens(usage)
 
 		summary := tracker.GetSummary()
 
@@ -471,13 +471,13 @@ func TestTracker_AtMostOnce(t *testing.T) {
 		assert.Equal(t, 1, count, "TrackTimeToFirstToken should only emit one event")
 	})
 
-	t.Run("TrackUsage only tracks once", func(t *testing.T) {
+	t.Run("TrackTokens only tracks once", func(t *testing.T) {
 		events := newMockEvents()
 		config := &Config{}
 		tracker := newTracker(events, newRunID(), "key", "variationKey", 1, ldcontext.New("key"), config, events.log.Loggers)
 
-		assert.NoError(t, tracker.TrackUsage(TokenUsage{Total: 10}))
-		assert.NoError(t, tracker.TrackUsage(TokenUsage{Total: 20}))
+		assert.NoError(t, tracker.TrackTokens(TokenUsage{Total: 10}))
+		assert.NoError(t, tracker.TrackTokens(TokenUsage{Total: 20}))
 
 		count := 0
 		for _, e := range events.events {
@@ -485,7 +485,7 @@ func TestTracker_AtMostOnce(t *testing.T) {
 				count++
 			}
 		}
-		assert.Equal(t, 1, count, "TrackUsage should only emit one event")
+		assert.Equal(t, 1, count, "TrackTokens should only emit one event")
 	})
 
 	t.Run("TrackFeedback only tracks once", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Renames `Tracker.TrackUsage` → `Tracker.TrackTokens` to align with AITRACK spec requirement 1.1.7
- Keeps a deprecated `TrackUsage` shim that delegates to `TrackTokens` for backwards compatibility
- All internal call sites updated to use `TrackTokens`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (ldai + judge packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a public API rename (`TrackUsage`→`TrackTokens`) that can break external `Tracker` implementations (notably the `judge.Tracker` interface), though the core `ldai.Tracker` keeps a deprecated `TrackUsage` wrapper for backward compatibility.
> 
> **Overview**
> Renames token-usage tracking across the SDK from `TrackUsage` to **`TrackTokens`**, updating internal call sites (including judge evaluation) and associated tests.
> 
> Adds a deprecated `Tracker.TrackUsage` shim that delegates to `TrackTokens`, while updating log messages/comments and ensuring `TrackRequest` and judge flows record token metrics via the new method name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 964a5a6e5e74409c16d2bc30b9dd4ff9b0814959. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->