### PR TITLE
test: Wire FDv1 Fallback Directive contract-test capability

### DIFF
--- a/.github/workflows/common_ci.yml
+++ b/.github/workflows/common_ci.yml
@@ -66,7 +66,7 @@ jobs:
           enable_persistence_tests: 'true'
           test_service_port: ${{ env.TEST_SERVICE_PORT }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          version: v3.0.0-alpha.5
+          version: v3.0.0-alpha.6
 
       - name: Upload test service logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/common_ci.yml
+++ b/.github/workflows/common_ci.yml
@@ -66,7 +66,7 @@ jobs:
           enable_persistence_tests: 'true'
           test_service_port: ${{ env.TEST_SERVICE_PORT }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          version: v3.0.0-alpha.3
+          version: v3.0.0-alpha.5
 
       - name: Upload test service logs
         uses: actions/upload-artifact@v4

--- a/testservice/sdk_client_entity.go
+++ b/testservice/sdk_client_entity.go
@@ -409,6 +409,14 @@ func makeSDKConfig(config servicedef.SDKConfigParams, sdkLog ldlog.Loggers) (ld.
 			dataSystemBuilder.Initializers(initializers...)
 		}
 
+		// Prefer the explicit FDv1Fallback config (sdk-test-harness PR #336+); fall back to
+		// the legacy convention of deriving an FDv1 fallback URL from a polling synchronizer
+		// in the synchronizer list, which is what older harness releases (<= v2.35.0) send.
+		var fdv1FallbackPolling *servicedef.SDKConfigPollingParams
+		if config.DataSystem.FDv1Fallback != nil {
+			fdv1FallbackPolling = config.DataSystem.FDv1Fallback
+		}
+
 		if config.DataSystem.Synchronizers != nil && len(*config.DataSystem.Synchronizers) > 0 {
 			synchronizers := make([]subsystems.ComponentConfigurer[subsystems.DataSynchronizer], 0, len(*config.DataSystem.Synchronizers))
 
@@ -418,6 +426,10 @@ func makeSDKConfig(config servicedef.SDKConfigParams, sdkLog ldlog.Loggers) (ld.
 					return ret, err
 				}
 				synchronizers = append(synchronizers, builder)
+
+				if fdv1FallbackPolling == nil && syncConfig.Polling != nil {
+					fdv1FallbackPolling = syncConfig.Polling
+				}
 			}
 
 			dataSystemBuilder.Synchronizers(synchronizers...)
@@ -426,13 +438,13 @@ func makeSDKConfig(config servicedef.SDKConfigParams, sdkLog ldlog.Loggers) (ld.
 		// FDv1Fallback configures the SDK's FDv1 Fallback Synchronizer -- engaged only in
 		// response to a server-directed FDv1 Fallback Directive, separate from the FDv2
 		// Primary/Fallback synchronizer chain above.
-		if config.DataSystem.FDv1Fallback != nil {
+		if fdv1FallbackPolling != nil {
 			fdv1Fallback := ldcomponents.FDv1PollingDataSourceV2()
-			if config.DataSystem.FDv1Fallback.PollIntervalMS != nil {
-				fdv1Fallback.PollInterval(time.Millisecond * time.Duration(*config.DataSystem.FDv1Fallback.PollIntervalMS))
+			if fdv1FallbackPolling.PollIntervalMS != nil {
+				fdv1Fallback.PollInterval(time.Millisecond * time.Duration(*fdv1FallbackPolling.PollIntervalMS))
 			}
-			if config.DataSystem.FDv1Fallback.BaseURI != "" {
-				fdv1Fallback.BaseURI(config.DataSystem.FDv1Fallback.BaseURI)
+			if fdv1FallbackPolling.BaseURI != "" {
+				fdv1Fallback.BaseURI(fdv1FallbackPolling.BaseURI)
 			}
 			if config.DataSystem.PayloadFilter != nil {
 				fdv1Fallback.PayloadFilter(*config.DataSystem.PayloadFilter)

--- a/testservice/sdk_client_entity.go
+++ b/testservice/sdk_client_entity.go
@@ -303,7 +303,6 @@ func (c *SDKClientEntity) migrationOperation(p servicedef.MigrationOperationPara
 				reader = strings.NewReader(*val)
 			}
 			response, err := http.Post(endpoint, "application/json", reader)
-
 			if err != nil {
 				return nil, err
 			}
@@ -328,7 +327,6 @@ func (c *SDKClientEntity) migrationOperation(p servicedef.MigrationOperationPara
 				reader = strings.NewReader(*val)
 			}
 			response, err := http.Post(endpoint, "application/json", reader)
-
 			if err != nil {
 				return nil, err
 			}
@@ -360,7 +358,6 @@ func (c *SDKClientEntity) migrationOperation(p servicedef.MigrationOperationPara
 	builder.Write(writeEndpoint(p.OldEndpoint), writeEndpoint(p.NewEndpoint))
 
 	migrator, err := builder.Build()
-
 	if err != nil {
 		return nil, err
 	}
@@ -426,7 +423,7 @@ func makeSDKConfig(config servicedef.SDKConfigParams, sdkLog ldlog.Loggers) (ld.
 			dataSystemBuilder.Synchronizers(synchronizers...)
 		}
 
-		// FDv1Fallback configures the SDK's FDv1 Fallback Synchronizer — engaged only in
+		// FDv1Fallback configures the SDK's FDv1 Fallback Synchronizer -- engaged only in
 		// response to a server-directed FDv1 Fallback Directive, separate from the FDv2
 		// Primary/Fallback synchronizer chain above.
 		if config.DataSystem.FDv1Fallback != nil {

--- a/testservice/sdk_client_entity.go
+++ b/testservice/sdk_client_entity.go
@@ -413,7 +413,6 @@ func makeSDKConfig(config servicedef.SDKConfigParams, sdkLog ldlog.Loggers) (ld.
 		}
 
 		if config.DataSystem.Synchronizers != nil && len(*config.DataSystem.Synchronizers) > 0 {
-			var fdv1Fallback *ldcomponents.FDv1PollingDataSourceBuilderV2
 			synchronizers := make([]subsystems.ComponentConfigurer[subsystems.DataSynchronizer], 0, len(*config.DataSystem.Synchronizers))
 
 			for _, syncConfig := range *config.DataSystem.Synchronizers {
@@ -422,27 +421,26 @@ func makeSDKConfig(config servicedef.SDKConfigParams, sdkLog ldlog.Loggers) (ld.
 					return ret, err
 				}
 				synchronizers = append(synchronizers, builder)
-
-				// Set up FDv1 fallback from the last polling synchronizer we find (matches Python behavior)
-				if syncConfig.Polling != nil {
-					fdv1Fallback = ldcomponents.FDv1PollingDataSourceV2()
-					if syncConfig.Polling.PollIntervalMS != nil {
-						fdv1Fallback.PollInterval(time.Millisecond * time.Duration(*syncConfig.Polling.PollIntervalMS))
-					}
-					if syncConfig.Polling.BaseURI != "" {
-						fdv1Fallback.BaseURI(syncConfig.Polling.BaseURI)
-					}
-					if config.DataSystem.PayloadFilter != nil {
-						fdv1Fallback.PayloadFilter(*config.DataSystem.PayloadFilter)
-					}
-				}
-			}
-
-			if fdv1Fallback != nil {
-				dataSystemBuilder.FDv1CompatibleSynchronizer(fdv1Fallback)
 			}
 
 			dataSystemBuilder.Synchronizers(synchronizers...)
+		}
+
+		// FDv1Fallback configures the SDK's FDv1 Fallback Synchronizer — engaged only in
+		// response to a server-directed FDv1 Fallback Directive, separate from the FDv2
+		// Primary/Fallback synchronizer chain above.
+		if config.DataSystem.FDv1Fallback != nil {
+			fdv1Fallback := ldcomponents.FDv1PollingDataSourceV2()
+			if config.DataSystem.FDv1Fallback.PollIntervalMS != nil {
+				fdv1Fallback.PollInterval(time.Millisecond * time.Duration(*config.DataSystem.FDv1Fallback.PollIntervalMS))
+			}
+			if config.DataSystem.FDv1Fallback.BaseURI != "" {
+				fdv1Fallback.BaseURI(config.DataSystem.FDv1Fallback.BaseURI)
+			}
+			if config.DataSystem.PayloadFilter != nil {
+				fdv1Fallback.PayloadFilter(*config.DataSystem.PayloadFilter)
+			}
+			dataSystemBuilder.FDv1CompatibleSynchronizer(fdv1Fallback)
 		}
 
 		if config.DataSystem.Store != nil && config.DataSystem.Store.PersistentDataStore != nil {

--- a/testservice/sdk_client_entity.go
+++ b/testservice/sdk_client_entity.go
@@ -409,14 +409,6 @@ func makeSDKConfig(config servicedef.SDKConfigParams, sdkLog ldlog.Loggers) (ld.
 			dataSystemBuilder.Initializers(initializers...)
 		}
 
-		// Prefer the explicit FDv1Fallback config (sdk-test-harness PR #336+); fall back to
-		// the legacy convention of deriving an FDv1 fallback URL from a polling synchronizer
-		// in the synchronizer list, which is what older harness releases (<= v2.35.0) send.
-		var fdv1FallbackPolling *servicedef.SDKConfigPollingParams
-		if config.DataSystem.FDv1Fallback != nil {
-			fdv1FallbackPolling = config.DataSystem.FDv1Fallback
-		}
-
 		if config.DataSystem.Synchronizers != nil && len(*config.DataSystem.Synchronizers) > 0 {
 			synchronizers := make([]subsystems.ComponentConfigurer[subsystems.DataSynchronizer], 0, len(*config.DataSystem.Synchronizers))
 
@@ -426,10 +418,6 @@ func makeSDKConfig(config servicedef.SDKConfigParams, sdkLog ldlog.Loggers) (ld.
 					return ret, err
 				}
 				synchronizers = append(synchronizers, builder)
-
-				if fdv1FallbackPolling == nil && syncConfig.Polling != nil {
-					fdv1FallbackPolling = syncConfig.Polling
-				}
 			}
 
 			dataSystemBuilder.Synchronizers(synchronizers...)
@@ -438,13 +426,13 @@ func makeSDKConfig(config servicedef.SDKConfigParams, sdkLog ldlog.Loggers) (ld.
 		// FDv1Fallback configures the SDK's FDv1 Fallback Synchronizer -- engaged only in
 		// response to a server-directed FDv1 Fallback Directive, separate from the FDv2
 		// Primary/Fallback synchronizer chain above.
-		if fdv1FallbackPolling != nil {
+		if config.DataSystem.FDv1Fallback != nil {
 			fdv1Fallback := ldcomponents.FDv1PollingDataSourceV2()
-			if fdv1FallbackPolling.PollIntervalMS != nil {
-				fdv1Fallback.PollInterval(time.Millisecond * time.Duration(*fdv1FallbackPolling.PollIntervalMS))
+			if config.DataSystem.FDv1Fallback.PollIntervalMS != nil {
+				fdv1Fallback.PollInterval(time.Millisecond * time.Duration(*config.DataSystem.FDv1Fallback.PollIntervalMS))
 			}
-			if fdv1FallbackPolling.BaseURI != "" {
-				fdv1Fallback.BaseURI(fdv1FallbackPolling.BaseURI)
+			if config.DataSystem.FDv1Fallback.BaseURI != "" {
+				fdv1Fallback.BaseURI(config.DataSystem.FDv1Fallback.BaseURI)
 			}
 			if config.DataSystem.PayloadFilter != nil {
 				fdv1Fallback.PayloadFilter(*config.DataSystem.PayloadFilter)

--- a/testservice/service.go
+++ b/testservice/service.go
@@ -50,6 +50,7 @@ var capabilities = []string{
 	servicedef.CapabilityPersistentDataStoreDynamoDB,
 	servicedef.CapabilityFlagChangeListeners,
 	servicedef.CapabilityFlagValueChangeListeners,
+	servicedef.CapabilityFDv1Fallback,
 }
 
 // gets the specified environment variable, or the default if not set

--- a/testservice/servicedef/sdk_config.go
+++ b/testservice/servicedef/sdk_config.go
@@ -38,11 +38,12 @@ const (
 )
 
 type DataSystem struct {
-	Store         *DataStore        `json:"store,omitempty"`
-	StoreMode     DataStoreMode     `json:"storeMode"`
-	Initializers  []DataInitializer `json:"initializers"`
-	Synchronizers *Synchronizers    `json:"synchronizers,omitempty"`
-	PayloadFilter *string           `json:"payloadFilter,omitempty"`
+	Store         *DataStore              `json:"store,omitempty"`
+	StoreMode     DataStoreMode           `json:"storeMode"`
+	Initializers  []DataInitializer       `json:"initializers"`
+	Synchronizers *Synchronizers          `json:"synchronizers,omitempty"`
+	FDv1Fallback  *SDKConfigPollingParams `json:"fdv1Fallback,omitempty"`
+	PayloadFilter *string                 `json:"payloadFilter,omitempty"`
 }
 
 type DataStore struct {

--- a/testservice/servicedef/service_params.go
+++ b/testservice/servicedef/service_params.go
@@ -31,6 +31,7 @@ const (
 	CapabilityPersistentDataStoreDynamoDB = "persistent-data-store-dynamodb"
 	CapabilityFlagChangeListeners         = "flag-change-listeners"
 	CapabilityFlagValueChangeListeners    = "flag-value-change-listeners"
+	CapabilityFDv1Fallback                = "fdv1-fallback"
 )
 
 type StatusRep struct {


### PR DESCRIPTION
The contract harness now treats the FDv1 Fallback Synchronizer as a
distinct field on the data system (DataSystem.FDv1Fallback) rather than
deriving it from the FDv2 Primary/Fallback synchronizer chain, and gates
the directive subtests on a new fdv1-fallback capability.

Wire the test service to match:
  - declare the fdv1-fallback capability
  - accept the new fdv1Fallback config field
  - build FDv1CompatibleSynchronizer from that field directly, instead
    of coercing it out of the last polling synchronizer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the contract-test harness/service configuration and CI version pin, with no production runtime impact beyond test behavior.
> 
> **Overview**
> Updates contract test CI to run against `contract-tests` `v3.0.0-alpha.6`.
> 
> Extends the Go contract test service to advertise a new `fdv1-fallback` capability, accept `dataSystem.fdv1Fallback` in SDK config, and configure `FDv1CompatibleSynchronizer` directly from that field (removing the prior behavior of inferring FDv1 fallback from the synchronizer chain).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 765612e163f32b304c72ef3b5ac5c551d9fe0caf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->