### PR TITLE
fix: execute afterTrack hooks in registration order

### DIFF
--- a/internal/hooks/runner_test.go
+++ b/internal/hooks/runner_test.go
@@ -167,7 +167,7 @@ func TestHookRunner(t *testing.T) {
 			},
 		})
 
-		// AfterTrack should execute in reverse registration order.
-		assert.Equal(t, []string{"b", "a"}, tracker.orderAfter)
+		// AfterTrack should execute in registration order.
+		assert.Equal(t, []string{"a", "b"}, tracker.orderAfter)
 	})
 }

--- a/internal/hooks/track_execution.go
+++ b/internal/hooks/track_execution.go
@@ -16,7 +16,7 @@ type TrackExecution struct {
 
 // AfterTrack executes the AfterTrack stage of registered hooks.
 func (t *TrackExecution) AfterTrack(ctx gocontext.Context) {
-	iterator := newIterator(true, t.hooks)
+	iterator := newIterator(false, t.hooks)
 	for iterator.hasNext() {
 		_, hook := iterator.getNext()
 		err := hook.AfterTrack(ctx, t.context)

--- a/internal/hooks/track_execution_test.go
+++ b/internal/hooks/track_execution_test.go
@@ -48,7 +48,7 @@ func TestTrackExecution(t *testing.T) {
 				loggers: &loggers,
 			}
 			execution.AfterTrack(gocontext.Background())
-			assert.Equal(t, []string{"b", "a"}, tracker.orderAfter)
+			assert.Equal(t, []string{"a", "b"}, tracker.orderAfter)
 		})
 
 		t.Run("run after track", func(t *testing.T) {
@@ -84,14 +84,14 @@ func TestTrackExecution(t *testing.T) {
 			mockLog := ldlogtest.NewMockLog()
 
 			hookA := sharedtest.NewTestHook("a")
-			// The hooks execute in reverse order, so we have an error in B and check that A still executes.
+			// The hooks execute in forward order, so we have an error in A and check that B still executes.
 			hookA.AfterTrackInject = func(ctx gocontext.Context, tsc ldhooks.TrackSeriesContext) error {
-				return nil
+				return errors.New("something bad")
 			}
 
 			hookB := sharedtest.NewTestHook("b")
 			hookB.AfterTrackInject = func(ctx gocontext.Context, tsc ldhooks.TrackSeriesContext) error {
-				return errors.New("something bad")
+				return nil
 			}
 
 			execution := TrackExecution{
@@ -103,7 +103,7 @@ func TestTrackExecution(t *testing.T) {
 
 			assert.Len(t, execution.hooks, 2)
 			assert.Equal(t, execution.context, ldhooks.NewTrackSeriesContext(ldContext, "test-event", nil, ldvalue.Null(), ldvalue.OptionalString{}))
-			assert.Equal(t, []string{"During tracking of event \"test-event\", an error was encountered in \"AfterTrack\" of the \"b\" hook: something bad"},
+			assert.Equal(t, []string{"During tracking of event \"test-event\", an error was encountered in \"AfterTrack\" of the \"a\" hook: something bad"},
 				mockLog.GetOutput(ldlog.Error))
 		})
 	})


### PR DESCRIPTION
AfterTrack was calling newIterator with reverse=true, causing hooks to run in reverse registration order. The correct behavior is forward (registration) order, matching how beforeEvaluation and beforeIdentify behave. Changed the iterator flag to false in AfterTrack and updated the corresponding tests to reflect the corrected ordering.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes hook execution order for the `AfterTrack` stage and updates tests accordingly, with no impact on data/auth flows beyond hook side effects timing.
> 
> **Overview**
> Fixes `TrackExecution.AfterTrack` to iterate hooks in **registration (forward) order** by switching `newIterator` from reverse to forward.
> 
> Updates hook runner and `TrackExecution` tests to assert the new ordering and to attribute/log errors to the correct hook while ensuring subsequent hooks still run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8092eb33fc58e5016a5ca93dc3ad0b7fb5d0c49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->