### PR TITLE
ci: Use the latest v3 contract test harness

### DIFF
--- a/.github/workflows/common_ci.yml
+++ b/.github/workflows/common_ci.yml
@@ -66,7 +66,7 @@ jobs:
           enable_persistence_tests: 'true'
           test_service_port: ${{ env.TEST_SERVICE_PORT }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          version: v3.0.0-alpha.6
+          version: v3
 
       - name: Upload test service logs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/v5/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Companion to the same pin move in ruby-server-sdk (launchdarkly/ruby-server-sdk#414).

**Describe the solution you've provided**

The v3 contract test job was pinned to `v3.0.0-alpha.6`, so new coverage added to the harness never reaches CI. Moved the pin to floating `v3`.

Validated locally before bumping: `testservice` built from this branch, run against the released harness `v3.2.0-alpha.6` — 4946 total, 12 skipped, all ran passed (persistence tests skipped locally; CI runs them with `enable_persistence_tests`).

**Describe alternatives you've considered**

Pinning to `v3.2.0-alpha.6` — a floating `v3` keeps the SDK honest against new coverage as it lands, which was the intent of the pin move.

**Additional context**

For contrast, python-server-sdk fails 6 subtests against the released harness (attribute-reference escaping in `_meta.redactedAttributes`), so its pin was left alone. ruby-server-sdk failed the same 6 and is being fixed in launchdarkly/ruby-server-sdk#415.


Link to Devin session: https://app.devin.ai/sessions/316afaccd2604f8d802a72c9080f6921
Requested by: @kinyoklion