### PR TITLE
test: declare polling-gzip contract test capability

### DIFF
--- a/testservice/service.go
+++ b/testservice/service.go
@@ -44,6 +44,7 @@ var capabilities = []string{
 	servicedef.CapabilityOmitAnonymousContexts,
 	servicedef.CapabilityEventGzip,
 	servicedef.CapabilityOptionalEventGzip,
+	servicedef.CapabilityPollingGzip,
 	servicedef.CapabilityClientPrereqEvents,
 	servicedef.CapabilityPersistentDataStoreRedis,
 	servicedef.CapabilityPersistentDataStoreConsul,

--- a/testservice/servicedef/service_params.go
+++ b/testservice/servicedef/service_params.go
@@ -25,6 +25,7 @@ const (
 	CapabilityOmitAnonymousContexts       = "omit-anonymous-contexts"
 	CapabilityEventGzip                   = "event-gzip"
 	CapabilityOptionalEventGzip           = "optional-event-gzip"
+	CapabilityPollingGzip                 = "polling-gzip"
 	CapabilityClientPrereqEvents          = "client-prereq-events"
 	CapabilityPersistentDataStoreRedis    = "persistent-data-store-redis"
 	CapabilityPersistentDataStoreConsul   = "persistent-data-store-consul"


### PR DESCRIPTION
## What

Declares the `polling-gzip` contract-test capability for the Go server SDK, so the sdk-test-harness verifies `Accept-Encoding: gzip` on FDv2 polling requests.

Part of epic **SDK-950** (Polling Gzip Support) · ticket **SDK-2717**.

## Why this is capability-only

The Go SDK already requests and decompresses gzip on polling transparently via `net/http` (no `DisableCompression`, no explicit header), so no SDK code change is required — only the capability declaration in the contract-test service.

## Changes

- `testservice/servicedef/service_params.go` — add `CapabilityPollingGzip = "polling-gzip"`
- `testservice/service.go` — add it to the reported `capabilities`

## Verification

Ran the v3 harness polling suite locally against the built test service with the capability enabled — all polling tests pass, including `polling/requests/method and headers` (the `Accept-Encoding: gzip` assertion). The mock returns HTTP 400 if the header is absent, so a green run confirms the header is sent and responses are decompressed end-to-end.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness capability wiring only; no changes to SDK polling or HTTP client behavior.
> 
> **Overview**
> Registers the **`polling-gzip`** contract-test capability on the Go server SDK test service so the sdk-test-harness can run FDv2 polling checks (including **`Accept-Encoding: gzip`** on polling requests).
> 
> Adds `CapabilityPollingGzip` in `servicedef/service_params.go` and includes it in the **`capabilities`** list returned from the test service status endpoint. No production SDK changes—the Go client already satisfies the behavior via default `net/http` compression handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc55a7d17bc157d6d05961693e9ae8316462d860. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->