### PR TITLE
fix: Log the cached-data evaluation warning only once per client

### DIFF
--- a/ldclient.go
+++ b/ldclient.go
@@ -128,6 +128,10 @@ type LDClient struct {
 	logEvaluationErrors              bool
 	offline                          bool
 	hookRunner                       *hooks.Runner
+
+	// Each flag records that the SDK has logged the matching cached-data warning for this client.
+	evalCachedDataWarningLogged     internal.AtomicBoolean
+	allFlagsCachedDataWarningLogged internal.AtomicBoolean
 }
 
 // Initialization errors
@@ -792,7 +796,9 @@ func (client *LDClient) AllFlagsState(context ldcontext.Context, options ...flag
 		valid = false
 	} else if client.dataSystem.DataAvailability() != datasystem.Refreshed {
 		if client.dataSystem.DataAvailability() == datasystem.Cached {
-			client.loggers.Warn("Called AllFlagsState before client initialization; using last known values from data store")
+			if !client.allFlagsCachedDataWarningLogged.GetAndSet(true) {
+				client.loggers.Warn("Called AllFlagsState before client initialization; using last known values from data store. This message is logged once.") //nolint:lll
+			}
 		} else {
 			client.loggers.Warn("Called AllFlagsState before client initialization. Data store not available; returning empty state") //nolint:lll
 			valid = false
@@ -1394,7 +1400,9 @@ func (client *LDClient) evaluateInternal(
 
 	if client.dataSystem.DataAvailability() != datasystem.Refreshed {
 		if client.dataSystem.DataAvailability() == datasystem.Cached {
-			client.loggers.Warn("Feature flag evaluation called before LaunchDarkly client initialization completed; using last known values from data store") //nolint:lll
+			if !client.evalCachedDataWarningLogged.GetAndSet(true) {
+				client.loggers.Warn("Feature flag evaluation called before LaunchDarkly client initialization completed; using last known values from data store. This message is logged once.") //nolint:lll
+			}
 		} else {
 			return evalErrorResult(ldreason.EvalErrorClientNotReady, nil, ErrClientNotInitialized)
 		}

--- a/ldclient_evaluation_all_flags_test.go
+++ b/ldclient_evaluation_all_flags_test.go
@@ -227,6 +227,30 @@ func TestAllFlagsStateUsesStoreAndLogsWarningIfClientIsNotInitializedButStoreIsI
 	assert.Contains(t, mockLoggers.GetOutput(ldlog.Warn)[0], "using last known values")
 }
 
+func TestAllFlagsStateLogsCachedDataWarningOnlyOncePerClient(t *testing.T) {
+	mockLoggers := ldlogtest.NewMockLog()
+	flag := ldbuilders.NewFlagBuilder(evalFlagKey).SingleVariation(ldvalue.Bool(true)).Build()
+	store := datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers())
+	_ = store.Init(nil)
+	_, _ = store.Upsert(datakinds.Features, flag.Key, sharedtest.FlagDescriptor(flag))
+
+	client := makeTestClientWithConfig(func(c *Config) {
+		c.DataSource = mocks.DataSourceThatNeverInitializes()
+		c.DataStore = mocks.SingleComponentConfigurer[subsystems.DataStore]{Instance: store}
+		c.Logging = ldcomponents.Logging().Loggers(mockLoggers.Loggers)
+	})
+	defer client.Close()
+
+	for i := 0; i < 3; i++ {
+		state := client.AllFlagsState(evalTestUser)
+		assert.True(t, state.IsValid())
+		assert.Len(t, state.ToValuesMap(), 1)
+	}
+
+	assert.Len(t, mockLoggers.GetOutput(ldlog.Warn), 1)
+	assert.Contains(t, mockLoggers.GetOutput(ldlog.Warn)[0], "using last known values")
+}
+
 func TestAllFlagsStateReturnsInvalidStateIfStoreReturnsError(t *testing.T) {
 	myError := errors.New("sorry")
 	store := mocks.NewCapturingDataStore(datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers()))

--- a/ldclient_evaluation_test.go
+++ b/ldclient_evaluation_test.go
@@ -1059,3 +1059,27 @@ func TestEvalUsesStoreAndLogsWarningIfClientIsNotInitializedButStoreIsInitialize
 	assert.Len(t, mockLoggers.GetOutput(ldlog.Warn), 1)
 	assert.Contains(t, mockLoggers.GetOutput(ldlog.Warn)[0], "using last known values")
 }
+
+func TestEvalLogsCachedDataWarningOnlyOncePerClient(t *testing.T) {
+	mockLoggers := ldlogtest.NewMockLog()
+	flag := ldbuilders.NewFlagBuilder(evalFlagKey).SingleVariation(ldvalue.Bool(true)).Build()
+	store := datastore.NewInMemoryDataStore(sharedtest.NewTestLoggers())
+	_ = store.Init(nil)
+	_, _ = store.Upsert(datakinds.Features, flag.Key, sharedtest.FlagDescriptor(flag))
+
+	client := makeTestClientWithConfig(func(c *Config) {
+		c.DataSource = mocks.DataSourceThatNeverInitializes()
+		c.DataStore = mocks.SingleComponentConfigurer[subsystems.DataStore]{Instance: store}
+		c.Logging = ldcomponents.Logging().Loggers(mockLoggers.Loggers)
+	})
+	defer client.Close()
+
+	for i := 0; i < 3; i++ {
+		value, err := client.BoolVariation(flag.Key, evalTestUser, false)
+		assert.NoError(t, err)
+		assert.True(t, value)
+	}
+
+	assert.Len(t, mockLoggers.GetOutput(ldlog.Warn), 1)
+	assert.Contains(t, mockLoggers.GetOutput(ldlog.Warn)[0], "using last known values")
+}


### PR DESCRIPTION
## Summary

The warning "using last known values from data store" now logs once per LDClient instance instead of on every call. There is one flag for the evaluation path and one for AllFlagsState, each an existing internal AtomicBoolean. The flag is read and set with a single atomic swap, and only inside the branch where data availability is Cached, so the normal evaluation path is unchanged.

Both messages now end with "This message is logged once." so a reader knows why it does not repeat.

Why: while data availability is Cached, every evaluation logged the warning. That floods logs in two common situations: an initializer such as the S3 initializer supplies data with no selector and the synchronizer cannot connect, or a persistent store serves data before a synchronizer connects. In both cases the SDK is serving usable flag values and repeating the message adds nothing.

The gating condition is unchanged. The message can still fire once after initialization completes when the applied data carries no selector, because availability stays Cached until a synchronizer delivers a selector.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Limits **cached-data** warnings so each `LDClient` logs them at most once, instead of on every evaluation or `AllFlagsState` call while data availability stays `Cached`.
> 
> `LDClient` gains two `internal.AtomicBoolean` fields—one for flag evaluation (`evaluateInternal`) and one for `AllFlagsState`. When availability is `Cached` (not `Refreshed`), the SDK still uses the data store as before; it only emits the existing “using last known values from data store” warning on the first such call per path, via `GetAndSet(true)`. Both warning strings now end with **“This message is logged once.”**
> 
> Tests assert that three repeated evaluations or `AllFlagsState` calls in a never-initializing client with a populated store produce a single warn log each.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33c2be5c40ddfc4dbe1c19285592acffee12e5fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->