### PR TITLE
chore: Clarify TrackRequest re-call wording

### DIFF
--- a/ldai/tracker.go
+++ b/ldai/tracker.go
@@ -448,9 +448,8 @@ func (t *Tracker) GetSummary() MetricSummary {
 //     2a) If Latency was not set in the ProviderResponse's Metrics field, an automatically measured duration.
 //  3. Any token usage that was set in the ProviderResponse.
 //
-// Because each inner metric is at-most-once per Tracker, calling TrackRequest
-// twice on the same Tracker will run the task again but produce no additional
-// metric events.
+// Subsequent calls re-run the task but emit only metrics not already recorded
+// on this Tracker. Call CreateTracker on the AI Config to start a new run.
 func (t *Tracker) TrackRequest(task func(c *Config) (ProviderResponse, error)) (ProviderResponse, error) {
 	usage, duration, err := measureDurationOfTask(t.stopwatch, t.config, task)
 	if err != nil {


### PR DESCRIPTION
## Summary

The re-call paragraph added to `TrackRequest` in #363 overpromised: it said a second call would produce "no additional metric events." That isn't accurate in the partial-failure case -- if the first call's task returns an error before token usage is recorded, the token slot is still empty, and a second successful call will still emit token metric events.

Replaces the inaccurate paragraph with wording that matches the cross-SDK fixes shipped on Ruby, .NET, js-core, and Python.

## Test plan

- [ ] CI passes (doc-only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc-only change that updates `TrackRequest` semantics for re-calls; no runtime behavior is modified.
> 
> **Overview**
> Clarifies the `Tracker.TrackRequest` doc comment to accurately describe repeated-call behavior: the task may be re-run, and metrics are emitted only for fields not yet recorded on that `Tracker` (rather than claiming no additional metric events can ever occur).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca4fef204f05a095b6b4cd3107cb30ddf9b4b5f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->