### PR TITLE
chore: Track the latest v3 contract test release instead of a pinned alpha

### DIFF
--- a/.github/workflows/common_ci.yml
+++ b/.github/workflows/common_ci.yml
@@ -66,7 +66,7 @@ jobs:
           enable_persistence_tests: 'true'
           test_service_port: ${{ env.TEST_SERVICE_PORT }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          version: v3.0.0-alpha.6
+          version: v3
 
       - name: Upload test service logs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What

Change the FDv2 contract test job from `version: v3.0.0-alpha.6` to `version: v3`.

## Why

The pin means every `sdk-test-harness` release needs a manual bump in this repo. It went stale: `v3.0.0-alpha.6` shipped 2026-04-29, so this job has been skipping every v3.1.x and v3.2.x test since.

The harness downloader already handles this. `downloader/run.sh` resolves a partial version by querying the Releases API, filtering `tag_name` on the prefix, and taking the newest match. That endpoint includes prereleases, so partials land on alphas:

| `VERSION` | resolves to (checked 2026-08-14) |
| --- | --- |
| `v2` | `v2.39.0` |
| `v3` | `v3.2.0-alpha.7` |

This is not new ground. The FDv1 job in this repo already floats on the action default of `version: v2` and has never pinned a patch. `js-core` floats `v3` for `server-node`, `browser`, `vue`, and `node-client` today, through the same `launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1` action and the same downloader path.

## Notes

The `branch` input is deliberately left alone. `origin/v2:downloader/run.sh` and `origin/v3:downloader/run.sh` are the same blob (`df4fe4b`), so setting `branch: v3` would change nothing.

This jumps from an April harness build to current, so CI on this PR is the real verification. If new test cases fail, the follow-up is a `--skip-from` suppression file rather than restoring the pin.

SDK-2922

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Updates the **Run SDK contract test v3** step in `common_ci.yml` so `version` is **`v3`** instead of the pinned **`v3.0.0-alpha.6`**.
> 
> That aligns the FDv2 job with how v2 contract tests already float on a major version prefix and lets the harness downloader pick the newest matching release (including prereleases), avoiding manual bumps after each `sdk-test-harness` release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66b3bf25a0fe2a28d89742d4fbb4bcb529ba6e2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->