### PR TITLE
feat: Complete initialization when initializers return data without a selector

### DIFF
--- a/internal/datasystem/fdv1_datasystem.go
+++ b/internal/datasystem/fdv1_datasystem.go
@@ -154,8 +154,8 @@ func (f *FDv1) DataAvailability() DataAvailability {
 }
 
 //nolint:revive // Data system implementation.
-func (f *FDv1) MinimumAvailability() DataAvailability {
-	return Refreshed
+func (f *FDv1) InitializationSucceeded() bool {
+	return f.dataSource.IsInitialized()
 }
 
 //nolint:revive // Data system implementation.

--- a/internal/datasystem/fdv1_datasystem.go
+++ b/internal/datasystem/fdv1_datasystem.go
@@ -154,7 +154,7 @@ func (f *FDv1) DataAvailability() DataAvailability {
 }
 
 //nolint:revive // Data system implementation.
-func (f *FDv1) TargetAvailability() DataAvailability {
+func (f *FDv1) MinimumAvailability() DataAvailability {
 	return Refreshed
 }
 

--- a/internal/datasystem/fdv2_datasystem.go
+++ b/internal/datasystem/fdv2_datasystem.go
@@ -245,8 +245,11 @@ func (f *FDv2) runPersistentStoreOutageRecovery(ctx context.Context, statuses <-
 	}
 }
 
-// runInitializers runs each configured initializer in order until one succeeds, the context is
-// cancelled, or an initializer signals a fallback to FDv1. Returns (fallbackToFDv1, errorInfo):
+// runInitializers runs each configured initializer in order until one returns a basis with a
+// selector, the context is cancelled, or an initializer signals a fallback to FDv1. A basis
+// without a selector is applied to the store and the loop continues to the next initializer.
+// When all initializers have run, initialization is complete if any of them returned data,
+// even if that data had no selector. Returns (fallbackToFDv1, errorInfo):
 // fallbackToFDv1 is true when an initializer asked the SDK to switch to FDv1; errorInfo describes
 // the underlying error for status reporting when no FDv1 fallback is configured (empty when the
 // fallback accompanied a successful response). If fallback is signalled alongside a valid Basis,
@@ -255,6 +258,7 @@ func (f *FDv2) runPersistentStoreOutageRecovery(ctx context.Context, statuses <-
 func (f *FDv2) runInitializers(
 	ctx context.Context, closeWhenReady chan struct{},
 ) (fallbackToFDv1 bool, errorInfo interfaces.DataSourceErrorInfo) {
+	obtainedData := false
 	for _, initializer := range f.initializers {
 		f.loggers.Infof("Attempting to initialize via %s", initializer.Name())
 		basis, fallback, err := initializer.Fetch(f.store, ctx)
@@ -275,12 +279,10 @@ func (f *FDv2) runInitializers(
 			if basis != nil {
 				f.environmentIDProvider.SetEnvironmentID(basis.EnvironmentID)
 				f.store.Apply(basis.ChangeSet, basis.Persist)
-				if basis.ChangeSet.Selector().IsDefined() {
-					f.loggers.Infof("Applied payload from %s before falling back to FDv1", initializer.Name())
-					f.readyOnce.Do(func() {
-						close(closeWhenReady)
-					})
-				}
+				f.loggers.Infof("Applied payload from %s before falling back to FDv1", initializer.Name())
+				f.readyOnce.Do(func() {
+					close(closeWhenReady)
+				})
 			}
 			return true, errorInfo
 		}
@@ -290,6 +292,7 @@ func (f *FDv2) runInitializers(
 		}
 		f.environmentIDProvider.SetEnvironmentID(basis.EnvironmentID)
 		f.store.Apply(basis.ChangeSet, basis.Persist)
+		obtainedData = true
 		if basis.ChangeSet.Selector().IsDefined() {
 			f.loggers.Infof("Initialized via %s", initializer.Name())
 			f.readyOnce.Do(func() {
@@ -297,6 +300,12 @@ func (f *FDv2) runInitializers(
 			})
 			return false, interfaces.DataSourceErrorInfo{}
 		}
+	}
+	if obtainedData {
+		f.loggers.Info("All initializers have run; initialization is complete with data that has no selector")
+		f.readyOnce.Do(func() {
+			close(closeWhenReady)
+		})
 	}
 	return false, interfaces.DataSourceErrorInfo{}
 }
@@ -514,11 +523,9 @@ func (f *FDv2) DataAvailability() DataAvailability {
 }
 
 //nolint:revive // DataSystem method.
-func (f *FDv2) TargetAvailability() DataAvailability {
-	if f.configuredWithDataSources {
-		return Refreshed
-	}
-
+func (f *FDv2) MinimumAvailability() DataAvailability {
+	// Initialization is successful when the data system has any data, even if that data
+	// has no selector. Synchronizers refresh the data after initialization.
 	return Cached
 }
 

--- a/internal/datasystem/fdv2_datasystem.go
+++ b/internal/datasystem/fdv2_datasystem.go
@@ -249,17 +249,22 @@ func (f *FDv2) runPersistentStoreOutageRecovery(ctx context.Context, statuses <-
 	}
 }
 
-// runInitializers runs each configured initializer in order until one provides a basis with a
-// selector, the context is cancelled, or an initializer signals a fallback to FDv1. A basis
-// without a selector is applied to the store and the loop continues to the next initializer.
-// When all initializers have run, initialization is complete if any initializer's data was
-// applied to the store, even if that data had no selector. A basis that carries no data, or
-// data that cannot be applied, does not count; the synchronizers then decide.
-// Returns (fallbackToFDv1, errorInfo): fallbackToFDv1 is true when an initializer asked the SDK
-// to switch to FDv1; errorInfo describes the underlying error for status reporting when no FDv1
-// fallback is configured (empty when the fallback accompanied a successful response). If fallback
-// is signalled alongside a basis, that basis is applied before returning so evaluations can serve
-// the server-provided data while the FDv1 synchronizer spins up.
+// runInitializers runs each configured initializer in order, stopping early when one provides a
+// basis with a selector, the context is cancelled, or an initializer signals a fallback to FDv1.
+// A basis without a selector is applied to the store and the loop continues to the next
+// initializer.
+//
+// Once all initializers have run, initialization is complete if any initializer's data was
+// applied to the store, even if that data had no selector. A basis that carries no data, or data
+// that cannot be applied, does not count; the synchronizers then decide readiness.
+//
+// fallbackToFDv1 is true when an initializer asked the SDK to switch to FDv1. If the fallback is
+// signalled alongside a basis, that basis is applied before returning, so evaluations can serve
+// the server-provided data while the FDv1 synchronizer spins up. If any initializer's data was
+// applied by then, initialization is complete before returning.
+//
+// errorInfo describes the underlying error for status reporting when no FDv1 fallback is
+// configured. It is empty when the fallback accompanied a successful response.
 func (f *FDv2) runInitializers(
 	ctx context.Context, closeWhenReady chan struct{},
 ) (fallbackToFDv1 bool, errorInfo interfaces.DataSourceErrorInfo) {
@@ -283,7 +288,10 @@ func (f *FDv2) runInitializers(
 				f.loggers.Warnf("Initializer %s requested fallback to FDv1 protocol", initializer.Name())
 			}
 			if basis != nil && f.applyBasis(*basis, initializer.Name()) {
-				f.loggers.Infof("Applied payload from %s before falling back to FDv1", initializer.Name())
+				appliedFrom = initializer.Name()
+			}
+			if appliedFrom != "" {
+				f.loggers.Infof("Initialized via %s before falling back to FDv1", appliedFrom)
 				f.completeInitialization(closeWhenReady)
 			}
 			return true, errorInfo

--- a/internal/datasystem/fdv2_datasystem.go
+++ b/internal/datasystem/fdv2_datasystem.go
@@ -523,10 +523,15 @@ func (f *FDv2) DataAvailability() DataAvailability {
 }
 
 //nolint:revive // DataSystem method.
-func (f *FDv2) MinimumAvailability() DataAvailability {
-	// Initialization is successful when the data system has any data, even if that data
-	// has no selector. Synchronizers refresh the data after initialization.
-	return Cached
+func (f *FDv2) InitializationSucceeded() bool {
+	// Initialization requires that a data source provisioned the memory store. Data already
+	// present in a persistent store does not count: a store is not a data source. That data
+	// still counts as available for evaluations and for DataAvailability.
+	// A configuration with no data sources cannot receive data, so it is successful as-is.
+	if !f.configuredWithDataSources {
+		return true
+	}
+	return f.store.MemoryStoreInitialized()
 }
 
 //nolint:revive // DataSystem method.

--- a/internal/datasystem/fdv2_datasystem.go
+++ b/internal/datasystem/fdv2_datasystem.go
@@ -76,6 +76,10 @@ type FDv2 struct {
 	// To ensure the channel is closed only once, we use a sync.Once wrapping the close() call.
 	readyOnce sync.Once
 
+	// Set when a data source provides data that is applied to the store. This drives
+	// InitializationSucceeded. Data already present in a persistent store does not set it.
+	dataApplied internal.AtomicBoolean
+
 	// These broadcasters are mainly to satisfy the existing SDK contract with users to provide status updates for
 	// the data source, data store, and flag change events. These may be different in fdv2, but we attempt to implement
 	// them for now.
@@ -245,20 +249,22 @@ func (f *FDv2) runPersistentStoreOutageRecovery(ctx context.Context, statuses <-
 	}
 }
 
-// runInitializers runs each configured initializer in order until one returns a basis with a
+// runInitializers runs each configured initializer in order until one provides a basis with a
 // selector, the context is cancelled, or an initializer signals a fallback to FDv1. A basis
 // without a selector is applied to the store and the loop continues to the next initializer.
-// When all initializers have run, initialization is complete if any of them returned data,
-// even if that data had no selector. Returns (fallbackToFDv1, errorInfo):
-// fallbackToFDv1 is true when an initializer asked the SDK to switch to FDv1; errorInfo describes
-// the underlying error for status reporting when no FDv1 fallback is configured (empty when the
-// fallback accompanied a successful response). If fallback is signalled alongside a valid Basis,
-// that Basis is applied before returning so evaluations can serve the server-provided data while
-// the FDv1 synchronizer spins up.
+// When all initializers have run, initialization is complete if any initializer's data was
+// applied to the store, even if that data had no selector. A basis that carries no data, or
+// data that cannot be applied, does not count; the synchronizers then decide.
+// Returns (fallbackToFDv1, errorInfo): fallbackToFDv1 is true when an initializer asked the SDK
+// to switch to FDv1; errorInfo describes the underlying error for status reporting when no FDv1
+// fallback is configured (empty when the fallback accompanied a successful response). If fallback
+// is signalled alongside a basis, that basis is applied before returning so evaluations can serve
+// the server-provided data while the FDv1 synchronizer spins up.
 func (f *FDv2) runInitializers(
 	ctx context.Context, closeWhenReady chan struct{},
 ) (fallbackToFDv1 bool, errorInfo interfaces.DataSourceErrorInfo) {
-	obtainedData := false
+	// Name of the last initializer whose data was applied to the store.
+	appliedFrom := ""
 	for _, initializer := range f.initializers {
 		f.loggers.Infof("Attempting to initialize via %s", initializer.Name())
 		basis, fallback, err := initializer.Fetch(f.store, ctx)
@@ -276,13 +282,9 @@ func (f *FDv2) runInitializers(
 			} else {
 				f.loggers.Warnf("Initializer %s requested fallback to FDv1 protocol", initializer.Name())
 			}
-			if basis != nil {
-				f.environmentIDProvider.SetEnvironmentID(basis.EnvironmentID)
-				f.store.Apply(basis.ChangeSet, basis.Persist)
+			if basis != nil && f.applyBasis(*basis, initializer.Name()) {
 				f.loggers.Infof("Applied payload from %s before falling back to FDv1", initializer.Name())
-				f.readyOnce.Do(func() {
-					close(closeWhenReady)
-				})
+				f.completeInitialization(closeWhenReady)
 			}
 			return true, errorInfo
 		}
@@ -290,24 +292,43 @@ func (f *FDv2) runInitializers(
 			f.loggers.Warnf("Initializer %s failed: %v", initializer.Name(), err)
 			continue
 		}
-		f.environmentIDProvider.SetEnvironmentID(basis.EnvironmentID)
-		f.store.Apply(basis.ChangeSet, basis.Persist)
-		obtainedData = true
+		if !f.applyBasis(*basis, initializer.Name()) {
+			continue
+		}
+		appliedFrom = initializer.Name()
 		if basis.ChangeSet.Selector().IsDefined() {
 			f.loggers.Infof("Initialized via %s", initializer.Name())
-			f.readyOnce.Do(func() {
-				close(closeWhenReady)
-			})
+			f.completeInitialization(closeWhenReady)
 			return false, interfaces.DataSourceErrorInfo{}
 		}
 	}
-	if obtainedData {
-		f.loggers.Info("All initializers have run; initialization is complete with data that has no selector")
-		f.readyOnce.Do(func() {
-			close(closeWhenReady)
-		})
+	if appliedFrom != "" {
+		f.loggers.Infof("Initialized via %s; the data has no selector", appliedFrom)
+		f.completeInitialization(closeWhenReady)
 	}
 	return false, interfaces.DataSourceErrorInfo{}
+}
+
+// applyBasis applies an initializer's basis to the store. It reports whether the store received
+// data. A basis with no data, or with data that cannot be applied, is reported as false.
+func (f *FDv2) applyBasis(basis subsystems.Basis, initializerName string) bool {
+	f.environmentIDProvider.SetEnvironmentID(basis.EnvironmentID)
+	if !f.store.Apply(basis.ChangeSet, basis.Persist) {
+		f.loggers.Warnf("Initializer %s returned no usable data", initializerName)
+		return false
+	}
+	f.dataApplied.Set(true)
+	return true
+}
+
+// completeInitialization marks initialization as complete from the initializer phase. The status
+// update comes before the readiness signal, so a caller that wakes on the signal observes the
+// valid status.
+func (f *FDv2) completeInitialization(closeWhenReady chan struct{}) {
+	f.UpdateStatus(interfaces.DataSourceStateValid, interfaces.DataSourceErrorInfo{})
+	f.readyOnce.Do(func() {
+		close(closeWhenReady)
+	})
 }
 
 func (f *FDv2) runSynchronizers(ctx context.Context, closeWhenReady chan struct{}) {
@@ -437,8 +458,8 @@ func (f *FDv2) consumeSynchronizerResults(
 
 			switch result.State {
 			case interfaces.DataSourceStateValid:
-				if result.ChangeSet != nil {
-					f.store.Apply(*result.ChangeSet, true)
+				if result.ChangeSet != nil && f.store.Apply(*result.ChangeSet, true) {
+					f.dataApplied.Set(true)
 				}
 
 				// Report the valid state before the readiness signal. A caller that wakes on
@@ -524,14 +545,14 @@ func (f *FDv2) DataAvailability() DataAvailability {
 
 //nolint:revive // DataSystem method.
 func (f *FDv2) InitializationSucceeded() bool {
-	// Initialization requires that a data source provisioned the memory store. Data already
-	// present in a persistent store does not count: a store is not a data source. That data
-	// still counts as available for evaluations and for DataAvailability.
+	// Initialization requires that a data source provided data that was applied to the store.
+	// Data already present in a persistent store does not count: a store is not a data source.
+	// That data still counts as available for evaluations and for DataAvailability.
 	// A configuration with no data sources cannot receive data, so it is successful as-is.
 	if !f.configuredWithDataSources {
 		return true
 	}
-	return f.store.MemoryStoreInitialized()
+	return f.dataApplied.Get()
 }
 
 //nolint:revive // DataSystem method.

--- a/internal/datasystem/store.go
+++ b/internal/datasystem/store.go
@@ -373,6 +373,14 @@ func (s *Store) IsInitialized() bool {
 	return s.getActive().IsInitialized()
 }
 
+// MemoryStoreInitialized reports whether the memory store has received a basis from a data source.
+// Unlike IsInitialized, it never reflects data that was already present in a persistent store.
+func (s *Store) MemoryStoreInitialized() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.memoryStore.IsInitialized()
+}
+
 // updateDependencyTrackerFromFullDataSet is a copy of the implementation in
 // internal.datasource. This duplication will be removed when FDv1 support is
 // removed.

--- a/internal/datasystem/store.go
+++ b/internal/datasystem/store.go
@@ -179,13 +179,14 @@ func (s *Store) Close() error {
 	return nil
 }
 
-// Apply applies a changeset to the store. The changeset must be a valid set of changes that can be applied
-// to the store. If the changeset is not valid, an error will be logged and the changeset will not be applied.
-func (s *Store) Apply(changeSet subsystems.ChangeSet, persist bool) {
+// Apply applies a changeset to the store. It reports whether the store received data. It reports
+// false when the changeset carries no data, or when the data is malformed. A malformed changeset is
+// logged and not applied.
+func (s *Store) Apply(changeSet subsystems.ChangeSet, persist bool) bool {
 	collections, err := changeSet.Collections()
 	if err != nil {
 		s.loggers.Errorf("store: couldn't set basis due to malformed data: %v", err)
-		return
+		return false
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -196,11 +197,12 @@ func (s *Store) Apply(changeSet subsystems.ChangeSet, persist bool) {
 	case subsystems.IntentTransferChanges:
 		s.applyDelta(collections, changeSet.Selector(), persist)
 	case subsystems.IntentNone:
-		return
-		// No-op, no changes to apply.
+		// Nothing to apply.
+		return false
 	}
 
 	s.changeSetBroadcaster.Broadcast(changeSet)
+	return true
 }
 
 // setBasis sets the basis of the store. Any existing data is discarded. To request data persistence,
@@ -371,14 +373,6 @@ func (s *Store) Get(kind ldstoretypes.DataKind, key string) (ldstoretypes.ItemDe
 //nolint:revive // Implementation for ReadOnlyStore.
 func (s *Store) IsInitialized() bool {
 	return s.getActive().IsInitialized()
-}
-
-// MemoryStoreInitialized reports whether the memory store has received a basis from a data source.
-// Unlike IsInitialized, it never reflects data that was already present in a persistent store.
-func (s *Store) MemoryStoreInitialized() bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.memoryStore.IsInitialized()
 }
 
 // updateDependencyTrackerFromFullDataSet is a copy of the implementation in

--- a/ldclient.go
+++ b/ldclient.go
@@ -89,8 +89,9 @@ type dataSystem interface {
 	// DataAvailability indicates what form of data is available.
 	DataAvailability() datasystem.DataAvailability
 
-	/// TargetAvailability indicates the ideal form of data available.
-	TargetAvailability() datasystem.DataAvailability
+	// MinimumAvailability indicates the form of data that must be available for client
+	// initialization to be considered successful.
+	MinimumAvailability() datasystem.DataAvailability
 }
 
 var _ dataSystem = &datasystem.FDv1{}
@@ -370,7 +371,7 @@ func MakeCustomClient(sdkKey string, config Config, waitFor time.Duration) (*LDC
 		for {
 			select {
 			case <-closeWhenReady:
-				if client.dataSystem.DataAvailability().AtLeast(client.dataSystem.TargetAvailability()) {
+				if client.dataSystem.DataAvailability().AtLeast(client.dataSystem.MinimumAvailability()) {
 					loggers.Info("Initialized LaunchDarkly client")
 					return client, nil
 				}

--- a/ldclient.go
+++ b/ldclient.go
@@ -89,8 +89,9 @@ type dataSystem interface {
 	// DataAvailability indicates what form of data is available.
 	DataAvailability() datasystem.DataAvailability
 
-	// InitializationSucceeded reports whether the data system reached a successful initial
-	// state. The result is meaningful once the channel given to Start has been closed.
+	// InitializationSucceeded reports whether the data system reached a successful initial state,
+	// which means a data source provided flag data. The result is meaningful once the channel given
+	// to Start has been closed.
 	InitializationSucceeded() bool
 }
 
@@ -136,8 +137,9 @@ var (
 	// continue trying to connect in the background.
 	ErrInitializationTimeout = errors.New("timeout encountered waiting for LaunchDarkly client initialization")
 
-	// MakeClient and MakeCustomClient will return this error if the SDK detected an error that makes it
-	// impossible for a LaunchDarkly connection to succeed (e.g. an unparseable service URI).
+	// MakeClient and MakeCustomClient will return this error if initialization failed permanently: every
+	// data source stopped without providing flag data (e.g. an unparseable service URI). Flag evaluations
+	// return default values, unless a persistent data store already contains flag data.
 	ErrInitializationFailed = errors.New("LaunchDarkly client initialization failed")
 
 	// This error is returned by the Variation/VariationDetail methods if feature flags are not available
@@ -155,15 +157,18 @@ var (
 // constructor will return when it successfully connects, or when the timeout set by the waitFor parameter
 // expires, whichever comes first.
 //
-// If the connection succeeded, the first return value is the client instance, and the error value is nil.
+// If initialization succeeded, the first return value is the client instance, and the error value is nil.
+// Initialization succeeds when a data source has provided flag data. The data does not have to come from
+// a connection to LaunchDarkly; for example, a file data source can provide it.
 //
-// If the timeout elapsed without a successful connection, it still returns a client instance-- in an
+// If the timeout elapsed before initialization succeeded, it still returns a client instance-- in an
 // uninitialized state, where feature flags will return default values-- and the error value is
-// [ErrInitializationTimeout]. In this case, it will still continue trying to connect in the background.
+// [ErrInitializationTimeout]. In this case, the data sources continue trying in the background.
 //
-// If there was a startup configuration error such that no connection could be attempted-- for instance, an
-// unparseable service URI-- it will return a client instance in an uninitialized state, and the error value is
-// [ErrInitializationFailed].
+// If initialization failed permanently-- for instance, every data source stopped without providing flag
+// data, or a service URI was unparseable-- it returns a client instance and the error value is
+// [ErrInitializationFailed]. Feature flags will return default values, unless a persistent data store
+// already contains flag data.
 //
 // If you set waitFor to zero, the function will return immediately after creating the client instance, and
 // do any further initialization in the background.
@@ -191,15 +196,18 @@ func MakeClient(sdkKey string, waitFor time.Duration) (*LDClient, error) {
 // return when it successfully connects, or when the timeout set by the waitFor parameter expires, whichever
 // comes first.
 //
-// If the connection succeeded, the first return value is the client instance, and the error value is nil.
+// If initialization succeeded, the first return value is the client instance, and the error value is nil.
+// Initialization succeeds when a data source has provided flag data. The data does not have to come from
+// a connection to LaunchDarkly; for example, a file data source can provide it.
 //
-// If the timeout elapsed without a successful connection, it still returns a client instance-- in an
+// If the timeout elapsed before initialization succeeded, it still returns a client instance-- in an
 // uninitialized state, where feature flags will return default values-- and the error value is
-// [ErrInitializationTimeout]. In this case, it will still continue trying to connect in the background.
+// [ErrInitializationTimeout]. In this case, the data sources continue trying in the background.
 //
-// If there was a startup configuration error such that no connection could be attempted-- for instance, an
-// unparseable service URI-- it will return a client instance in an uninitialized state, and the error value is
-// [ErrInitializationFailed].
+// If initialization failed permanently-- for instance, every data source stopped without providing flag
+// data, or a service URI was unparseable-- it returns a client instance and the error value is
+// [ErrInitializationFailed]. Feature flags will return default values, unless a persistent data store
+// already contains flag data.
 //
 // If you set waitFor to zero, the function will return immediately after creating the client instance, and
 // do any further initialization in the background.

--- a/ldclient.go
+++ b/ldclient.go
@@ -89,9 +89,9 @@ type dataSystem interface {
 	// DataAvailability indicates what form of data is available.
 	DataAvailability() datasystem.DataAvailability
 
-	// MinimumAvailability indicates the form of data that must be available for client
-	// initialization to be considered successful.
-	MinimumAvailability() datasystem.DataAvailability
+	// InitializationSucceeded reports whether the data system reached a successful initial
+	// state. The result is meaningful once the channel given to Start has been closed.
+	InitializationSucceeded() bool
 }
 
 var _ dataSystem = &datasystem.FDv1{}
@@ -371,7 +371,7 @@ func MakeCustomClient(sdkKey string, config Config, waitFor time.Duration) (*LDC
 		for {
 			select {
 			case <-closeWhenReady:
-				if client.dataSystem.DataAvailability().AtLeast(client.dataSystem.MinimumAvailability()) {
+				if client.dataSystem.InitializationSucceeded() {
 					loggers.Info("Initialized LaunchDarkly client")
 					return client, nil
 				}

--- a/ldclient_end_to_end_fdv2_test.go
+++ b/ldclient_end_to_end_fdv2_test.go
@@ -525,7 +525,9 @@ func TestFDV2StreamingSynchronizerTimesOut(t *testing.T) {
 	})
 }
 
-func TestFDV2FileInitializerWillDeferToFirstSynchronizer(t *testing.T) {
+// A file initializer returns data without a selector. Initialization completes with that data,
+// and the streaming synchronizer then refreshes it.
+func TestFDV2SynchronizerRefreshesDataAfterInitializerCompletesInit(t *testing.T) {
 	data := ldservicesv2.NewServerSDKData().Flags(alwaysTrueFlag)
 
 	protocol := ldservicesv2.NewStreamingProtocol().
@@ -561,10 +563,91 @@ func TestFDV2FileInitializerWillDeferToFirstSynchronizer(t *testing.T) {
 			require.NoError(t, err)
 			defer client.Close()
 
+			assert.True(t, client.Initialized())
+
 			reached := client.GetDataSourceStatusProvider().WaitFor(interfaces.DataSourceStateValid, time.Second*5)
 			require.True(t, reached, "timed out waiting for data source to reach VALID state")
 
 			value, _ := client.BoolVariation(alwaysTrueFlag.Key, testUser, false)
+			assert.True(t, value)
+		})
+	})
+}
+
+// Initialization must complete when all initializers have run and any of them returned data,
+// even though that data has no selector. The synchronizer never delivers data, so a successful
+// (non-timeout) client start proves that the initializer data completed initialization.
+func TestFDV2InitializerDataWithoutSelectorCompletesInitialization(t *testing.T) {
+	hangingHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	})
+
+	fileData := []byte(`{"flags": {"flag-from-file": {"on": true, "fallthrough": {"variation": 0}, ` +
+		`"variations": [true]}}, "segments": {}}`)
+
+	testHelpers.WithTempFileData(fileData, func(filename string) {
+		httphelpers.WithServer(hangingHandler, func(server *httptest.Server) {
+			logCapture := ldlogtest.NewMockLog()
+
+			config := Config{
+				Events:  ldcomponents.NoEvents(),
+				Logging: ldcomponents.Logging().Loggers(logCapture.Loggers),
+				DataSystem: ldcomponents.DataSystem().Custom().
+					Initializers(
+						ldfiledatav2.DataSource().FilePaths(filename).AsInitializer(),
+					).
+					Synchronizers(
+						ldcomponents.StreamingDataSourceV2().BaseURI(server.URL),
+					),
+			}
+
+			client, err := MakeCustomClient(testSdkKey, config, time.Second*5)
+			require.NoError(t, err)
+			defer client.Close()
+
+			assert.True(t, client.Initialized())
+
+			value, _ := client.BoolVariation("flag-from-file", testUser, false)
+			assert.True(t, value)
+		})
+	})
+}
+
+// The first initializer returns data without a selector, so the loop continues to the next
+// initializer. The next initializer fails. Initialization must still complete with the data
+// from the first initializer.
+func TestFDV2InitializerDataIsRetainedWhenLaterInitializerFails(t *testing.T) {
+	hangingHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	})
+
+	fileData := []byte(`{"flags": {"flag-from-file": {"on": true, "fallthrough": {"variation": 0}, ` +
+		`"variations": [true]}}, "segments": {}}`)
+
+	testHelpers.WithTempFileData(fileData, func(filename string) {
+		httphelpers.WithServer(hangingHandler, func(server *httptest.Server) {
+			logCapture := ldlogtest.NewMockLog()
+
+			config := Config{
+				Events:  ldcomponents.NoEvents(),
+				Logging: ldcomponents.Logging().Loggers(logCapture.Loggers),
+				DataSystem: ldcomponents.DataSystem().Custom().
+					Initializers(
+						ldfiledatav2.DataSource().FilePaths(filename).AsInitializer(),
+						ldfiledatav2.DataSource().FilePaths(filename+".does-not-exist").AsInitializer(),
+					).
+					Synchronizers(
+						ldcomponents.StreamingDataSourceV2().BaseURI(server.URL),
+					),
+			}
+
+			client, err := MakeCustomClient(testSdkKey, config, time.Second*5)
+			require.NoError(t, err)
+			defer client.Close()
+
+			assert.True(t, client.Initialized())
+
+			value, _ := client.BoolVariation("flag-from-file", testUser, false)
 			assert.True(t, value)
 		})
 	})

--- a/ldclient_end_to_end_fdv2_test.go
+++ b/ldclient_end_to_end_fdv2_test.go
@@ -1,7 +1,9 @@
 package ldclient
 
 import (
+	"context"
 	"crypto/x509"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -528,8 +530,9 @@ func TestFDV2StreamingSynchronizerTimesOut(t *testing.T) {
 	})
 }
 
-// A file initializer returns data without a selector. Initialization completes with that data,
-// and the streaming synchronizer then refreshes it.
+// A file initializer returns data without a selector, and the streaming synchronizer later replaces
+// that data. This test checks the refresh. TestFDV2InitializerDataWithoutSelectorCompletesInitialization
+// checks that the initializer data alone completes initialization.
 func TestFDV2SynchronizerRefreshesDataAfterInitializerCompletesInit(t *testing.T) {
 	data := ldservicesv2.NewServerSDKData().Flags(alwaysTrueFlag)
 
@@ -568,11 +571,12 @@ func TestFDV2SynchronizerRefreshesDataAfterInitializerCompletesInit(t *testing.T
 
 			assert.True(t, client.Initialized())
 
-			reached := client.GetDataSourceStatusProvider().WaitFor(interfaces.DataSourceStateValid, time.Second*5)
-			require.True(t, reached, "timed out waiting for data source to reach VALID state")
-
-			value, _ := client.BoolVariation(alwaysTrueFlag.Key, testUser, false)
-			assert.True(t, value)
+			// The status is already Valid from the initializer data, so wait for the synchronizer's
+			// data by observing the evaluation result.
+			assert.Eventually(t, func() bool {
+				value, _ := client.BoolVariation(alwaysTrueFlag.Key, testUser, false)
+				return value
+			}, time.Second*5, time.Millisecond*20, "synchronizer did not replace the initializer data")
 		})
 	})
 }
@@ -581,15 +585,8 @@ func TestFDV2SynchronizerRefreshesDataAfterInitializerCompletesInit(t *testing.T
 // even though that data has no selector. The synchronizer never delivers data, so a successful
 // (non-timeout) client start proves that the initializer data completed initialization.
 func TestFDV2InitializerDataWithoutSelectorCompletesInitialization(t *testing.T) {
-	hangingHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		<-r.Context().Done()
-	})
-
-	fileData := []byte(`{"flags": {"flag-from-file": {"on": true, "fallthrough": {"variation": 0}, ` +
-		`"variations": [true]}}, "segments": {}}`)
-
-	testHelpers.WithTempFileData(fileData, func(filename string) {
-		httphelpers.WithServer(hangingHandler, func(server *httptest.Server) {
+	testHelpers.WithTempFileData(fileDataWithOneFlag, func(filename string) {
+		httphelpers.WithServer(hangingStreamHandler, func(server *httptest.Server) {
 			logCapture := ldlogtest.NewMockLog()
 
 			config := Config{
@@ -609,6 +606,7 @@ func TestFDV2InitializerDataWithoutSelectorCompletesInitialization(t *testing.T)
 			defer client.Close()
 
 			assert.True(t, client.Initialized())
+			assert.Equal(t, interfaces.DataSourceStateValid, client.GetDataSourceStatusProvider().GetStatus().State)
 
 			value, _ := client.BoolVariation("flag-from-file", testUser, false)
 			assert.True(t, value)
@@ -678,15 +676,8 @@ func TestFDV2PopulatedPersistentStoreDoesNotSatisfyInitSuccess(t *testing.T) {
 // initializer. The next initializer fails. Initialization must still complete with the data
 // from the first initializer.
 func TestFDV2InitializerDataIsRetainedWhenLaterInitializerFails(t *testing.T) {
-	hangingHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		<-r.Context().Done()
-	})
-
-	fileData := []byte(`{"flags": {"flag-from-file": {"on": true, "fallthrough": {"variation": 0}, ` +
-		`"variations": [true]}}, "segments": {}}`)
-
-	testHelpers.WithTempFileData(fileData, func(filename string) {
-		httphelpers.WithServer(hangingHandler, func(server *httptest.Server) {
+	testHelpers.WithTempFileData(fileDataWithOneFlag, func(filename string) {
+		httphelpers.WithServer(hangingStreamHandler, func(server *httptest.Server) {
 			logCapture := ldlogtest.NewMockLog()
 
 			config := Config{
@@ -707,9 +698,239 @@ func TestFDV2InitializerDataIsRetainedWhenLaterInitializerFails(t *testing.T) {
 			defer client.Close()
 
 			assert.True(t, client.Initialized())
+			assert.True(t, logCapture.HasMessageMatch(ldlog.Warn, "Initializer FileDataSynchronizer failed"),
+				"the second initializer should have run and failed")
 
 			value, _ := client.BoolVariation("flag-from-file", testUser, false)
 			assert.True(t, value)
 		})
+	})
+}
+
+// hangingStreamHandler accepts a connection and never responds.
+var hangingStreamHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	<-r.Context().Done()
+})
+
+// fileDataWithOneFlag defines flag-from-file, which evaluates to true.
+var fileDataWithOneFlag = []byte(`{"flags": {"flag-from-file": {"on": true, "fallthrough": {"variation": 0}, ` +
+	`"variations": [true]}}, "segments": {}}`)
+
+// healthyStreamHandler serves alwaysTrueFlag as a full transfer with a selector.
+func healthyStreamHandler() http.Handler {
+	data := ldservicesv2.NewServerSDKData().Flags(alwaysTrueFlag)
+	protocol := ldservicesv2.NewStreamingProtocol().
+		WithIntent(subsystems.ServerIntent{Payload: subsystems.Payload{
+			ID: "fake-id", Target: 0, Code: subsystems.IntentTransferFull, Reason: "payload-missing",
+		}}).
+		WithPutObjects(data.ToPutObjects()).
+		WithTransferred("state", 1)
+	handler, _ := ldservices.ServerSideStreamingV2ServiceProtocolHandler(protocol)
+	return handler
+}
+
+// fetchInitializer is a DataInitializer with a canned Fetch result.
+type fetchInitializer struct {
+	name  string
+	fetch func(ds subsystems.DataSelector, ctx context.Context) (*subsystems.Basis, bool, error)
+}
+
+func (i *fetchInitializer) Name() string { return i.name }
+
+func (i *fetchInitializer) Fetch(ds subsystems.DataSelector, ctx context.Context) (*subsystems.Basis, bool, error) {
+	return i.fetch(ds, ctx)
+}
+
+func initializerReturning(
+	name string,
+	fetch func(ds subsystems.DataSelector, ctx context.Context) (*subsystems.Basis, bool, error),
+) subsystems.ComponentConfigurer[subsystems.DataInitializer] {
+	return mocks.SingleComponentConfigurer[subsystems.DataInitializer]{
+		Instance: &fetchInitializer{name: name, fetch: fetch},
+	}
+}
+
+func noDataBasis() *subsystems.Basis {
+	return &subsystems.Basis{ChangeSet: *subsystems.NewChangeSetBuilder().NoChanges()}
+}
+
+func malformedBasis(t *testing.T) *subsystems.Basis {
+	builder := subsystems.NewChangeSetBuilder().Start(subsystems.ServerIntent{Payload: subsystems.Payload{
+		ID: "fake-id", Target: 1, Code: subsystems.IntentTransferFull, Reason: "payload-missing",
+	}})
+	builder.AddPut(subsystems.FlagKind, "bad", 1, json.RawMessage(`"this is not a flag object"`))
+	changeSet, err := builder.Finish(subsystems.NoSelector())
+	require.NoError(t, err)
+	return &subsystems.Basis{ChangeSet: *changeSet}
+}
+
+// An initializer that returns a basis with no data has not provided data. Initialization must
+// neither complete nor fail on that result; the synchronizer decides.
+func TestFDV2InitializerWithNoDataDefersToSynchronizer(t *testing.T) {
+	noData := initializerReturning("no-data",
+		func(subsystems.DataSelector, context.Context) (*subsystems.Basis, bool, error) {
+			return noDataBasis(), false, nil
+		})
+
+	httphelpers.WithServer(healthyStreamHandler(), func(server *httptest.Server) {
+		logCapture := ldlogtest.NewMockLog()
+
+		config := Config{
+			Events:  ldcomponents.NoEvents(),
+			Logging: ldcomponents.Logging().Loggers(logCapture.Loggers),
+			DataSystem: ldcomponents.DataSystem().Custom().
+				Initializers(noData).
+				Synchronizers(ldcomponents.StreamingDataSourceV2().BaseURI(server.URL)),
+		}
+
+		client, err := MakeCustomClient(testSdkKey, config, time.Second*5)
+		require.NoError(t, err)
+		defer client.Close()
+
+		assert.True(t, logCapture.HasMessageMatch(ldlog.Warn, "Initializer no-data returned no usable data"))
+		value, _ := client.BoolVariation(alwaysTrueFlag.Key, testUser, false)
+		assert.True(t, value)
+	})
+}
+
+// An initializer whose data cannot be applied has not provided data. The synchronizer decides.
+func TestFDV2InitializerWithMalformedDataDefersToSynchronizer(t *testing.T) {
+	malformed := initializerReturning("malformed",
+		func(subsystems.DataSelector, context.Context) (*subsystems.Basis, bool, error) {
+			return malformedBasis(t), false, nil
+		})
+
+	httphelpers.WithServer(healthyStreamHandler(), func(server *httptest.Server) {
+		logCapture := ldlogtest.NewMockLog()
+
+		config := Config{
+			Events:  ldcomponents.NoEvents(),
+			Logging: ldcomponents.Logging().Loggers(logCapture.Loggers),
+			DataSystem: ldcomponents.DataSystem().Custom().
+				Initializers(malformed).
+				Synchronizers(ldcomponents.StreamingDataSourceV2().BaseURI(server.URL)),
+		}
+
+		client, err := MakeCustomClient(testSdkKey, config, time.Second*5)
+		require.NoError(t, err)
+		defer client.Close()
+
+		assert.True(t, logCapture.HasMessageMatch(ldlog.Warn, "Initializer malformed returned no usable data"))
+		value, _ := client.BoolVariation(alwaysTrueFlag.Key, testUser, false)
+		assert.True(t, value)
+	})
+}
+
+// An initializer response that carries data and an FDv1 fallback directive completes
+// initialization with that data, before the FDv1 synchronizer has delivered anything.
+func TestFDV2FallbackDirectiveWithDataCompletesInitialization(t *testing.T) {
+	payload := ldservicesv2.NewServerSDKData().Flags(alwaysTrueFlag).ToInitializerPayload(subsystems.NoSelector())
+	header := http.Header{"X-LD-FD-Fallback": []string{"true"}}
+	pollHandler, pollRequests := httphelpers.RecordingHandler(httphelpers.HandlerWithJSONResponse(payload, header))
+
+	httphelpers.WithServer(pollHandler, func(pollServer *httptest.Server) {
+		httphelpers.WithServer(hangingStreamHandler, func(hangingServer *httptest.Server) {
+			logCapture := ldlogtest.NewMockLog()
+
+			config := Config{
+				Events:  ldcomponents.NoEvents(),
+				Logging: ldcomponents.Logging().Loggers(logCapture.Loggers),
+				DataSystem: ldcomponents.DataSystem().Custom().
+					Initializers(ldcomponents.PollingDataSourceV2().BaseURI(pollServer.URL).AsInitializer()).
+					Synchronizers(ldcomponents.StreamingDataSourceV2().BaseURI(hangingServer.URL)).
+					FDv1CompatibleSynchronizer(ldcomponents.FDv1PollingDataSourceV2().BaseURI(hangingServer.URL)),
+			}
+
+			client, err := MakeCustomClient(testSdkKey, config, time.Second*5)
+			<-pollRequests
+			require.NoError(t, err)
+			defer client.Close()
+
+			assert.True(t, client.Initialized())
+			assert.Equal(t, interfaces.DataSourceStateValid, client.GetDataSourceStatusProvider().GetStatus().State)
+			value, _ := client.BoolVariation(alwaysTrueFlag.Key, testUser, false)
+			assert.True(t, value)
+		})
+	})
+}
+
+// An FDv1 fallback directive that arrives with a basis that has no data does not complete
+// initialization. The FDv1 synchronizer decides.
+func TestFDV2FallbackDirectiveWithNoDataDefersToFDv1Synchronizer(t *testing.T) {
+	dataV1 := ldservices.NewServerSDKData().Flags(alwaysFalseFlag)
+	fallbackWithNoData := initializerReturning("fallback-no-data",
+		func(subsystems.DataSelector, context.Context) (*subsystems.Basis, bool, error) {
+			return noDataBasis(), true, nil
+		})
+	pollV1Handler, pollV1Requests := httphelpers.RecordingHandler(ldservices.ServerSidePollingServiceHandler(dataV1))
+
+	httphelpers.WithServer(pollV1Handler, func(pollV1Server *httptest.Server) {
+		httphelpers.WithServer(hangingStreamHandler, func(hangingServer *httptest.Server) {
+			logCapture := ldlogtest.NewMockLog()
+
+			config := Config{
+				Events:  ldcomponents.NoEvents(),
+				Logging: ldcomponents.Logging().Loggers(logCapture.Loggers),
+				DataSystem: ldcomponents.DataSystem().Custom().
+					Initializers(fallbackWithNoData).
+					Synchronizers(ldcomponents.StreamingDataSourceV2().BaseURI(hangingServer.URL)).
+					FDv1CompatibleSynchronizer(ldcomponents.FDv1PollingDataSourceV2().BaseURI(pollV1Server.URL)),
+			}
+
+			client, err := MakeCustomClient(testSdkKey, config, time.Second*5)
+			<-pollV1Requests
+			require.NoError(t, err)
+			defer client.Close()
+
+			value, _ := client.BoolVariation(alwaysFalseFlag.Key, testUser, true)
+			assert.False(t, value)
+		})
+	})
+}
+
+// A configuration with only initializers completes initialization from initializer data, even
+// though that data has no selector and no synchronizer will ever refresh it.
+func TestFDV2InitializerOnlyConfigurationCompletesInitialization(t *testing.T) {
+	testHelpers.WithTempFileData(fileDataWithOneFlag, func(filename string) {
+		logCapture := ldlogtest.NewMockLog()
+
+		config := Config{
+			Events:  ldcomponents.NoEvents(),
+			Logging: ldcomponents.Logging().Loggers(logCapture.Loggers),
+			DataSystem: ldcomponents.DataSystem().Custom().
+				Initializers(ldfiledatav2.DataSource().FilePaths(filename).AsInitializer()),
+		}
+
+		client, err := MakeCustomClient(testSdkKey, config, time.Second*5)
+		require.NoError(t, err)
+		defer client.Close()
+
+		assert.True(t, client.Initialized())
+		assert.Equal(t, interfaces.DataSourceStateValid, client.GetDataSourceStatusProvider().GetStatus().State)
+		value, _ := client.BoolVariation("flag-from-file", testUser, false)
+		assert.True(t, value)
+	})
+}
+
+// A synchronizer that delivers data without a selector completes initialization.
+func TestFDV2SelectorlessSynchronizerCompletesInitialization(t *testing.T) {
+	testHelpers.WithTempFileData(fileDataWithOneFlag, func(filename string) {
+		logCapture := ldlogtest.NewMockLog()
+
+		config := Config{
+			Events:  ldcomponents.NoEvents(),
+			Logging: ldcomponents.Logging().Loggers(logCapture.Loggers),
+			DataSystem: ldcomponents.DataSystem().Custom().
+				Synchronizers(ldfiledatav2.DataSource().FilePaths(filename)),
+		}
+
+		client, err := MakeCustomClient(testSdkKey, config, time.Second*5)
+		require.NoError(t, err)
+		defer client.Close()
+
+		assert.True(t, client.Initialized())
+		assert.Equal(t, interfaces.DataSourceStateValid, client.GetDataSourceStatusProvider().GetStatus().State)
+		value, _ := client.BoolVariation("flag-from-file", testUser, false)
+		assert.True(t, value)
 	})
 }

--- a/ldclient_end_to_end_fdv2_test.go
+++ b/ldclient_end_to_end_fdv2_test.go
@@ -8,9 +8,12 @@ import (
 	"time"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
+	"github.com/launchdarkly/go-server-sdk/v7/internal/datakinds"
 	"github.com/launchdarkly/go-server-sdk/v7/internal/sharedtest"
+	"github.com/launchdarkly/go-server-sdk/v7/internal/sharedtest/mocks"
 	"github.com/launchdarkly/go-server-sdk/v7/ldfiledatav2"
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
 	"github.com/launchdarkly/go-server-sdk/v7/testhelpers/ldservicesv2"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldlogtest"
@@ -610,6 +613,64 @@ func TestFDV2InitializerDataWithoutSelectorCompletesInitialization(t *testing.T)
 			value, _ := client.BoolVariation("flag-from-file", testUser, false)
 			assert.True(t, value)
 		})
+	})
+}
+
+// A persistent store is a data store, not a data source. Data that a previous SDK instance
+// persisted must not satisfy the initialization success signal when every configured data
+// source fails. The client still reports Initialized and serves the persisted data.
+func TestFDV2PopulatedPersistentStoreDoesNotSatisfyInitSuccess(t *testing.T) {
+	flag := alwaysTrueFlag
+	persistentStore := mocks.NewMockPersistentDataStore()
+	require.NoError(t, persistentStore.Init([]ldstoretypes.SerializedCollection{
+		{
+			Kind: datakinds.Features,
+			Items: []ldstoretypes.KeyedSerializedItemDescriptor{
+				{
+					Key: flag.Key,
+					Item: ldstoretypes.SerializedItemDescriptor{
+						Version: flag.Version,
+						SerializedItem: datakinds.Features.Serialize(
+							ldstoretypes.ItemDescriptor{Version: flag.Version, Item: &flag}),
+					},
+				},
+			},
+		},
+	}))
+
+	// The initializer fails because its file does not exist; the streaming synchronizer fails
+	// permanently with a 401.
+	handler := httphelpers.HandlerWithStatus(401)
+
+	httphelpers.WithServer(handler, func(server *httptest.Server) {
+		logCapture := ldlogtest.NewMockLog()
+
+		config := Config{
+			Events:  ldcomponents.NoEvents(),
+			Logging: ldcomponents.Logging().Loggers(logCapture.Loggers),
+			DataSystem: ldcomponents.DataSystem().Custom().
+				Initializers(
+					ldfiledatav2.DataSource().FilePaths("does-not-exist.json").AsInitializer(),
+				).
+				Synchronizers(
+					ldcomponents.StreamingDataSourceV2().BaseURI(server.URL),
+				).
+				DataStore(ldcomponents.PersistentDataStore(
+					mocks.SingleComponentConfigurer[subsystems.PersistentDataStore]{Instance: persistentStore},
+				), subsystems.DataStoreModeReadWrite),
+		}
+
+		client, err := MakeCustomClient(testSdkKey, config, time.Second*5)
+		require.Error(t, err)
+		require.NotNil(t, client)
+		defer client.Close()
+		assert.Equal(t, initializationFailedErrorMessage, err.Error())
+
+		// The persisted data is still available: the client reports Initialized and evaluates
+		// with the stored flag.
+		assert.True(t, client.Initialized())
+		value, _ := client.BoolVariation(flag.Key, testUser, false)
+		assert.True(t, value)
 	})
 }
 

--- a/ldclient_end_to_end_fdv2_test.go
+++ b/ldclient_end_to_end_fdv2_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -932,5 +933,42 @@ func TestFDV2SelectorlessSynchronizerCompletesInitialization(t *testing.T) {
 		assert.Equal(t, interfaces.DataSourceStateValid, client.GetDataSourceStatusProvider().GetStatus().State)
 		value, _ := client.BoolVariation("flag-from-file", testUser, false)
 		assert.True(t, value)
+	})
+}
+
+// When an earlier initializer applied data and a later one signals an FDv1 fallback without data
+// of its own, initialization completes with the earlier data instead of waiting for the FDv1
+// synchronizer.
+func TestFDV2FallbackDirectiveAfterEarlierInitializerDataCompletesInitialization(t *testing.T) {
+	fallbackWithoutData := initializerReturning("fallback-without-data",
+		func(subsystems.DataSelector, context.Context) (*subsystems.Basis, bool, error) {
+			return nil, true, errors.New("server requested fallback")
+		})
+
+	testHelpers.WithTempFileData(fileDataWithOneFlag, func(filename string) {
+		httphelpers.WithServer(hangingStreamHandler, func(hangingServer *httptest.Server) {
+			logCapture := ldlogtest.NewMockLog()
+
+			config := Config{
+				Events:  ldcomponents.NoEvents(),
+				Logging: ldcomponents.Logging().Loggers(logCapture.Loggers),
+				DataSystem: ldcomponents.DataSystem().Custom().
+					Initializers(
+						ldfiledatav2.DataSource().FilePaths(filename).AsInitializer(),
+						fallbackWithoutData,
+					).
+					Synchronizers(ldcomponents.StreamingDataSourceV2().BaseURI(hangingServer.URL)).
+					FDv1CompatibleSynchronizer(ldcomponents.FDv1PollingDataSourceV2().BaseURI(hangingServer.URL)),
+			}
+
+			client, err := MakeCustomClient(testSdkKey, config, time.Second*5)
+			require.NoError(t, err)
+			defer client.Close()
+
+			assert.True(t, client.Initialized())
+			assert.Equal(t, interfaces.DataSourceStateValid, client.GetDataSourceStatusProvider().GetStatus().State)
+			value, _ := client.BoolVariation("flag-from-file", testUser, false)
+			assert.True(t, value)
+		})
 	})
 }

--- a/ldclient_test.go
+++ b/ldclient_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/launchdarkly/go-server-sdk/v7/internal/datastore"
 
+	"github.com/launchdarkly/go-server-sdk/v7/internal/datakinds"
 	"github.com/launchdarkly/go-server-sdk/v7/internal/sharedtest/mocks"
 
 	"github.com/launchdarkly/go-sdk-common/v3/lduser"
@@ -14,6 +15,7 @@ import (
 	"github.com/launchdarkly/go-server-sdk/v7/internal/sharedtest"
 	"github.com/launchdarkly/go-server-sdk/v7/ldcomponents"
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -60,6 +62,44 @@ func TestMakeCustomClientWithFailedInitialization(t *testing.T) {
 
 	assert.NotNil(t, client)
 	assert.Equal(t, err, ErrInitializationFailed)
+}
+
+// A populated persistent store is a data store, not a data source. It does not make client
+// construction succeed when the data source never initializes. Evaluations still use its data.
+func TestMakeCustomClientWithPopulatedPersistentStoreAndFailedDataSource(t *testing.T) {
+	flag := alwaysTrueFlag
+	persistentStore := mocks.NewMockPersistentDataStore()
+	require.NoError(t, persistentStore.Init([]ldstoretypes.SerializedCollection{
+		{
+			Kind: datakinds.Features,
+			Items: []ldstoretypes.KeyedSerializedItemDescriptor{
+				{
+					Key: flag.Key,
+					Item: ldstoretypes.SerializedItemDescriptor{
+						Version: flag.Version,
+						SerializedItem: datakinds.Features.Serialize(
+							ldstoretypes.ItemDescriptor{Version: flag.Version, Item: &flag}),
+					},
+				},
+			},
+		},
+	}))
+
+	client, err := MakeCustomClient(testSdkKey, Config{
+		Logging:    ldcomponents.Logging().Loggers(sharedtest.NewTestLoggers()),
+		DataSource: mocks.DataSourceThatNeverInitializes(),
+		DataStore: ldcomponents.PersistentDataStore(
+			mocks.SingleComponentConfigurer[subsystems.PersistentDataStore]{Instance: persistentStore},
+		),
+		Events: ldcomponents.NoEvents(),
+	}, time.Second)
+
+	require.NotNil(t, client)
+	defer client.Close()
+	assert.Equal(t, ErrInitializationFailed, err)
+
+	value, _ := client.BoolVariation(flag.Key, testUser, false)
+	assert.True(t, value)
 }
 
 func TestInvalidCharacterInSDKKey(t *testing.T) {

--- a/ldcomponents/data_system_configuration_builder.go
+++ b/ldcomponents/data_system_configuration_builder.go
@@ -149,8 +149,10 @@ func (d *DataSystemConfigurationBuilder) DataStore(store ss.ComponentConfigurer[
 }
 
 // Initializers configures the SDK with one or more DataInitializers, which are responsible for fetching
-// complete payloads of flag data. The SDK will run the initializers in the order they are specified,
-// stopping when one successfully returns data.
+// complete payloads of flag data. The SDK runs the initializers in the order they are specified. It stops
+// when one returns data with a payload selector, or when all of them have run. Initialization is complete
+// once any initializer's data has been applied, even if that data has no selector; a synchronizer, if
+// configured, then refreshes the data.
 func (d *DataSystemConfigurationBuilder) Initializers(
 	initializers ...ss.ComponentConfigurer[ss.DataInitializer],
 ) *DataSystemConfigurationBuilder {


### PR DESCRIPTION
## Summary

The FDv2 data system now completes initialization once all initializers have run and any of them provided data, even when that data has no selector. Previously only a basis with a selector completed initialization from the initializer phase; selector-less data was applied to the store but readiness waited on a synchronizer.

This follows the updated data system spec: Requirement 1.1.5 (a basis produced by the initialization process initializes the memory store) and Requirement 1.3.11 (an initialized data system drives SDK readiness). Init termination (Requirement 1.1.3) is unchanged: a selector-less basis does not stop the loop early. Java and .NET already behave this way; Go was the outlier.

How readiness is decided:

- `Store.Apply` (internal) now reports whether it applied data. The data system tracks that at the orchestration level, as Java and .NET do. Both the readiness signal and `InitializationSucceeded` (the internal method the blocking client constructor consults; replaces `TargetAvailability`) are keyed on "a data source provided data that was applied", so they cannot disagree.
- A basis that carries no data, or data that cannot be applied, is treated as an initializer that failed: the SDK logs it, moves to the next initializer, and otherwise lets the synchronizers decide. For LaunchDarkly's own sources this input is a protocol violation (a `none` intent or 304 in reply to a request with no basis); it is reachable from third-party initializers.
- A persistent store is a data store, not a data source. Data persisted by a previous SDK instance keeps evaluations working and keeps `Initialized()` true, but does not make client construction report success when every data source has failed. A configuration with no data sources (daemon mode) is successful as-is, unchanged. FDv1 semantics are unchanged: success still requires the data source to have initialized.
- When the initializer phase completes initialization, the data source status is set to `Valid` before the readiness signal (parity with Java). A nil constructor error therefore implies a `Valid` status.

Behavior changes relative to `v7`:

1. An initializer-only configuration with selector-less data (for example a file initializer alone) now succeeds; it previously returned `ErrInitializationFailed`.
2. A synchronizer-only configuration that delivers selector-less data (for example the file data source as a synchronizer) now succeeds; it previously returned `ErrInitializationFailed`.
3. An initializer response that carries data together with an FDv1 fallback directive now completes initialization with that data (matching .NET and spec sections 1.1.3 and 1.6.2), rather than waiting for the FDv1 synchronizer.
4. Status is `Valid` as soon as initialization completes from initializer data. One consequence: an application that waited for `Valid` to learn that a synchronizer had refreshed selector-less initializer data no longer has that signal; a public data availability API (`REFRESHED` vs `CACHED`, spec Requirement 1.3.5) would be the right way to expose it.
5. A malformed selector-ful initializer payload no longer fails construction immediately; like other unusable initializer results it defers to the remaining sources.

Known and deliberately out of scope (pre-existing): daemon mode leaves the data source status at `Initializing`; `Initialized()` counts persistent-store data (Java and .NET do not); the streaming synchronizer's first connection cannot be cancelled by `Close()` while it is dialing; a delta before any basis is a protocol violation and is not special-cased; the wording of spec Requirement 1.3.11 item 3 (populated persistent store) should be clarified with the spec owners.

Validated with the full unit suite, golangci-lint, and contract test harnesses v2 and v3 including the persistence suites against redis, consul, and dynamodb. Each new end-to-end test fails against the behavior it replaces (the `v7` base or an earlier revision of this branch) and passes with these changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **FDv2 initialization** now finishes once any initializer has applied usable flag data, including payloads **without a selector** (after all initializers run). Empty or malformed initializer results are skipped and left to synchronizers; **data source status becomes `Valid` before the readiness channel closes**.
> 
> **Readiness contract:** `TargetAvailability()` is replaced by **`InitializationSucceeded()`**, which is true only when a **data source** applied data (`dataApplied` + `Store.Apply` returning whether data landed). **Pre-populated persistent stores** still enable evaluations and `Initialized()`, but no longer make blocking client construction succeed when every data source fails.
> 
> **`MakeCustomClient`** treats initialization success using `InitializationSucceeded()` instead of comparing `DataAvailability` to a target tier; **`ErrInitializationFailed`** docs now describe permanent failure when no data source provides data.
> 
> Extensive **FDv2 e2e tests** cover file-only init, selector-less synchronizers, FDv1 fallback with/without data, and persistent-store edge cases; **FDv1** maps `InitializationSucceeded()` to the data source having initialized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a78cec950862197f95d52b1f3f5634fd6a0e79e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->