### PR TITLE
ci: use shared sdk-go-versions workflow

### DIFF
--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -7,85 +7,15 @@ on:
 permissions: {}
 
 jobs:
-  check-go-eol:
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    outputs:
-      latest: ${{ steps.parse.outputs.latest }}
-      penultimate: ${{ steps.parse.outputs.penultimate }}
-    timeout-minutes: 2
-    steps:
-        # Perform a GET request to endoflife.date for the Go language. The response
-        # contains all Go releases; we're interested in the 0'th and 1'th (latest and penultimate.)
-      - name: Fetch officially supported Go versions
-        uses: JamesIves/fetch-api-data-action@396ebea7d13904824f85b892b1616985f847301c # v2.2.4
-        with:
-          endpoint: https://endoflife.date/api/go.json
-          configuration: '{ "method": "GET" }'
-          debug: true
-        # Parse the response JSON and insert into environment variables for the next step.
-      - name: Parse officially supported Go versions
-        id: parse
-        env:
-          FETCH_API_DATA: ${{ env.fetch-api-data }}
-        run: |
-          set -euo pipefail
-          latest=$(jq -r '.[0].cycle' <<< "$FETCH_API_DATA")
-          penultimate=$(jq -r '.[1].cycle' <<< "$FETCH_API_DATA")
-          for version in "$latest" "$penultimate"; do
-            if [[ ! "$version" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
-              echo "Unexpected Go version string from endoflife.date: $version" >&2
-              exit 1
-            fi
-          done
-          echo "latest=$latest" >> "$GITHUB_OUTPUT"
-          echo "penultimate=$penultimate" >> "$GITHUB_OUTPUT"
-
-
-  create-prs:
+  check-go-versions:
+    # The called workflow narrows check-go-eol to `contents: read`; a reusable workflow
+    # cannot grant itself more than the caller does, which is why the write scopes are here.
     permissions:
       contents: write
       pull-requests: write
-    needs: check-go-eol
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        branch: ["v7"]
-      fail-fast: false
-    env:
-      officialLatestVersion: ${{ needs.check-go-eol.outputs.latest }}
-      officialPenultimateVersion: ${{ needs.check-go-eol.outputs.penultimate }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ matrix.branch }}
-
-      - name: Get current Go versions
-        id: go-versions
-        run:  cat ./.github/variables/go-versions.env >> "$GITHUB_OUTPUT"
-
-      - name: Update go-versions.env and README.md
-        if: steps.go-versions.outputs.latest != env.officialLatestVersion
-        id: update-go-versions
-        run: |
-          set -euo pipefail
-          sed -i -e "s#latest=[^ ]*#latest=$officialLatestVersion#g" \
-                 -e "s#penultimate=[^ ]*#penultimate=$officialPenultimateVersion#g" \
-                  ./.github/variables/go-versions.env
-
-      - name: Create pull request
-        if: steps.update-go-versions.outcome == 'success'
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          add-paths: |
-            .github/variables/go-versions.env
-          branch: "launchdarklyreleasebot/update-to-go${{ env.officialLatestVersion }}-${{ matrix.branch }}"
-          author: "LaunchDarklyReleaseBot <LaunchDarklyReleaseBot@launchdarkly.com>"
-          committer: "LaunchDarklyReleaseBot <LaunchDarklyReleaseBot@launchdarkly.com>"
-          labels: ${{ matrix.branch }}
-          title: "ci: bump tested Go versions to ${{ env.officialLatestVersion }} and ${{ env.officialPenultimateVersion }}"
-          commit-message: "Bumps from Go ${{ steps.go-versions.outputs.latest }} -> ${{ env.officialLatestVersion }} and ${{ steps.go-versions.outputs.penultimate }} -> ${{ env.officialPenultimateVersion }}."
-          body: |
-            - [ ] I have triggered CI on this PR (either close & reopen this PR in Github UI, or `git commit -m "run ci" --allow-empty && git push`)
+    # Reusable workflows in gh-actions are consumed at @main; release-please does not version
+    # them (see launchdarkly/gh-actions#51). The composite action that workflow calls is
+    # pinned to an exact release tag on that side.
+    uses: launchdarkly/gh-actions/.github/workflows/sdk-go-versions.yml@main
+    with:
+      branches: '["v7"]'

--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -4,6 +4,8 @@ on:
     - cron: "0 17 * * *"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   check-go-eol:
     permissions:
@@ -14,7 +16,6 @@ jobs:
       penultimate: ${{ steps.parse.outputs.penultimate }}
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v4
         # Perform a GET request to endoflife.date for the Go language. The response
         # contains all Go releases; we're interested in the 0'th and 1'th (latest and penultimate.)
       - name: Fetch officially supported Go versions
@@ -26,9 +27,20 @@ jobs:
         # Parse the response JSON and insert into environment variables for the next step.
       - name: Parse officially supported Go versions
         id: parse
+        env:
+          FETCH_API_DATA: ${{ env.fetch-api-data }}
         run: |
-          echo "latest=${{ fromJSON(env.fetch-api-data)[0].cycle }}" >> $GITHUB_OUTPUT
-          echo "penultimate=${{ fromJSON(env.fetch-api-data)[1].cycle }}" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          latest=$(jq -r '.[0].cycle' <<< "$FETCH_API_DATA")
+          penultimate=$(jq -r '.[1].cycle' <<< "$FETCH_API_DATA")
+          for version in "$latest" "$penultimate"; do
+            if [[ ! "$version" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+              echo "Unexpected Go version string from endoflife.date: $version" >&2
+              exit 1
+            fi
+          done
+          echo "latest=$latest" >> "$GITHUB_OUTPUT"
+          echo "penultimate=$penultimate" >> "$GITHUB_OUTPUT"
 
 
   create-prs:
@@ -51,14 +63,15 @@ jobs:
 
       - name: Get current Go versions
         id: go-versions
-        run:  cat ./.github/variables/go-versions.env > $GITHUB_OUTPUT
+        run:  cat ./.github/variables/go-versions.env >> "$GITHUB_OUTPUT"
 
       - name: Update go-versions.env and README.md
         if: steps.go-versions.outputs.latest != env.officialLatestVersion
         id: update-go-versions
         run: |
-          sed -i -e "s#latest=[^ ]*#latest=${{ env.officialLatestVersion }}#g" \
-                 -e "s#penultimate=[^ ]*#penultimate=${{ env.officialPenultimateVersion }}#g" \
+          set -euo pipefail
+          sed -i -e "s#latest=[^ ]*#latest=$officialLatestVersion#g" \
+                 -e "s#penultimate=[^ ]*#penultimate=$officialPenultimateVersion#g" \
                   ./.github/variables/go-versions.env
 
       - name: Create pull request

--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -8,14 +8,9 @@ permissions: {}
 
 jobs:
   check-go-versions:
-    # The called workflow narrows check-go-eol to `contents: read`; a reusable workflow
-    # cannot grant itself more than the caller does, which is why the write scopes are here.
     permissions:
       contents: write
       pull-requests: write
-    # Reusable workflows in gh-actions are consumed at @main; release-please does not version
-    # them (see launchdarkly/gh-actions#51). The composite action that workflow calls is
-    # pinned to an exact release tag on that side.
     uses: launchdarkly/gh-actions/.github/workflows/sdk-go-versions.yml@main
     with:
       branches: '["v7"]'


### PR DESCRIPTION
Replaces this repo's copy of the Go version check with a call to the shared `sdk-go-versions` reusable workflow, deleting the inline shell entirely.

**Why this supersedes the previous approach**

The earlier revision of this PR hardened the inline shell in place (the port of launchdarkly/ld-relay#841, SEC-9481) — quoting the untrusted endoflife.date payload into an env var, adding `jq` extraction and a version regex. That fixed the injection; it did not remove the surface. Calling the shared workflow removes the shell from this repo altogether, so the script-injection class is structurally unavailable here rather than merely patched. 78 lines of inline workflow (91 after the earlier hardening revision) become 21 lines, none of which is a `run:` step.

The shared workflow pins the composite action to the released `go-eol-versions-v0.1.0`; consumers track the workflow itself at `@main`, matching how this org already consumes `sdk-stale` and `dependency-scan` (release-please does not version reusable workflows in gh-actions — see launchdarkly/gh-actions#51).

**Inputs**

- `branches: '["v7"]'` — the only maintained release branch for this repo, matching the previous `strategy.matrix.branch` value.

Everything else is left at its default: `precision` (`cycle`), `versions_file` (`.github/variables/go-versions.env`), `add_paths`, and `pr_title_prefix` already match what this repo needs.

**Behaviour**

Intended to be unchanged: same `0 17 * * *` schedule plus `workflow_dispatch`, same `.github/variables/go-versions.env` updated, same bot author/committer and PR shape. Two fixes the shared version carries that the inline copy did not:

- A penultimate-only upstream release now opens a PR. The inline gate compared only `latest`, so a new penultimate with an unchanged latest was silently dropped.
- The bot branch name includes both versions, so a latest-only and a penultimate-only bump can no longer collide on one branch.

**Verification**

- YAML parses and resolves to a single reusable-workflow call: `python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/check-go-versions.yml')); print(d['jobs'])"` → one `check-go-versions` job with `uses:`, `with: {branches: '["v7"]'}`, and `contents: write` / `pull-requests: write`.
- No inline shell remains: `grep -c 'run:'` → 0.
- No remnants of the old implementation: `grep -c 'fromJSON\|JamesIves\|peter-evans\|sed -i'` → 0.
- `git diff --stat` against `v7` touches only `.github/workflows/check-go-versions.yml` (11 insertions, 68 deletions).
- The workflow was not dispatched from this repo; the shared workflow is verified end to end in launchdarkly/go-test-helpers ([run 33534426032](https://github.com/launchdarkly/go-test-helpers/actions/runs/33534426032)).

Tracked by SDK-3023.
Shared workflow: launchdarkly/gh-actions#113.

**Requirements**

- [x] I have added test coverage for new or changed functionality — n/a — workflow-only change
- [x] I have followed the repository's [pull request submission guidelines](../blob/v5/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Replaces the in-repo Go version automation** with a call to `launchdarkly/gh-actions` reusable workflow `sdk-go-versions.yml@main`, shrinking `check-go-versions.yml` from two jobs and ~78 lines of inline steps to a single job with no local `run:` blocks.
> 
> The removed implementation fetched supported versions from endoflife.date, updated `.github/variables/go-versions.env` via `sed`, and opened PRs with `peter-evans/create-pull-request` on branch `v7`. **Behaviour is intended to stay the same** (daily `0 17 * * *` schedule, `workflow_dispatch`, same env file and bot PRs) via `with: branches: '["v7"]'` and shared defaults for paths and titles.
> 
> **Why:** Centralizing logic in gh-actions removes shell/script-injection surface from this repo and picks up shared fixes (e.g. PRs when only penultimate changes, distinct bot branch names per bump).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac80e11296c2e93e0590e7ab5cfb722313bc9e38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->