### PR TITLE
chore: Declare the hook-environment-id contract test capability

### DIFF
--- a/testservice/service.go
+++ b/testservice/service.go
@@ -41,6 +41,7 @@ var capabilities = []string{
 	servicedef.CapabilityAnonymousRedaction,
 	servicedef.CapabilityEvaluationHooks,
 	servicedef.CapabilityTrackHooks,
+	servicedef.CapabilityHookEnvironmentID,
 	servicedef.CapabilityOmitAnonymousContexts,
 	servicedef.CapabilityEventGzip,
 	servicedef.CapabilityOptionalEventGzip,

--- a/testservice/servicedef/service_params.go
+++ b/testservice/servicedef/service_params.go
@@ -22,6 +22,7 @@ const (
 	CapabilityAnonymousRedaction          = "anonymous-redaction"
 	CapabilityEvaluationHooks             = "evaluation-hooks"
 	CapabilityTrackHooks                  = "track-hooks"
+	CapabilityHookEnvironmentID           = "hook-environment-id"
 	CapabilityOmitAnonymousContexts       = "omit-anonymous-contexts"
 	CapabilityEventGzip                   = "event-gzip"
 	CapabilityOptionalEventGzip           = "optional-event-gzip"


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/v7/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Depends on launchdarkly/sdk-test-harness#410, which adds the `hook-environment-id` capability and a test asserting `evaluationSeriesContext.environmentId`.

**Describe the solution you've provided**

The test service already forwards `EnvironmentID` from both series contexts in `testservice/test_hook.go`, so it only needed to declare the capability.

Verified with a local build of the harness branch: `hooks/evaluation/provides the environment ID` passes unchanged.

**Describe alternatives you've considered**

None; no behavior change is needed.

**Additional context**

The capability only takes effect once the harness change is released; until then the harness ignores it.


Link to Devin session: https://app.devin.ai/sessions/bfe54128e2804a96bb100e6120e9a3ef
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Advertises support for the **`hook-environment-id`** harness capability so contract tests can assert `evaluationSeriesContext.environmentId` (and track hook context) once the harness ships sdk-test-harness#410.
> 
> The change adds `CapabilityHookEnvironmentID` in `servicedef` and includes it in the test service status **`capabilities`** list. **No SDK or test-service hook behavior changes**—`test_hook.go` already forwards `EnvironmentID` from evaluation and track series contexts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93ef25f303b3c027ed614bdb2950a26f359907da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->