### PR TITLE
test(ldtestdata): increase channel-wait timeouts to reduce CI flakiness

### DIFF
--- a/testhelpers/ldtestdata/test_data_source_flag_test.go
+++ b/testhelpers/ldtestdata/test_data_source_flag_test.go
@@ -30,7 +30,7 @@ func verifyFlag(t *testing.T, configureFlag func(*FlagBuilder), expectedFlag *ld
 			f := p.td.Flag("flagkey")
 			configureFlag(f)
 			p.td.Update(f)
-			up := p.updates.DataStore.WaitForUpsert(t, ldstoreimpl.Features(), "flagkey", 1, time.Millisecond)
+			up := p.updates.DataStore.WaitForUpsert(t, ldstoreimpl.Features(), "flagkey", 1, time.Second)
 			upJSON := ldstoreimpl.Features().Serialize(up.Item)
 			m.In(t).Assert(string(upJSON), m.JSONStrEqual(string(expectedJSON)))
 		})

--- a/testhelpers/ldtestdata/test_data_source_test.go
+++ b/testhelpers/ldtestdata/test_data_source_test.go
@@ -49,7 +49,7 @@ func (p testDataSourceTestParams) withDataSource(t *testing.T, action func(subsy
 
 	closer := make(chan struct{})
 	ds.Start(closer)
-	if !th.AssertChannelClosed(t, closer, time.Millisecond, "start did not close channel") {
+	if !th.AssertChannelClosed(t, closer, time.Second, "start did not close channel") {
 		t.FailNow()
 	}
 	p.updates.RequireStatusOf(t, interfaces.DataSourceStateValid)
@@ -62,7 +62,7 @@ func TestTestDataSource(t *testing.T) {
 		testDataSourceTest(t, func(p testDataSourceTestParams) {
 			p.withDataSource(t, func(ds subsystems.DataSource) {
 				expectedData := ldservices.NewServerSDKData()
-				p.updates.DataStore.WaitForInit(t, expectedData, time.Millisecond)
+				p.updates.DataStore.WaitForInit(t, expectedData, time.Second)
 				assert.True(t, ds.IsInitialized())
 			})
 		})
@@ -74,7 +74,7 @@ func TestTestDataSource(t *testing.T) {
 				Update(p.td.Flag("flag2").On(false))
 
 			p.withDataSource(t, func(subsystems.DataSource) {
-				initData := p.updates.DataStore.WaitForNextInit(t, time.Millisecond)
+				initData := p.updates.DataStore.WaitForNextInit(t, time.Second)
 				dataMap := sharedtest.DataSetToMap(initData)
 				require.Len(t, dataMap, 2)
 				flags := dataMap[ldstoreimpl.Features()]
@@ -93,7 +93,7 @@ func TestTestDataSource(t *testing.T) {
 			p.withDataSource(t, func(subsystems.DataSource) {
 				p.td.Update(p.td.Flag("flag1").On(true))
 
-				up := p.updates.DataStore.WaitForUpsert(t, ldstoreimpl.Features(), "flag1", 1, time.Millisecond)
+				up := p.updates.DataStore.WaitForUpsert(t, ldstoreimpl.Features(), "flag1", 1, time.Second)
 				assert.True(t, up.Item.Item.(*ldmodel.FeatureFlag).On)
 			})
 		})
@@ -106,7 +106,7 @@ func TestTestDataSource(t *testing.T) {
 			p.withDataSource(t, func(subsystems.DataSource) {
 				p.td.Update(p.td.Flag("flag1").On(true))
 
-				up := p.updates.DataStore.WaitForUpsert(t, ldstoreimpl.Features(), "flag1", 2, time.Millisecond)
+				up := p.updates.DataStore.WaitForUpsert(t, ldstoreimpl.Features(), "flag1", 2, time.Second)
 				assert.True(t, up.Item.Item.(*ldmodel.FeatureFlag).On)
 			})
 		})
@@ -130,7 +130,7 @@ func TestTestDataSource(t *testing.T) {
 			p.withDataSource(t, func(subsystems.DataSource) {
 				p.td.UsePreconfiguredFlag(flagv1)
 
-				up := p.updates.DataStore.WaitForUpsert(t, ldstoreimpl.Features(), flagv1.Key, 1, time.Millisecond)
+				up := p.updates.DataStore.WaitForUpsert(t, ldstoreimpl.Features(), flagv1.Key, 1, time.Second)
 				assert.Equal(t, &flagv1, up.Item.Item.(*ldmodel.FeatureFlag))
 
 				updatedFlag := flagv1
@@ -139,7 +139,7 @@ func TestTestDataSource(t *testing.T) {
 				expectedFlagV2.Version = 2
 				p.td.UsePreconfiguredFlag(updatedFlag)
 
-				up = p.updates.DataStore.WaitForUpsert(t, ldstoreimpl.Features(), flagv1.Key, 2, time.Millisecond)
+				up = p.updates.DataStore.WaitForUpsert(t, ldstoreimpl.Features(), flagv1.Key, 2, time.Second)
 				assert.Equal(t, &expectedFlagV2, up.Item.Item.(*ldmodel.FeatureFlag))
 			})
 		})
@@ -151,7 +151,7 @@ func TestTestDataSource(t *testing.T) {
 			p.withDataSource(t, func(subsystems.DataSource) {
 				p.td.UsePreconfiguredSegment(segmentv1)
 
-				up := p.updates.DataStore.WaitForUpsert(t, ldstoreimpl.Segments(), segmentv1.Key, 1, time.Millisecond)
+				up := p.updates.DataStore.WaitForUpsert(t, ldstoreimpl.Segments(), segmentv1.Key, 1, time.Second)
 				assert.Equal(t, &segmentv1, up.Item.Item.(*ldmodel.Segment))
 
 				updatedSegment := segmentv1
@@ -160,7 +160,7 @@ func TestTestDataSource(t *testing.T) {
 				expectedSegmentV2.Version = 2
 				p.td.UsePreconfiguredSegment(updatedSegment)
 
-				up = p.updates.DataStore.WaitForUpsert(t, ldstoreimpl.Segments(), segmentv1.Key, 2, time.Millisecond)
+				up = p.updates.DataStore.WaitForUpsert(t, ldstoreimpl.Segments(), segmentv1.Key, 2, time.Second)
 				assert.Equal(t, &expectedSegmentV2, up.Item.Item.(*ldmodel.Segment))
 			})
 		})


### PR DESCRIPTION
## Summary
Increases hardcoded `time.Millisecond` channel-wait timeouts in `testhelpers/ldtestdata` to `time.Second` to fix intermittent CI flakiness.

## Background
`TestFlagTargets/user_targets` intermittently failed in CI (observed on the Windows, Go 1.26 job) with:

```
channels.go:126: expected a mocks.UpsertParams value from channel but did not receive one in 1ms
channels.go:128: timed out before receiving expected update
```

Sibling jobs in the same CI run (Windows Go 1.24/1.25, all Linux jobs) passed with the identical test suite, confirming this is a timing flake rather than a real regression. Several test call sites in `test_data_source_flag_test.go` and `test_data_source_test.go` pass a hardcoded `time.Millisecond` timeout to `WaitForUpsert`/`WaitForInit`/`WaitForNextInit`/`AssertChannelClosed`, which wait on a channel populated by a producer goroutine. Under `go test -race` on slower/jitterier runners, 1ms isn't enough margin. This pattern dates back to a 2020 commit and has just been latent until now.

No behavior change is intended — only the timeout values increase, so tests will still fail fast (within a second) on a genuine hang.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timeout tuning with no production or behavioral changes; genuine hangs still fail within one second.
> 
> **Overview**
> Raises channel-wait deadlines from **`time.Millisecond`** to **`time.Second`** in `testhelpers/ldtestdata` tests that block on mock data-source updates.
> 
> Affected helpers include **`WaitForUpsert`**, **`WaitForInit`**, **`WaitForNextInit`**, and **`AssertChannelClosed`** in `test_data_source_test.go` and the shared **`verifyFlag`** path in `test_data_source_flag_test.go`. Assertions and production code are unchanged; only how long tests wait before failing on a missing channel message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96abc032e5c5663f9cd259d48ec865d9c435592b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->