### PR TITLE
fix: execute afterTrack hooks in registration order

### DIFF
--- a/internal/hooks/track_execution.go
+++ b/internal/hooks/track_execution.go
@@ -16,7 +16,7 @@ type TrackExecution struct {
 
 // AfterTrack executes the AfterTrack stage of registered hooks.
 func (t *TrackExecution) AfterTrack(ctx gocontext.Context) {
-	iterator := newIterator(true, t.hooks)
+	iterator := newIterator(false, t.hooks)
 	for iterator.hasNext() {
 		_, hook := iterator.getNext()
 		err := hook.AfterTrack(ctx, t.context)

--- a/internal/hooks/track_execution_test.go
+++ b/internal/hooks/track_execution_test.go
@@ -48,7 +48,7 @@ func TestTrackExecution(t *testing.T) {
 				loggers: &loggers,
 			}
 			execution.AfterTrack(gocontext.Background())
-			assert.Equal(t, []string{"b", "a"}, tracker.orderAfter)
+			assert.Equal(t, []string{"a", "b"}, tracker.orderAfter)
 		})
 
 		t.Run("run after track", func(t *testing.T) {
@@ -84,7 +84,7 @@ func TestTrackExecution(t *testing.T) {
 			mockLog := ldlogtest.NewMockLog()
 
 			hookA := sharedtest.NewTestHook("a")
-			// The hooks execute in reverse order, so we have an error in B and check that A still executes.
+			// hookA executes first and hookB second (forward order); an error in hookB should not prevent hookA from running.
 			hookA.AfterTrackInject = func(ctx gocontext.Context, tsc ldhooks.TrackSeriesContext) error {
 				return nil
 			}


### PR DESCRIPTION
AfterTrack was calling newIterator with reverse=true, causing hooks to run in the reverse of their registration order. The correct behavior is forward order: the hook registered first should execute first.

Updated the iterator call in AfterTrack to use reverse=false, and aligned the execution-order test assertion and comment to reflect forward ordering.