### PR TITLE
fix(ldai): Populate VariationKey and Version on Config returned by CompletionConfig

### DIFF
--- a/ldai/client.go
+++ b/ldai/client.go
@@ -152,6 +152,7 @@ func (c *Client) evaluateConfig(
 	}
 
 	builder := NewConfig().
+		withVariationKey(parsed.Meta.VariationKey).
 		WithModelName(parsed.Model.Name).
 		WithProviderName(parsed.Provider.Name).
 		WithEnabled(parsed.Meta.Enabled).
@@ -159,6 +160,10 @@ func (c *Client) evaluateConfig(
 		WithEvaluationMetricKey(parsed.EvaluationMetricKey).
 		WithEvaluationMetricKeys(parsed.EvaluationMetricKeys).
 		WithJudgeConfiguration(parsed.JudgeConfiguration)
+
+	if parsed.Meta.Version != nil {
+		builder.withVersion(*parsed.Meta.Version)
+	}
 
 	for k, v := range parsed.Model.Parameters {
 		builder.WithModelParam(k, v)
@@ -181,12 +186,7 @@ func (c *Client) evaluateConfig(
 
 	cfg := builder.Build()
 
-	version := 1
-	if parsed.Meta.Version != nil {
-		version = *parsed.Meta.Version
-	}
-
-	return cfg, newTracker(key, parsed.Meta.VariationKey, version, c.sdk, &cfg, context, c.logger)
+	return cfg, newTracker(key, cfg.VariationKey(), cfg.Version(), c.sdk, &cfg, context, c.logger)
 }
 
 func getAllAttributes(context ldcontext.Context) map[string]interface{} {

--- a/ldai/client_test.go
+++ b/ldai/client_test.go
@@ -151,6 +151,15 @@ func TestConfigVariationKeyAndVersionArePopulated(t *testing.T) {
 			wantVariationKey: "v1-explicit",
 			wantVersion:      1,
 		},
+		{
+			name: "version is 0 explicitly",
+			json: []byte(`{
+				"_ldMeta": {"variationKey": "v0-explicit", "enabled": true, "version": 0},
+				"messages": [{"content": "hello", "role": "user"}]
+			}`),
+			wantVariationKey: "v0-explicit",
+			wantVersion:      0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/ldai/client_test.go
+++ b/ldai/client_test.go
@@ -99,6 +99,138 @@ func TestEvalErrorReturnsDefault(t *testing.T) {
 	assert.Equal(t, defaultVal, cfg)
 }
 
+func TestConfigVariationKeyAndVersionArePopulated(t *testing.T) {
+	tests := []struct {
+		name             string
+		json             []byte
+		wantVariationKey string
+		wantVersion      int
+	}{
+		{
+			name: "both variationKey and version present",
+			json: []byte(`{
+				"_ldMeta": {"variationKey": "my-variation", "enabled": true, "version": 3},
+				"messages": [{"content": "hello", "role": "user"}]
+			}`),
+			wantVariationKey: "my-variation",
+			wantVersion:      3,
+		},
+		{
+			name: "variationKey present, version omitted defaults to 1",
+			json: []byte(`{
+				"_ldMeta": {"variationKey": "only-key", "enabled": true},
+				"messages": [{"content": "hello", "role": "user"}]
+			}`),
+			wantVariationKey: "only-key",
+			wantVersion:      1,
+		},
+		{
+			name: "both omitted",
+			json: []byte(`{
+				"_ldMeta": {"enabled": true},
+				"messages": [{"content": "hello", "role": "user"}]
+			}`),
+			wantVariationKey: "",
+			wantVersion:      1,
+		},
+		{
+			name: "empty _ldMeta object",
+			json: []byte(`{
+				"_ldMeta": {},
+				"messages": [{"content": "hello", "role": "user"}]
+			}`),
+			wantVariationKey: "",
+			wantVersion:      1,
+		},
+		{
+			name: "version is 1 explicitly",
+			json: []byte(`{
+				"_ldMeta": {"variationKey": "v1-explicit", "enabled": true, "version": 1},
+				"messages": [{"content": "hello", "role": "user"}]
+			}`),
+			wantVariationKey: "v1-explicit",
+			wantVersion:      1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewClient(newMockSDK(tt.json, nil))
+			require.NoError(t, err)
+
+			cfg, _ := client.CompletionConfig("key", ldcontext.New("user"), Disabled(), nil)
+
+			assert.Equal(t, tt.wantVariationKey, cfg.VariationKey())
+			assert.Equal(t, tt.wantVersion, cfg.Version())
+		})
+	}
+}
+
+func TestConfigVariationKeyMatchesTrackerEvents(t *testing.T) {
+	json := []byte(`{
+		"_ldMeta": {"variationKey": "test-variation", "enabled": true, "version": 7},
+		"model": {"name": "gpt-4"},
+		"provider": {"name": "OpenAI"},
+		"messages": [{"content": "test", "role": "system"}]
+	}`)
+
+	mockSDK := newMockSDK(json, nil)
+	client, err := NewClient(mockSDK)
+	require.NoError(t, err)
+
+	// Clear SDK info event from construction.
+	mockSDK.events = nil
+
+	cfg, tracker := client.CompletionConfig("my-config", ldcontext.New("user"), Disabled(), nil)
+
+	// Config should expose the correct variation key and version.
+	assert.Equal(t, "test-variation", cfg.VariationKey())
+	assert.Equal(t, 7, cfg.Version())
+
+	// Tracker should emit events with the same variation key and version.
+	require.NotNil(t, tracker)
+	_ = tracker.TrackSuccess()
+
+	// Events: [0] = completion-config, [1] = generation:success
+	require.Len(t, mockSDK.events, 2)
+	successEvent := mockSDK.events[1]
+	assert.Equal(t, "$ld:ai:generation:success", successEvent.eventName)
+	assert.Equal(t, "test-variation", successEvent.data.GetByKey("variationKey").StringValue())
+	assert.Equal(t, 7, successEvent.data.GetByKey("version").IntValue())
+	assert.Equal(t, "my-config", successEvent.data.GetByKey("configKey").StringValue())
+}
+
+func TestJudgeConfigVariationKeyIsPopulated(t *testing.T) {
+	json := []byte(`{
+		"_ldMeta": {"variationKey": "judge-var", "enabled": true, "version": 2},
+		"mode": "judge",
+		"evaluationMetricKey": "toxicity",
+		"messages": [{"content": "evaluate this", "role": "system"}]
+	}`)
+
+	client, err := NewClient(newMockSDK(json, nil))
+	require.NoError(t, err)
+
+	cfg, _ := client.JudgeConfig("judge-key", ldcontext.New("user"), Disabled(), nil)
+
+	assert.Equal(t, "judge-var", cfg.VariationKey())
+	assert.Equal(t, 2, cfg.Version())
+}
+
+func TestDefaultConfigHasEmptyVariationKey(t *testing.T) {
+	// When the SDK returns the default (e.g. evaluation error), VariationKey and Version
+	// should have their zero/default values since the default Config is builder-created
+	// without metadata.
+	client, err := NewClient(newMockSDK(nil, errors.New("offline")))
+	require.NoError(t, err)
+
+	defaultVal := NewConfig().Enable().WithMessage("fallback", datamodel.User).Build()
+	cfg, _ := client.CompletionConfig("key", ldcontext.New("user"), defaultVal, nil)
+
+	assert.Equal(t, "", cfg.VariationKey())
+	assert.Equal(t, 1, cfg.Version())
+}
+
 func TestParseMultipleMessages(t *testing.T) {
 	json := []byte(`{
 		"_ldMeta": {"variationKey": "1", "enabled": true},

--- a/ldai/config.go
+++ b/ldai/config.go
@@ -97,6 +97,8 @@ func (c *Config) AsLdValue() ldvalue.Value {
 type ConfigBuilder struct {
 	messages             []datamodel.Message
 	enabled              bool
+	variationKey         string
+	version              *int
 	providerName         string
 	modelName            string
 	modelParams          map[string]ldvalue.Value
@@ -143,6 +145,18 @@ func (cb *ConfigBuilder) Enable() *ConfigBuilder {
 // Disable disables the config.
 func (cb *ConfigBuilder) Disable() *ConfigBuilder {
 	return cb.WithEnabled(false)
+}
+
+// withVariationKey sets the variation key. This is used internally by LaunchDarkly.
+func (cb *ConfigBuilder) withVariationKey(variationKey string) *ConfigBuilder {
+	cb.variationKey = variationKey
+	return cb
+}
+
+// withVersion sets the version. This is used internally by LaunchDarkly.
+func (cb *ConfigBuilder) withVersion(version int) *ConfigBuilder {
+	cb.version = &version
+	return cb
 }
 
 // WithModelName sets the model name associated with the config.
@@ -217,7 +231,9 @@ func (cb *ConfigBuilder) Build() Config {
 		c: datamodel.Config{
 			Messages: slices.Clone(cb.messages),
 			Meta: datamodel.Meta{
-				Enabled: cb.enabled,
+				VariationKey: cb.variationKey,
+				Enabled:      cb.enabled,
+				Version:      cb.version,
 			},
 			Model: datamodel.Model{
 				Name:       cb.modelName,

--- a/ldai/config.go
+++ b/ldai/config.go
@@ -233,7 +233,7 @@ func (cb *ConfigBuilder) Build() Config {
 			Meta: datamodel.Meta{
 				VariationKey: cb.variationKey,
 				Enabled:      cb.enabled,
-				Version:      cb.version,
+				Version:      copyIntPtr(cb.version),
 			},
 			Model: datamodel.Model{
 				Name:       cb.modelName,
@@ -249,4 +249,12 @@ func (cb *ConfigBuilder) Build() Config {
 			JudgeConfiguration:   judgeConfig,
 		},
 	}
+}
+
+func copyIntPtr(p *int) *int {
+	if p == nil {
+		return nil
+	}
+	v := *p
+	return &v
 }


### PR DESCRIPTION
## Summary

`Config.VariationKey()` and `Config.Version()` always return zero values (`""` and `1` respectively) when called on a `Config` returned from `CompletionConfig()` or `JudgeConfig()`.

<img width="242*3" height="450" alt="pr372-ldai-config-metadata" src="https://github.com/user-attachments/assets/547b0a61-7e22-42ec-a0ab-d37c2400bd01" />


## Problem

`ConfigBuilder.Build()` only sets `Meta.Enabled` — it does not populate `Meta.VariationKey` or `Meta.Version`. The `evaluateConfig()` method correctly parses these fields from the flag JSON, but only passes them to `newTracker()`. The `Config` struct returned to callers has no way to access the actual variation key or version.

The `Tracker` is unaffected because it receives the values directly. Code that uses `Tracker.TrackSuccess()` etc. sends correct event data. However, any code that reads `cfg.VariationKey()` to build its own event payloads will send empty values.

## Fix

- Add unexported `variationKey` and `version` fields to `ConfigBuilder` with internal setters (`withVariationKey`, `withVersion`)
- Call these setters from `evaluateConfig()` before `Build()`
- Update `Build()` to include `VariationKey` and `Version` in `Meta`
- Derive `Tracker` values from `cfg.VariationKey()` and `cfg.Version()` instead of separate local variables, keeping `Config` and `Tracker` in sync

## Tests

Added test coverage for:
- `Config.VariationKey()` and `Config.Version()` populated correctly across 5 sub-cases (both present, key only, both omitted, empty meta, explicit version 1)
- `Config` and `Tracker` emit consistent `variationKey`/`version` values in tracked events
- `JudgeConfig` also populates variation key correctly
- Default config (evaluation error path) returns expected zero values

All existing tests continue to pass.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to propagating LaunchDarkly `_ldMeta` fields (`variationKey`, `version`) into the returned `Config` and aligning `Tracker` construction with those values, plus added unit tests.
> 
> **Overview**
> **AI Config metadata is now preserved on returned `Config` objects.** `evaluateConfig` now sets `variationKey` and optional `version` on the `ConfigBuilder`, `Build()` writes them into `Meta`, and `newTracker` is constructed from `cfg.VariationKey()`/`cfg.Version()` to keep `Config` and emitted events consistent.
> 
> **Tests added** to cover variation/version population across meta-shape edge cases, confirm `Tracker` event payloads match the `Config` values, and verify judge/default-config behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 221371ae0fb89d85d67115b84346542f7b0f7977. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->