### PR TITLE
test: Allow time for asynchronous close of flag value change listener channels

### DIFF
--- a/ldclient_listeners_fdv2_test.go
+++ b/ldclient_listeners_fdv2_test.go
@@ -125,7 +125,8 @@ func TestFlagTrackerV2(t *testing.T) {
 			ch3 := p.client.GetFlagTracker().AddFlagValueChangeListener(alwaysTrueFlag.Key, otherUser, ldvalue.Null())
 
 			p.client.GetFlagTracker().RemoveFlagValueChangeListener(ch2) // just verifying that the remove method works
-			th.AssertChannelClosed(t, ch2, time.Millisecond)
+			// The value channel is closed by a forwarding goroutine, so allow time for it to run.
+			th.AssertChannelClosed(t, ch2, time.Second)
 
 			th.AssertNoMoreValues(t, ch1, timeout)
 			th.AssertNoMoreValues(t, ch3, timeout)

--- a/ldclient_listeners_test.go
+++ b/ldclient_listeners_test.go
@@ -101,7 +101,8 @@ func TestFlagTracker(t *testing.T) {
 			ch3 := p.client.GetFlagTracker().AddFlagValueChangeListener(flagKey, otherUser, ldvalue.Null())
 
 			p.client.GetFlagTracker().RemoveFlagValueChangeListener(ch2) // just verifying that the remove method works
-			th.AssertChannelClosed(t, ch2, time.Millisecond)
+			// The value channel is closed by a forwarding goroutine, so allow time for it to run.
+			th.AssertChannelClosed(t, ch2, time.Second)
 
 			th.AssertNoMoreValues(t, ch1, timeout)
 			th.AssertNoMoreValues(t, ch3, timeout)


### PR DESCRIPTION
## Summary

Fixes a flaky test failure seen on a Windows CI runner: `TestFlagTracker/sends_flag_value_change_events` failed with `expected channel to be closed within 1ms but it was not`.

When a flag value change listener is removed, `RemoveFlagValueChangeListener` synchronously closes the underlying flag change channel, but the channel the caller observes is closed by the forwarding goroutine (`runValueChangeListener`) only after it wakes and sees that its input channel closed. The test asserted the close within a 1 millisecond window, which races that goroutine scheduling hop; Windows runners with ~15ms timer granularity lose the race under load. The plain flag change listener assertions are not affected because `Broadcaster.RemoveListener` closes those channels synchronously.

The two affected assertions (the FDv1 and FDv2 variants of the test) now use a 1 second window. `AssertChannelClosed` returns as soon as the channel closes, so the wider window adds no time to passing runs.

Verified by inserting a temporary 5ms delay before the forwarding goroutine's close: the old 1ms window then fails on every run with the exact CI failure message, and the widened window passes on every run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes flaky `sends flag value change events` failures on Windows CI by giving the test more time to observe channel closure after `RemoveFlagValueChangeListener`.
> 
> In both FDv1 (`ldclient_listeners_test.go`) and FDv2 (`ldclient_listeners_fdv2_test.go`) variants, `AssertChannelClosed` on the removed listener’s channel now uses **1 second** instead of **1 millisecond**, with a short comment that the caller-visible channel is closed by the `runValueChangeListener` forwarding goroutine after the underlying flag channel is removed—not synchronously in `RemoveFlagValueChangeListener`. Passing runs still finish as soon as the channel closes; only the failure window widens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd0aa5a0c2dcdc9d2aa310b90de898f1ec38758b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->