### PR TITLE
build: Add ldmiddleware to "make bump-min-go-version"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,8 @@ The SDK is tested against three Go versions: the latest, penultimate, and a mini
 Whereas the latest and penultimate are updates on a regular cadence to track upstream Go releases, the minimum version
 may be bumped at the discretion of the SDK maintainers to take advantage of new features.
 
-Invoke the following make command, which will update `go.mod`, `ldotel/go.mod`, `ldai/go.mod`, `testservice/go.mod`, and 
-`.github/variables/go-versions.env` (pass the desired Go version):
+Invoke the following make command, which will update `go.mod`, `ldotel/go.mod`, `ldai/go.mod`, `ldmiddleware/go.mod`,
+`testservice/go.mod`, and `.github/variables/go-versions.env` (pass the desired Go version):
 ```shell
 make bump-min-go-version MIN_GO_VERSION=1.18
 ```

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ bump-min-go-version:
 	go mod edit -go=$(MIN_GO_VERSION) go.mod
 	cd ldotel && go mod edit -go=$(MIN_GO_VERSION) go.mod
 	cd ldai && go mod edit -go=$(MIN_GO_VERSION) go.mod
+	cd ldmiddleware && go mod edit -go=$(MIN_GO_VERSION) go.mod
 	cd testservice && go mod edit -go=$(MIN_GO_VERSION) go.mod
 	cd ./.github/variables && sed -i.bak "s#min=[^ ]*#min=$(MIN_GO_VERSION)#g" go-versions.env && rm go-versions.env.bak
 


### PR DESCRIPTION
## Summary

Adds `ldmiddleware` to the `bump-min-go-version` Makefile target and the CONTRIBUTING docs.

## Background

The repo has five Go modules — `go.mod`, `ldotel/go.mod`, `ldai/go.mod`, `ldmiddleware/go.mod`, and `testservice/go.mod` — all currently on `go 1.24.0`. The `bump-min-go-version` target is meant to move the minimum version across all of them (plus `min=` in `.github/variables/go-versions.env`) in one shot.

`ldmiddleware` was added after the target was written and never wired in. Both the Makefile target and the CONTRIBUTING file that documents it omitted it. The result is a latent drift bug: the next time someone runs `make bump-min-go-version MIN_GO_VERSION=1.25`, the other four modules and the env file would advance while `ldmiddleware` silently stayed behind. It only lines up today because it was set manually.

## Changes

- `Makefile` — add the `cd ldmiddleware && go mod edit -go=$(MIN_GO_VERSION) go.mod` line alongside the other modules.
- `CONTRIBUTING.md` — add `ldmiddleware/go.mod` to the documented list of files the command updates.

No version value changes; all five modules remain at `go 1.24.0`. Verified by running `make bump-min-go-version MIN_GO_VERSION=1.24.0` (a no-op re-set) and confirming no unexpected diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Makefile-only change to a maintainer tooling target; no runtime or dependency version changes.
> 
> **Overview**
> Wires the **`ldmiddleware`** Go module into the shared minimum-Go bump workflow so it stays aligned with the other modules.
> 
> `make bump-min-go-version` now runs `go mod edit` in `ldmiddleware` alongside `go.mod`, `ldotel`, `ldai`, and `testservice`, and **CONTRIBUTING.md** lists `ldmiddleware/go.mod` among the files that command updates. No Go version values change in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e525eb70ec52711e2da8ea4ffc93dff9bf07f095. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->