### PR TITLE
chore(build): add ldmiddleware to go.work generation target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,7 @@ go.work:
 	go work init ./
 	go work use ./ldotel
 	go work use ./ldai
+	go work use ./ldmiddleware
 	go work use ./testservice
 
 workspace-clean:


### PR DESCRIPTION
## Summary

The \`go.work:\` target in the Makefile seeds the local Go workspace with \`ldotel\`, \`ldai\`, and \`testservice\`, but omits \`ldmiddleware\` — even though \`ldmiddleware\` is a fully-fledged sub-module with its own \`go.mod\` (\`github.com/launchdarkly/go-server-sdk/ldmiddleware\`), following the exact same pattern as \`ldai\`/\`ldotel\`.

Because \`ldmiddleware\` was missing from the generated \`go.work\`, building it while workspace mode is active failed, and contributors had to fall back to \`GOWORK=off go build ./...\` as a workaround.

This adds \`go work use ./ldmiddleware\` to the target so a freshly generated workspace includes it.

> Note: \`go.work\`/\`go.work.sum\` are gitignored (generated per-developer), so the fix necessarily lives in the Makefile generator rather than in a committed \`go.work\`.

## Testing

In a freshly generated workspace (no \`GOWORK=off\`):

- \`make workspace\` → \`go.work\` now lists \`./ldmiddleware\`
- \`go build ./...\` (root) — passes
- \`cd ldmiddleware && go build ./... && go test ./...\` — passes (\`ok ... 1.742s\`)

## Context

Surfaced during the EasyJSON removal cascade (SDK-2119) while building \`ldmiddleware\` locally. Independent of the v4 dependency-cascade work in #382 — this only touches build tooling, hence a standalone PR against \`v7\`.

via LD Research 🤖

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Makefile line for developer workspace generation; no runtime or library behavior changes.
> 
> **Overview**
> **`make workspace`** now runs **`go work use ./ldmiddleware`** when generating **`go.work`**, alongside **`ldotel`**, **`ldai`**, and **`testservice`**.
> 
> That aligns the generated local Go workspace with the existing **`ldmiddleware`** Makefile build/test/lint targets, so **`ldmiddleware`** builds under active workspace mode without needing **`GOWORK=off`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d889f7b55dac3af465d552c3c2ec5f32b5b5e66a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->