### PR TITLE
fix: Accept DescribeConfiguration without a client context

### DIFF
--- a/internal/diagnostics/describe.go
+++ b/internal/diagnostics/describe.go
@@ -1,0 +1,30 @@
+// Package diagnostics contains helpers that collect the configuration data for diagnostic events.
+package diagnostics
+
+import (
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+)
+
+// descriptionWithoutContext is the shape that components used before version 6.0.0 of the SDK.
+// Version 6.0.0 merged two interfaces into subsystems.DiagnosticDescription and gave the method a
+// context parameter. A component whose description does not depend on the context may still use
+// this shape. The persistent store integrations do.
+type descriptionWithoutContext interface {
+	DescribeConfiguration() ldvalue.Value
+}
+
+// DescribeConfiguration returns the component's own description of its configuration. It returns
+// ldvalue.Null() if the component does not describe itself.
+//
+// A component may declare DescribeConfiguration with or without the client context parameter. Go
+// does not allow both on one type, so the two shapes are mutually exclusive.
+func DescribeConfiguration(component interface{}, context subsystems.ClientContext) ldvalue.Value {
+	if dd, ok := component.(subsystems.DiagnosticDescription); ok {
+		return dd.DescribeConfiguration(context)
+	}
+	if dd, ok := component.(descriptionWithoutContext); ok {
+		return dd.DescribeConfiguration()
+	}
+	return ldvalue.Null()
+}

--- a/internal/diagnostics/describe_test.go
+++ b/internal/diagnostics/describe_test.go
@@ -1,0 +1,46 @@
+package diagnostics
+
+import (
+	"testing"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type componentWithoutDescription struct{}
+
+type componentWithContext struct{}
+
+func (c componentWithContext) DescribeConfiguration(context subsystems.ClientContext) ldvalue.Value {
+	return ldvalue.String("with context: " + context.GetSDKKey())
+}
+
+type componentWithoutContext struct{}
+
+func (c componentWithoutContext) DescribeConfiguration() ldvalue.Value {
+	return ldvalue.String("without context")
+}
+
+func TestDescribeConfiguration(t *testing.T) {
+	context := subsystems.BasicClientContext{SDKKey: "my-key"}
+
+	t.Run("component does not describe itself", func(t *testing.T) {
+		assert.Equal(t, ldvalue.Null(), DescribeConfiguration(componentWithoutDescription{}, context))
+	})
+
+	t.Run("component takes the context", func(t *testing.T) {
+		assert.Equal(t, ldvalue.String("with context: my-key"),
+			DescribeConfiguration(componentWithContext{}, context))
+	})
+
+	t.Run("component omits the context", func(t *testing.T) {
+		assert.Equal(t, ldvalue.String("without context"),
+			DescribeConfiguration(componentWithoutContext{}, context))
+	})
+
+	t.Run("nil component", func(t *testing.T) {
+		assert.Equal(t, ldvalue.Null(), DescribeConfiguration(nil, context))
+	})
+}

--- a/ldcomponents/persistent_data_store_builder.go
+++ b/ldcomponents/persistent_data_store_builder.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 	"github.com/launchdarkly/go-server-sdk/v7/internal/datastore"
+	"github.com/launchdarkly/go-server-sdk/v7/internal/diagnostics"
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
 )
 
@@ -125,8 +126,8 @@ func (b *PersistentDataStoreBuilder) Build(clientContext subsystems.ClientContex
 
 // DescribeConfiguration is used internally by the SDK to inspect the configuration.
 func (b *PersistentDataStoreBuilder) DescribeConfiguration(context subsystems.ClientContext) ldvalue.Value {
-	if dd, ok := b.persistentDataStoreFactory.(subsystems.DiagnosticDescription); ok {
-		return dd.DescribeConfiguration(context)
+	if description := diagnostics.DescribeConfiguration(b.persistentDataStoreFactory, context); !description.IsNull() {
+		return description
 	}
 	return ldvalue.String("custom")
 }

--- a/ldcomponents/persistent_data_store_builder_test.go
+++ b/ldcomponents/persistent_data_store_builder_test.go
@@ -88,6 +88,10 @@ func TestPersistentDataStoreBuilder(t *testing.T) {
 
 		f2 := PersistentDataStore(&mockPersistentDataStoreFactoryWithDescription{ldvalue.String("MyDatabase")})
 		assert.Equal(t, ldvalue.String("MyDatabase"), f2.DescribeConfiguration(basicClientContext()))
+
+		// The persistent store integrations describe themselves without the context parameter.
+		f3 := PersistentDataStore(&mockPersistentDataStoreFactoryWithDescriptionNoContext{ldvalue.String("MyDatabase")})
+		assert.Equal(t, ldvalue.String("MyDatabase"), f3.DescribeConfiguration(basicClientContext()))
 	})
 }
 
@@ -115,5 +119,19 @@ func (m *mockPersistentDataStoreFactoryWithDescription) Build(
 }
 
 func (m *mockPersistentDataStoreFactoryWithDescription) DescribeConfiguration(context subsystems.ClientContext) ldvalue.Value {
+	return m.description
+}
+
+type mockPersistentDataStoreFactoryWithDescriptionNoContext struct {
+	description ldvalue.Value
+}
+
+func (m *mockPersistentDataStoreFactoryWithDescriptionNoContext) Build(
+	context subsystems.ClientContext,
+) (subsystems.PersistentDataStore, error) {
+	return nil, nil
+}
+
+func (m *mockPersistentDataStoreFactoryWithDescriptionNoContext) DescribeConfiguration() ldvalue.Value {
 	return m.description
 }

--- a/server_side_diagnostics.go
+++ b/server_side_diagnostics.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 	ldevents "github.com/launchdarkly/go-sdk-events/v3"
+	"github.com/launchdarkly/go-server-sdk/v7/internal/diagnostics"
 	"github.com/launchdarkly/go-server-sdk/v7/ldcomponents"
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems"
 )
@@ -60,8 +61,8 @@ var allowedDiagnosticComponentProperties = map[string]ldvalue.ValueType{ //nolin
 // Attempts to add relevant configuration properties, if any, from a customizable component:
 //   - If the component does not implement DiagnosticDescription, set the defaultPropertyName property to
 //     "custom".
-//   - If it does implement DiagnosticDescription or DiagnosticDescriptionExt, call the corresponding
-//     interface method to get a value.
+//   - If it does implement DiagnosticDescription, or the same method without the context
+//     parameter, call that method to get a value.
 //   - If the value is a string, then set the defaultPropertyName property to that value.
 //   - If the value is an object, then copy all of its properties as long as they are ones we recognize
 //     and have the expected type.
@@ -75,10 +76,7 @@ func mergeComponentProperties(
 	if component == nil {
 		component = defaultComponent
 	}
-	var componentDesc ldvalue.Value
-	if dd, ok := component.(subsystems.DiagnosticDescription); ok {
-		componentDesc = dd.DescribeConfiguration(context)
-	}
+	componentDesc := diagnostics.DescribeConfiguration(component, context)
 	if !componentDesc.IsNull() {
 		if componentDesc.Type() == ldvalue.StringType && defaultPropertyName != "" {
 			builder.Set(defaultPropertyName, componentDesc)

--- a/server_side_diagnostics_test.go
+++ b/server_side_diagnostics_test.go
@@ -62,6 +62,11 @@ func TestDiagnosticEventCustomConfig(t *testing.T) {
 		func(b *ldvalue.ObjectBuilder) { b.SetString("dataStoreType", "Foo") })
 	doTest(func(c *Config) { c.DataStore = customStoreFactoryWithoutDiagnosticDescription{} },
 		func(b *ldvalue.ObjectBuilder) { b.SetString("dataStoreType", "custom") })
+	doTest(func(c *Config) { c.DataStore = customStoreFactoryWithNoContextDescription{name: "Foo"} },
+		func(b *ldvalue.ObjectBuilder) { b.SetString("dataStoreType", "Foo") })
+	doTest(func(c *Config) {
+		c.DataStore = ldcomponents.PersistentDataStore(customPersistentStoreFactoryWithNoContextDescription{name: "Foo"})
+	}, func(b *ldvalue.ObjectBuilder) { b.SetString("dataStoreType", "Foo") })
 
 	// data source configuration
 	doTest(func(c *Config) { c.DataSource = ldcomponents.StreamingDataSource() }, func(b *ldvalue.ObjectBuilder) {})
@@ -154,6 +159,36 @@ func (c customStoreFactoryForDiagnostics) DescribeConfiguration(context subsyste
 }
 
 func (c customStoreFactoryForDiagnostics) Build(context subsystems.ClientContext) (subsystems.DataStore, error) {
+	return nil, errors.New("not implemented")
+}
+
+// customStoreFactoryWithNoContextDescription describes itself without the context parameter, as
+// the persistent store integrations do.
+type customStoreFactoryWithNoContextDescription struct {
+	name string
+}
+
+func (c customStoreFactoryWithNoContextDescription) DescribeConfiguration() ldvalue.Value {
+	return ldvalue.String(c.name)
+}
+
+func (c customStoreFactoryWithNoContextDescription) Build(context subsystems.ClientContext) (subsystems.DataStore, error) {
+	return nil, errors.New("not implemented")
+}
+
+// customPersistentStoreFactoryWithNoContextDescription is the same shape behind
+// ldcomponents.PersistentDataStore, which is how the integrations are actually configured.
+type customPersistentStoreFactoryWithNoContextDescription struct {
+	name string
+}
+
+func (c customPersistentStoreFactoryWithNoContextDescription) DescribeConfiguration() ldvalue.Value {
+	return ldvalue.String(c.name)
+}
+
+func (c customPersistentStoreFactoryWithNoContextDescription) Build(
+	context subsystems.ClientContext,
+) (subsystems.PersistentDataStore, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/subsystems/diagnostic_description.go
+++ b/subsystems/diagnostic_description.go
@@ -7,6 +7,10 @@ import "github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 // The SDK uses a simplified JSON representation of its configuration when recording diagnostics data.
 // Any component type that implements ComponentConfigurer may choose to contribute values to this
 // representation, although the SDK may or may not use them.
+//
+// The SDK also accepts a DescribeConfiguration method that takes no parameters. Use that form if
+// the description does not depend on the client context, as is true for a persistent store that
+// reports only the name of its database.
 type DiagnosticDescription interface {
 	// DescribeConfiguration should return a JSON value or ldvalue.Null().
 	//


### PR DESCRIPTION
## Summary

The persistent store integrations declare `DescribeConfiguration` with no parameters. Version 6.0.0 of the SDK merged `interfaces.DiagnosticDescription` (no parameters, deprecated in v5) and `interfaces.DiagnosticDescriptionContext` into a single `subsystems.DiagnosticDescription`. That merge kept both the interface name and the method name but added a `ClientContext` parameter. The integrations kept compiling and silently stopped satisfying the interface, so diagnostic events have reported `dataStoreType` as `"custom"` for every Go persistent store since December 2022.

`internal/diagnostics.DescribeConfiguration` now tries `subsystems.DiagnosticDescription` first and then the no-parameter form. Both call sites use it: `mergeComponentProperties`, and `PersistentDataStoreBuilder.DescribeConfiguration`, which is the assertion the integrations actually reach. The no-parameter form is documented as supported on `subsystems.DiagnosticDescription` rather than reinstated as a deprecated path, because a description that does not depend on the client context legitimately does not need one. Go does not allow a single type to declare both forms, so the two are mutually exclusive.

Verified against released artifacts. An unmodified redigo v3.0.5 reports `"custom"` against SDK v7.17.0 and `"Redis"` against this branch, read out of the `diagnostic-init` payload on the wire.

Five integrations carry the no-parameter shape: redigo, dynamodb, consul, redis-go-redis and firestore. redigo v4 and firestore take the context parameter directly in their own pull requests, since a major version was already in play for both.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes **diagnostic `dataStoreType` reporting** for persistent store integrations that still implement parameterless `DescribeConfiguration()` (e.g. Redis, DynamoDB) after SDK v6.0.0 required `ClientContext` on `subsystems.DiagnosticDescription`.
> 
> Adds **`internal/diagnostics.DescribeConfiguration`**, which prefers the context-aware interface and falls back to the legacy no-parameter method, returning `ldvalue.Null()` when neither applies. **`mergeComponentProperties`** and **`PersistentDataStoreBuilder.DescribeConfiguration`** now delegate to that helper instead of only type-asserting `DiagnosticDescription`.
> 
> Documents the parameterless form as a supported alternative on **`subsystems.DiagnosticDescription`**, with unit and integration tests for both shapes (including `PersistentDataStore` wrappers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b2487059b1a071c108ebb19168f171ca33ced50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->