### PR TITLE
fix: Report data source Valid status before signaling readiness

### DIFF
--- a/internal/datasource/streaming_data_source.go
+++ b/internal/datasource/streaming_data_source.go
@@ -210,6 +210,9 @@ func (sp *StreamProcessor) consumeStream(stream *es.Stream, closeWhenReady chan<
 							dataSourceUpdatesWithInitMetadata.SetEnvironmentID(initMetadata.GetEnvironmentID())
 						}
 					}
+					// Report the valid state before the readiness signal. A caller that wakes on
+					// the signal must observe the updated status.
+					sp.dataSourceUpdates.UpdateStatus(interfaces.DataSourceStateValid, interfaces.DataSourceErrorInfo{})
 					sp.setInitializedAndNotifyClient(true, closeWhenReady)
 				} else {
 					storeUpdateFailed("initial streaming data")

--- a/internal/datasource/streaming_data_source.go
+++ b/internal/datasource/streaming_data_source.go
@@ -165,6 +165,7 @@ func (sp *StreamProcessor) consumeStream(stream *es.Stream, closeWhenReady chan<
 
 			processedEvent := true
 			shouldRestart := false
+			becameInitialized := false
 
 			gotMalformedEvent := func(event es.Event, err error) {
 				sp.loggers.Errorf(
@@ -210,10 +211,7 @@ func (sp *StreamProcessor) consumeStream(stream *es.Stream, closeWhenReady chan<
 							dataSourceUpdatesWithInitMetadata.SetEnvironmentID(initMetadata.GetEnvironmentID())
 						}
 					}
-					// Report the valid state before the readiness signal. A caller that wakes on
-					// the signal must observe the updated status.
-					sp.dataSourceUpdates.UpdateStatus(interfaces.DataSourceStateValid, interfaces.DataSourceErrorInfo{})
-					sp.setInitializedAndNotifyClient(true, closeWhenReady)
+					becameInitialized = true
 				} else {
 					storeUpdateFailed("initial streaming data")
 				}
@@ -251,6 +249,11 @@ func (sp *StreamProcessor) consumeStream(stream *es.Stream, closeWhenReady chan<
 
 			if processedEvent {
 				sp.dataSourceUpdates.UpdateStatus(interfaces.DataSourceStateValid, interfaces.DataSourceErrorInfo{})
+			}
+			// The readiness signal comes after the status update above. A caller that wakes on
+			// the signal must observe the valid status.
+			if becameInitialized {
+				sp.setInitializedAndNotifyClient(true, closeWhenReady)
 			}
 			if shouldRestart {
 				stream.Restart()

--- a/internal/datasystem/fdv2_datasystem.go
+++ b/internal/datasystem/fdv2_datasystem.go
@@ -432,11 +432,13 @@ func (f *FDv2) consumeSynchronizerResults(
 					f.store.Apply(*result.ChangeSet, true)
 				}
 
+				// Report the valid state before the readiness signal. A caller that wakes on
+				// the signal must observe the updated status.
+				f.UpdateStatus(result.State, result.Error)
+
 				f.readyOnce.Do(func() {
 					close(closeWhenReady)
 				})
-
-				f.UpdateStatus(result.State, result.Error)
 			case interfaces.DataSourceStateInterrupted:
 				f.UpdateStatus(result.State, result.Error)
 			case interfaces.DataSourceStateOff:

--- a/ldclient_end_to_end_fdv2_test.go
+++ b/ldclient_end_to_end_fdv2_test.go
@@ -298,8 +298,11 @@ func TestFDV2StreamingSynchronizer(t *testing.T) {
 		require.NoError(t, err)
 		defer client.Close()
 
-		reached := client.GetDataSourceStatusProvider().WaitFor(interfaces.DataSourceStateValid, time.Second*5)
-		require.True(t, reached, "timed out waiting for data source to reach VALID state")
+		// A successful start must leave the data source in the valid state; the status update
+		// must not lag behind the readiness signal.
+		assert.Equal(t,
+			string(interfaces.DataSourceStateValid),
+			string(client.GetDataSourceStatusProvider().GetStatus().State))
 
 		value, _ := client.BoolVariation(alwaysTrueFlag.Key, testUser, false)
 		assert.True(t, value)


### PR DESCRIPTION
## Summary

Fixes a flaky test failure (`TestDefaultDataSourceIsStreaming`, seen on CI as status `INITIALIZING` instead of `VALID` right after a successful client start) caused by an ordering race between the readiness signal and the data source status update.

In the FDv1 streaming data source, a successful initial `put` closed the `closeWhenReady` channel before updating the data source status to Valid. A caller blocked in `MakeCustomClient` can wake on the channel close and read the status while it still says Initializing. The FDv2 synchronizer path had the same ordering (channel close before `UpdateStatus`). The FDv1 polling data source already does this in the correct order (status first, then readiness), so this change brings the other two paths in line with it.

For the streaming source, the `Valid` status update stays in its single existing location after the event handling; the put branch now records that initialization occurred, and the readiness notification runs after that shared status update. `setInitializedAndNotifyClient` is idempotent (atomic initialized flag plus `sync.Once` for the channel close), so the deferred notification is safe.

The race window is a few instructions wide, so it only fires on loaded runners. Verified by widening the window with a temporary sleep: the test fails deterministically with the exact CI failure signature under the old ordering, and passes 50/50 with the new ordering even with a sleep inserted between the status update and the readiness notification.

Also adds an immediate post-start status assertion to `TestFDV2StreamingSynchronizer` so the FDv2 ordering is regression-tested the same way `TestDefaultDataSourceIsStreaming` covers FDv1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes a race where **readiness** (`closeWhenReady`) could fire before the data source reported **Valid**, so callers waking on client start could still see `INITIALIZING` (flaky `TestDefaultDataSourceIsStreaming` on CI).
> 
> In **FDv1 streaming**, a successful initial `put` no longer closes the readiness channel inside the init branch; it defers `setInitializedAndNotifyClient` until after the shared `UpdateStatus(Valid)` path runs for the event. **FDv2** `fdv2_datasystem` now calls `UpdateStatus` before `readyOnce` closes `closeWhenReady`, matching the polling data source’s status-first ordering.
> 
> **FDv2 e2e** (`TestFDV2StreamingSynchronizer`) asserts Valid status immediately after `MakeCustomClient` returns instead of blocking on `WaitFor`, so FDv2 ordering is regression-tested like the FDv1 streaming test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 633c3897f6b1e1560ec8d23603a720051ee7793a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->