### PR TITLE
feat: Add DuplicateKeysKeepFirst and deprecate DuplicateKeysIgnoreAllButFirst

### DIFF
--- a/ldfiledata/file_data_source_builder.go
+++ b/ldfiledata/file_data_source_builder.go
@@ -17,8 +17,13 @@ const (
 	// should fail if keys are duplicated across files. This is the default behavior.
 	DuplicateKeysFail DuplicateKeysHandling = "fail"
 
-	// DuplicateKeysIgnoreAllButFirst is an option for DataSourceBuilder.DuplicateKeysHandling, meaning that
+	// DuplicateKeysKeepFirst is an option for DataSourceBuilder.DuplicateKeysHandling, meaning that
 	// if keys are duplicated across files the first occurrence will be used.
+	DuplicateKeysKeepFirst DuplicateKeysHandling = "ignore"
+
+	// DuplicateKeysIgnoreAllButFirst is an older name for [DuplicateKeysKeepFirst].
+	//
+	// Deprecated: Use [DuplicateKeysKeepFirst] instead.
 	DuplicateKeysIgnoreAllButFirst DuplicateKeysHandling = "ignore"
 )
 

--- a/ldfiledata/file_data_source_test.go
+++ b/ldfiledata/file_data_source_test.go
@@ -162,7 +162,7 @@ func TestDuplicateKeysHandlingCanSuppressErrors(t *testing.T) {
 	th.WithTempFileData([]byte(file1Data), func(filename1 string) {
 		th.WithTempFileData([]byte(file2Data), func(filename2 string) {
 			factory := DataSource().FilePaths(filename1, filename2).
-				DuplicateKeysHandling(DuplicateKeysIgnoreAllButFirst)
+				DuplicateKeysHandling(DuplicateKeysKeepFirst)
 			withFileDataSourceTestParams(factory, func(p fileDataSourceTestParams) {
 				p.waitForStart()
 				require.True(t, p.dataSource.IsInitialized())

--- a/ldfiledatav2/file_data_source_builder.go
+++ b/ldfiledatav2/file_data_source_builder.go
@@ -17,8 +17,13 @@ const (
 	// should fail if keys are duplicated across files. This is the default behavior.
 	DuplicateKeysFail DuplicateKeysHandling = "fail"
 
-	// DuplicateKeysIgnoreAllButFirst is an option for DataSourceBuilder.DuplicateKeysHandling, meaning that
+	// DuplicateKeysKeepFirst is an option for DataSourceBuilder.DuplicateKeysHandling, meaning that
 	// if keys are duplicated across files the first occurrence will be used.
+	DuplicateKeysKeepFirst DuplicateKeysHandling = "ignore"
+
+	// DuplicateKeysIgnoreAllButFirst is an older name for [DuplicateKeysKeepFirst].
+	//
+	// Deprecated: Use [DuplicateKeysKeepFirst] instead.
 	DuplicateKeysIgnoreAllButFirst DuplicateKeysHandling = "ignore"
 )
 

--- a/ldfiledatav2/file_data_source_test.go
+++ b/ldfiledatav2/file_data_source_test.go
@@ -163,7 +163,7 @@ func TestIsInterruptedWhenLoadingConflictingFiles(t *testing.T) {
 func TestIsValidWhenLoadingConflictingFilesWhenIgnoringDuplicates(t *testing.T) {
 	th.WithTempFileData([]byte(`{"flags": {"my-flag": {"on": true, "version": 1}}}`), func(filename1 string) {
 		th.WithTempFileData([]byte(`{"flags": {"my-flag": {"on": false, "version": 2}, "your-flag": {"on": false}}}`), func(filename2 string) {
-			factory := DataSource().FilePaths(filename1, filename2).DuplicateKeysHandling(DuplicateKeysIgnoreAllButFirst)
+			factory := DataSource().FilePaths(filename1, filename2).DuplicateKeysHandling(DuplicateKeysKeepFirst)
 			sync, err := factory.Build(subsystems.BasicClientContext{})
 			assert.NoError(t, err)
 


### PR DESCRIPTION
## Summary

Adds `DuplicateKeysKeepFirst` to the `DuplicateKeysHandling` options in both `ldfiledata` and `ldfiledatav2`, and deprecates `DuplicateKeysIgnoreAllButFirst` in its favor. The new name states the behavior directly (the first occurrence of a duplicated key is kept), and newer LaunchDarkly integrations that reuse the file-data document format are standardizing on it.

The two constants share the same underlying value, so this is a name-level change only: existing code using the deprecated constant keeps working with identical behavior, and there are no wire or configuration format changes. Test usages are updated to the new name.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Introduces **`DuplicateKeysKeepFirst`** as the preferred `DuplicateKeysHandling` option in **`ldfiledata`** and **`ldfiledatav2`**, with docs that spell out that the first duplicate key across files wins. **`DuplicateKeysIgnoreAllButFirst`** remains as a deprecated alias with the same `"ignore"` value, so runtime behavior and config semantics are unchanged.
> 
> Tests in both packages now call **`DuplicateKeysKeepFirst`** instead of the deprecated name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aa0fe7c853909ac61ce7138c6cb4fcdfa4d5e21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->