### PR TITLE
fix: avoid data races in test flag creation

### DIFF
--- a/testhelpers/ldtestdata/test_data_source_flag.go
+++ b/testhelpers/ldtestdata/test_data_source_flag.go
@@ -400,7 +400,7 @@ func (f *FlagBuilder) createFlag(version int) ldmodel.FeatureFlag {
 		fb.AddRule(ldbuilders.NewRuleBuilder().
 			ID(fmt.Sprintf("rule%d", i)).
 			Variation(r.variation).
-			Clauses(r.clauses...),
+			Clauses(slices.Clone(r.clauses)...),
 		)
 	}
 	return fb.Build()

--- a/testhelpers/ldtestdata/test_data_source_flag_reuse_race_test.go
+++ b/testhelpers/ldtestdata/test_data_source_flag_reuse_race_test.go
@@ -1,0 +1,39 @@
+//go:build race
+
+package ldtestdata
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	eval "github.com/launchdarkly/go-server-sdk-evaluation/v3"
+	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldmodel"
+)
+
+type nilProvider struct{}
+
+func (nilProvider) GetFeatureFlag(string) *ldmodel.FeatureFlag { return nil }
+func (nilProvider) GetSegment(string) *ldmodel.Segment         { return nil }
+
+// TestFlagCreateEvalRace verifies that a test flag
+// can be created while an existing test flag is being evaluated.
+func TestFlagCreateEvalRace(t *testing.T) {
+	f := DataSource().Flag("flag").
+		IfMatch("is", ldvalue.Bool(true)).
+		ThenReturn(true)
+	published := f.createFlag(1)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// An in-flight evaluation of the published flag, on the SDK's own goroutine.
+		evaluator := eval.NewEvaluator(nilProvider{})
+		evaluator.Evaluate(&published, ldcontext.New("user"), nil)
+	}()
+	// Caller reuses the builder; Builder use must not alter existing flags.
+	f.createFlag(2)
+	wg.Wait()
+}

--- a/testhelpers/ldtestdatav2/test_data_source_flag.go
+++ b/testhelpers/ldtestdatav2/test_data_source_flag.go
@@ -400,7 +400,7 @@ func (f *FlagBuilder) createFlag(version int) ldmodel.FeatureFlag {
 		fb.AddRule(ldbuilders.NewRuleBuilder().
 			ID(fmt.Sprintf("rule%d", i)).
 			Variation(r.variation).
-			Clauses(r.clauses...),
+			Clauses(slices.Clone(r.clauses)...),
 		)
 	}
 	return fb.Build()

--- a/testhelpers/ldtestdatav2/test_data_source_flag_reuse_race_test.go
+++ b/testhelpers/ldtestdatav2/test_data_source_flag_reuse_race_test.go
@@ -1,0 +1,39 @@
+//go:build race
+
+package ldtestdatav2
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	eval "github.com/launchdarkly/go-server-sdk-evaluation/v3"
+	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldmodel"
+)
+
+type nilProvider struct{}
+
+func (nilProvider) GetFeatureFlag(string) *ldmodel.FeatureFlag { return nil }
+func (nilProvider) GetSegment(string) *ldmodel.Segment         { return nil }
+
+// TestFlagCreateEvalRace verifies that a test flag
+// can be created while an existing test flag is being evaluated.
+func TestFlagCreateEvalRace(t *testing.T) {
+	f := DataSource().Flag("flag").
+		IfMatch("is", ldvalue.Bool(true)).
+		ThenReturn(true)
+	published := f.createFlag(1)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// An in-flight evaluation of the published flag, on the SDK's own goroutine.
+		evaluator := eval.NewEvaluator(nilProvider{})
+		evaluator.Evaluate(&published, ldcontext.New("user"), nil)
+	}()
+	// Caller reuses the builder; Builder use must not alter existing flags.
+	f.createFlag(2)
+	wg.Wait()
+}


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/v5/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

None found when searching.

**Describe the solution you've provided**

`go test -race` no longer fails when creating multiple test flag data sources. This was handled through a simple `slice.Clone` of the rule's clauses on duplication. 

**Describe alternatives you've considered**

Not running tests in `-race` mode.

**Additional context**

This prevents a data race on the clauses section of a test flag, though the actual behaviour at runtime was unlikely to present as a meaningful issue in practice. This just helps with downstream data-race detection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to test helper flag construction; behavior change is defensive copying with no production SDK path impact.
> 
> **Overview**
> Fixes a **data race** when reusing a `FlagBuilder` to publish another flag while an earlier snapshot is still being evaluated (e.g. on an SDK goroutine).
> 
> `createFlag` now passes **`slices.Clone(r.clauses)`** into rule builders instead of sharing the builder’s clause slice, so later builder work does not race with reads during evaluation.
> 
> Adds **`//go:build race`** tests in `ldtestdata` and `ldtestdatav2` that evaluate a published flag concurrently with a second `createFlag` on the same builder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1701af879d0af54656a9fa5e844b93a86a5f421f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->