### PR TITLE
fix: remove non-spec Silent/Catastrophe fields from FDv2 Goodbye

### DIFF
--- a/internal/datasourcev2/streaming_data_source.go
+++ b/internal/datasourcev2/streaming_data_source.go
@@ -264,9 +264,7 @@ func (sp *StreamProcessor) consumeStream(stream *es.Stream, resultChan chan<- su
 					break
 				}
 
-				if !goodbye.Silent {
-					sp.loggers.Errorf("SSE server received error: %s (%v)", goodbye.Reason, goodbye.Catastrophe)
-				}
+				sp.loggers.Infof("SSE server sent goodbye: %s", goodbye.Reason)
 			case subsystems.EventError:
 				var errorData subsystems.Error
 				err := json.Unmarshal([]byte(event.Data()), &errorData)

--- a/internal/datasourcev2/streaming_data_source_test.go
+++ b/internal/datasourcev2/streaming_data_source_test.go
@@ -754,9 +754,7 @@ func TestStreamingDataSourceIgnoresGoodbye(t *testing.T) {
 			protocol.WithPutObjects([]subsystems.PutObject{change})
 
 			protocol.WithGoodbye(subsystems.Goodbye{
-				Reason:      "for testing reason",
-				Silent:      false,
-				Catastrophe: false,
+				Reason: "for testing reason",
 			})
 
 			// Push a change through the data source

--- a/subsystems/events.go
+++ b/subsystems/events.go
@@ -207,9 +207,7 @@ func (e Error) Name() EventName {
 // Do not use it.
 // You have been warned.
 type Goodbye struct {
-	Reason      string `json:"reason"`
-	Silent      bool   `json:"silent"`
-	Catastrophe bool   `json:"catastrophe"`
+	Reason string `json:"reason"`
 }
 
 //nolint:revive // Event method.


### PR DESCRIPTION
## Summary
- The FDv2 `goodbye` event is specified to carry only a `reason` field. The Go SDK's `subsystems.Goodbye` struct incorrectly included `Silent` and `Catastrophe` fields. This PR removes them.
- The streaming data source previously logged the goodbye at `Errorf` level, gated on `!silent` and including `catastrophe` in the message. With those fields gone, the gating is dropped and the level softened to `Infof` — a goodbye is the server's normal "I'm closing the stream" signal, matching what the Java SDK already does. Message text: `"SSE server sent goodbye: %s"`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages, including `TestStreamingDataSourceIgnoresGoodbye`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, spec-alignment change that only affects parsing of `goodbye` events and the log level/message when they occur.
> 
> **Overview**
> Updates the FDv2 `goodbye` event model to match the protocol by removing the non-spec `Silent` and `Catastrophe` fields from `subsystems.Goodbye`.
> 
> Adjusts streaming (`StreamProcessor.consumeStream`) to always log `goodbye` as an `Infof` message (`"SSE server sent goodbye: %s"`) rather than conditionally emitting an error, and updates the corresponding streaming test payload to only include `reason`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33ba349fafbac10ec65df0e9e9fa653105cb27a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->