### PR TITLE
fix: execute AfterTrack hooks in registration order

### DIFF
--- a/internal/hooks/track_execution.go
+++ b/internal/hooks/track_execution.go
@@ -16,7 +16,7 @@ type TrackExecution struct {
 
 // AfterTrack executes the AfterTrack stage of registered hooks.
 func (t *TrackExecution) AfterTrack(ctx gocontext.Context) {
-	iterator := newIterator(true, t.hooks)
+	iterator := newIterator(false, t.hooks)
 	for iterator.hasNext() {
 		_, hook := iterator.getNext()
 		err := hook.AfterTrack(ctx, t.context)

--- a/internal/hooks/track_execution_test.go
+++ b/internal/hooks/track_execution_test.go
@@ -48,7 +48,7 @@ func TestTrackExecution(t *testing.T) {
 				loggers: &loggers,
 			}
 			execution.AfterTrack(gocontext.Background())
-			assert.Equal(t, []string{"b", "a"}, tracker.orderAfter)
+			assert.Equal(t, []string{"a", "b"}, tracker.orderAfter)
 		})
 
 		t.Run("run after track", func(t *testing.T) {
@@ -84,14 +84,14 @@ func TestTrackExecution(t *testing.T) {
 			mockLog := ldlogtest.NewMockLog()
 
 			hookA := sharedtest.NewTestHook("a")
-			// The hooks execute in reverse order, so we have an error in B and check that A still executes.
+			// The hooks execute in forward order, so we have an error in A and check that B still executes.
 			hookA.AfterTrackInject = func(ctx gocontext.Context, tsc ldhooks.TrackSeriesContext) error {
-				return nil
+				return errors.New("something bad")
 			}
 
 			hookB := sharedtest.NewTestHook("b")
 			hookB.AfterTrackInject = func(ctx gocontext.Context, tsc ldhooks.TrackSeriesContext) error {
-				return errors.New("something bad")
+				return nil
 			}
 
 			execution := TrackExecution{
@@ -103,7 +103,7 @@ func TestTrackExecution(t *testing.T) {
 
 			assert.Len(t, execution.hooks, 2)
 			assert.Equal(t, execution.context, ldhooks.NewTrackSeriesContext(ldContext, "test-event", nil, ldvalue.Null(), ldvalue.OptionalString{}))
-			assert.Equal(t, []string{"During tracking of event \"test-event\", an error was encountered in \"AfterTrack\" of the \"b\" hook: something bad"},
+			assert.Equal(t, []string{"During tracking of event \"test-event\", an error was encountered in \"AfterTrack\" of the \"a\" hook: something bad"},
 				mockLog.GetOutput(ldlog.Error))
 		})
 	})


### PR DESCRIPTION
AfterTrack was invoking hooks in reverse registration order due to passing `true` (reverse) to the internal iterator. The correct behaviour is forward order — the same order hooks were registered — consistent with how BeforeEvaluation and other forward-order stages work.

Changed the iterator call in `TrackExecution.AfterTrack` to use forward iteration (`false`). Updated the order-verification test to assert `["a", "b"]`, and adjusted the error-resilience test so that the error is injected into the first hook (hookA) and the assertion checks for hookA's name in the log message, accurately reflecting the new execution order.